### PR TITLE
update npu dockerfile

### DIFF
--- a/docker/docker-npu/Dockerfile
+++ b/docker/docker-npu/Dockerfile
@@ -1,5 +1,9 @@
 # https://hub.docker.com/r/ascendai/cann/tags
-ARG BASE_IMAGE=ascendai/cann:8.1.rc1-910b-ubuntu22.04-py3.11
+
+# default base image build for A2, if build for A3, using this image:
+# ARG BASE_IMAGE=ascendai/cann:8.3.rc1-a3-ubuntu22.04-py3.11
+
+ARG BASE_IMAGE=ascendai/cann:8.3.rc1-910b-ubuntu22.04-py3.11
 FROM ${BASE_IMAGE}
 
 # Installation arguments
@@ -31,7 +35,7 @@ RUN pip config set global.index-url "${PIP_INDEX}" && \
 
 # Install torch-npu
 RUN pip uninstall -y torch torchvision torchaudio && \
-    pip install --no-cache-dir "torch-npu==2.5.1" "torchvision==0.20.1" --index-url "${PYTORCH_INDEX}"
+    pip install --no-cache-dir "torch==2.7.1" "torch-npu==2.7.1" "torchvision==0.22.1" --index-url "${PYTORCH_INDEX}"
 
 # Install the requirements
 COPY requirements.txt /app

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def get_console_scripts() -> list[str]:
 
 extra_require = {
     "torch": ["torch>=2.0.0", "torchvision>=0.15.0"],
-    "torch-npu": ["torch-npu==2.5.1", "torchvision==0.20.1", "decorator"],
+    "torch-npu": ["torch==2.7.1", "torch-npu==2.7.1", "torchvision==0.22.1", "decorator"],
     "metrics": ["nltk", "jieba", "rouge-chinese"],
     "deepspeed": ["deepspeed>=0.10.0,<=0.16.9"],
     "liger-kernel": ["liger-kernel>=0.5.5"],


### PR DESCRIPTION
更新npu docker基础镜像为最新的稳定社区版本8.3.rc1, 升级torch和torch-npu为最新LTS版本v2.7.1
