### PR TITLE
support pre-tokenized parquet datasets

### DIFF
--- a/src/llamafactory/data/collator_tokenized.py
+++ b/src/llamafactory/data/collator_tokenized.py
@@ -1,0 +1,91 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+from transformers import DataCollatorForSeq2Seq
+
+from ..extras.constants import IGNORE_INDEX
+
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedModel, PreTrainedTokenizer
+
+
+def _resolve_pad_token_id(tokenizer: "PreTrainedTokenizer", model: "PreTrainedModel") -> int:
+    r"""Resolve the padding token ID from the tokenizer, falling back to the model config."""
+    pad_id = getattr(tokenizer, "pad_token_id", None)
+    if pad_id is None:
+        pad_id = getattr(tokenizer, "eos_token_id", None)
+    if pad_id is None:
+        pad_id = getattr(getattr(model, "config", None), "pad_token_id", None)
+    if pad_id is None:
+        raise ValueError("Cannot resolve a pad token id: set `tokenizer.pad_token` before using TokenizedIdsCollator.")
+    return int(pad_id)
+
+
+@dataclass
+class TokenizedIdsCollator(DataCollatorForSeq2Seq):
+    r"""Collator for pre-tokenized LM data.
+
+    Expects features containing `input_ids` and optionally `attention_mask`.
+    Pads to batch max length with `pad_token_id`, generates labels and masks missing fields when needed.
+    """
+
+    strict: bool = True
+
+    def __call__(self, features: list[dict[str, Any]]) -> dict[str, "torch.Tensor"]:
+        pad_id = _resolve_pad_token_id(self.tokenizer, self.model)
+
+        # Validate and compute max length
+        max_len = 0
+        for f in features:
+            ids = f.get("input_ids")
+            if ids is None or isinstance(ids, (str, bytes)) or not isinstance(ids, Iterable):
+                if self.strict:
+                    raise ValueError("Each feature must contain a sequence of ints in `input_ids`.")
+                ids = []
+            f["input_ids"] = [int(x) for x in ids]  # accept list, tuple, numpy array, tensor
+            if f.get("attention_mask") is not None:
+                f["attention_mask"] = [int(x) for x in f["attention_mask"]]
+            max_len = max(max_len, len(f["input_ids"]))
+
+        input_ids = []
+        attention_mask = []
+        labels = []
+        for f in features:
+            ids = f["input_ids"]
+            pad_amt = max_len - len(ids)
+            row_ids = ids + [pad_id] * pad_amt
+            input_ids.append(row_ids)
+
+            if f.get("attention_mask") is not None:
+                if self.strict and len(f["attention_mask"]) != len(ids):
+                    raise ValueError("attention_mask length must match input_ids length.")
+                mask = f["attention_mask"] + [0] * pad_amt
+            else:
+                mask = [1] * len(ids) + [0] * pad_amt
+            attention_mask.append(mask)
+
+            labels.append(ids + [IGNORE_INDEX] * pad_amt)
+
+        batch = {
+            "input_ids": torch.tensor(input_ids, dtype=torch.long),
+            "attention_mask": torch.tensor(attention_mask, dtype=torch.long),
+            "labels": torch.tensor(labels, dtype=torch.long),
+        }
+        return batch

--- a/src/llamafactory/data/tokenized_parquet.py
+++ b/src/llamafactory/data/tokenized_parquet.py
@@ -1,0 +1,85 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from ..extras import logging
+
+
+if TYPE_CHECKING:
+    from datasets import IterableDataset
+
+
+logger = logging.get_logger(__name__)
+
+
+def _iter_parquet_rows(paths: list[str], ids_key: str, mask_key: str | None) -> Iterable[dict[str, Any]]:
+    r"""Iterate over rows from multiple Parquet files, yielding pre-tokenized samples."""
+    for path in paths:
+        try:
+            pf = pq.ParquetFile(path)
+        except FileNotFoundError:
+            logger.warning(f"Parquet file not found, skipping: {path}")
+            continue
+
+        with pf:
+            for i in range(pf.num_row_groups):
+                table: pa.Table = pf.read_row_group(i)
+                ids_col = table[ids_key]
+                mask_col = table[mask_key] if mask_key and mask_key in table.column_names else None
+                ids_py = ids_col.to_pylist()
+                mask_py = mask_col.to_pylist() if mask_col is not None else itertools.repeat(None)
+                for ids, mask in zip(ids_py, mask_py):
+                    yield {
+                        "input_ids": list(ids) if isinstance(ids, (list, tuple)) else ids,
+                        **(
+                            {"attention_mask": (list(mask) if isinstance(mask, (list, tuple)) else mask)}
+                            if mask is not None
+                            else {}
+                        ),
+                    }
+
+
+def load_tokenized_parquet_dataset(
+    data_files: list[str],
+    ids_key: str = "input_ids",
+    mask_key: str | None = "attention_mask",
+) -> "IterableDataset":
+    r"""Create a streaming HF IterableDataset over pre-tokenized Parquet samples.
+
+    Args:
+        data_files: List of local Parquet file paths.
+        ids_key: Column name for input token IDs.
+        mask_key: Column name for attention mask (optional).
+
+    Returns:
+        IterableDataset yielding dictionaries with `input_ids` and optionally `attention_mask`.
+
+    Note:
+        Always streams row groups to avoid materializing large corpora in memory.
+    """
+    from datasets import IterableDataset
+
+    if not data_files:
+        raise ValueError("data_files must be a non-empty list of Parquet paths")
+
+    logger.info_rank0(f"Building streaming dataset from {len(data_files)} parquet file(s)")
+    return IterableDataset.from_generator(
+        _iter_parquet_rows, gen_kwargs={"paths": data_files, "ids_key": ids_key, "mask_key": mask_key}
+    )  # type: ignore

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -143,6 +143,34 @@ class DataArguments:
         default=False,
         metadata={"help": "Whether or not to use a shared file system for the datasets."},
     )
