### PR TITLE
enable using FA in npu, remove  is_torch_sdpa_available() dependent

### DIFF
--- a/src/llamafactory/extras/packages.py
+++ b/src/llamafactory/extras/packages.py
@@ -106,6 +106,10 @@ def is_starlette_available():
 def is_transformers_version_greater_than(content: str):
     return _get_package_version("transformers") >= version.parse(content)
 
+@lru_cache
+def is_torch_version_greater_than(content: str):
+    return _get_package_version("torch") >= version.parse(content)
+
 
 def is_uvicorn_available():
     return _is_package_available("uvicorn")

--- a/src/llamafactory/model/model_utils/attention.py
+++ b/src/llamafactory/model/model_utils/attention.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from ...extras import logging
 from ...extras.constants import AttentionFunction
+from ...extras.packages import is_torch_version_greater_than
 
 
 if TYPE_CHECKING:
@@ -51,15 +52,14 @@ def configure_attn_implementation(config: "PretrainedConfig", model_args: "Model
         requested_attn_implementation = "eager"
 
     elif model_args.flash_attn == AttentionFunction.SDPA:
-        from transformers.utils import is_torch_sdpa_available
-
-        if not is_torch_sdpa_available():
+        if not is_torch_version_greater_than("2.1.1"):
             logger.warning_rank0("torch>=2.1.1 is required for SDPA attention.")
             return
 
         requested_attn_implementation = "sdpa"
     elif model_args.flash_attn == AttentionFunction.FA2:
-        if not is_flash_attn_2_available():
+        from transformers import is_torch_npu_available
+        if not (is_flash_attn_2_available() or is_torch_npu_available()):
             logger.warning_rank0("FlashAttention-2 is not installed.")
             return
 


### PR DESCRIPTION
支持通过设置 `flash_attn: fa2` 来开启npu上的 flash-attention2

在transformers的main分支中，`is_torch_sdpa_available`已被废弃，因此去除了llamafactory对该接口的依赖