+    dataset_format: Literal["default", "tokenized_ids"] = field(
+        default="default",
+        metadata={
+            "help": (
+                "Format of the input dataset. Use 'tokenized_ids' for pre-tokenized parquet files "
+                "containing token IDs. This bypasses the tokenization step during training."
+            )
+        },
+    )
+    data_files: Any = field(
+        default=None,
+        metadata={
+            "help": (
+                "Path(s) to data files for tokenized_ids format. "
+                "Can be a single path, comma-separated paths, or a list of paths."
+            )
+        },
+    )
+    dataset_columns: dict[str, str] | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Column name mapping for tokenized datasets. "
+                "Example: {'ids': 'token_ids', 'mask': 'attn_mask'}. "
+                "Defaults to {'ids': 'input_ids', 'mask': 'attention_mask'}."
+            )
+        },
+    )
 
     def __post_init__(self):
         def split_arg(arg):
@@ -152,6 +180,12 @@ class DataArguments:
 
         self.dataset = split_arg(self.dataset)
         self.eval_dataset = split_arg(self.eval_dataset)
+
+        # Handle data_files for tokenized_ids format
+        if self.dataset_format == "tokenized_ids":
+            if self.data_files is None:
+                raise ValueError("data_files must be specified when using dataset_format='tokenized_ids'.")
+            self.data_files = split_arg(self.data_files)
 
         if self.media_dir is None:
             self.media_dir = self.dataset_dir

--- a/tests/data/test_tokenized_parquet.py
+++ b/tests/data/test_tokenized_parquet.py
@@ -1,0 +1,55 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from llamafactory.data.collator_tokenized import TokenizedIdsCollator, _resolve_pad_token_id
+from llamafactory.data.tokenized_parquet import load_tokenized_parquet_dataset
+from llamafactory.extras.constants import IGNORE_INDEX
+
+
+class _Tok:
+    pad_token_id = 99
+    eos_token_id = 2
+
+
+def test_load_and_collate(tmp_path):
+    path = str(tmp_path / "t.parquet")
+    pq.write_table(pa.table({"input_ids": [[5, 6, 7], [8, 9]], "attention_mask": [[1, 1, 1], [1, 1]]}), path)
+    rows = list(load_tokenized_parquet_dataset([str(tmp_path / "missing.parquet"), path]))
+    assert len(rows) == 2
+
+    batch = TokenizedIdsCollator(tokenizer=_Tok(), model=None)(rows)
+    assert batch["input_ids"].tolist() == [[5, 6, 7], [8, 9, 99]]
+    assert batch["attention_mask"].tolist() == [[1, 1, 1], [1, 1, 0]]
+    assert batch["labels"].tolist() == [[5, 6, 7], [8, 9, IGNORE_INDEX]]
+
+
+def test_collator_accepts_numpy():
+    batch = TokenizedIdsCollator(tokenizer=_Tok(), model=None)(
+        [{"input_ids": np.array([3, 4])}, {"input_ids": np.array([5])}]
+    )
+    assert batch["input_ids"].tolist() == [[3, 4], [5, 99]]
+
+
+def test_pad_id_required():
+    class _NoPad:
+        pad_token_id = None
+        eos_token_id = None
+
+    with pytest.raises(ValueError):
+        _resolve_pad_token_id(_NoPad(), None)


### PR DESCRIPTION
# What does this PR do?

Support pre-tokenized datasets in Parquet format and to skip tokenization step if it's already has been done.

## Motivation

I needed to use Parquet files with pre-tokenized data, but LLaMA-Factory didn't support the format. This adds Parquet support and skips tokenization when data is already tokenized.

## Changes

**New files:**
- `src/llamafactory/data/tokenized_parquet.py` - Parquet loader
- `src/llamafactory/data/collator_tokenized.py` - Data collator for pre-tokenized samples

## Usage Example

```yaml
dataset_format: tokenized_ids
data_files:
  - /path/to/chunk_000.parquet
  - /path/to/chunk_001.parquet
```

Parquet files should have `input_ids` (required) and `attention_mask` (optional) columns.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you run `make style && make quality`?
- [ ] Did you write any new necessary tests?