### PR TITLE
Fix Qwen3omni 

### DIFF
--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -17,9 +17,12 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 from peft import PeftModel
+from torch import nn
+from torch.nn import functional as F
 from transformers import GenerationMixin, PreTrainedModel, PreTrainedTokenizerBase
 from transformers.integrations import is_deepspeed_zero3_enabled
 from transformers.modeling_utils import is_fsdp_enabled
+from transformers.models.qwen3_omni_moe import modeling_qwen3_omni_moe
 
 from ..extras import logging
 from ..extras.misc import infer_optim_dtype
@@ -45,6 +48,73 @@ if TYPE_CHECKING:
 
 
 logger = logging.get_logger(__name__)
+
+
+class Qwen3OmniMoeThinkerTextSparseMoeBlock(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.num_experts = config.num_experts
+        self.top_k = config.num_experts_per_tok
+        self.norm_topk_prob = config.norm_topk_prob
+
+        # gating
+        self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
+        self.experts = nn.ModuleList(
+            [
+                modeling_qwen3_omni_moe.Qwen3OmniMoeThinkerTextMLP(
+                    config, intermediate_size=config.moe_intermediate_size
+                )
+                for _ in range(self.num_experts)
+            ]
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+        # router_logits: (batch * sequence_length, n_experts)
+        router_logits = self.gate(hidden_states)
+
+        # 计算所有专家的路由权重
+        routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+
+        # 保留top_k的权重，其余专家权重置为0（而非仅保留top_k专家）
+        top_k_weights, top_k_indices = torch.topk(routing_weights, self.top_k, dim=-1)
+        # 初始化全零权重矩阵（形状与所有专家相同）
+        full_routing_weights = torch.zeros_like(routing_weights)
+        # 仅保留top_k专家的权重，其余专家权重保持为0
+        full_routing_weights.scatter_(1, top_k_indices, top_k_weights)
+
+        # 归一化top_k权重（保持与原逻辑一致）
+        if self.norm_topk_prob:
+            # 计算每行top_k权重的和（用于归一化）
+            top_k_sum = full_routing_weights.sum(dim=-1, keepdim=True)
+            # 避免除零（虽然softmax后和不为零，但归一化可能导致极端情况）
+            top_k_sum = torch.clamp(top_k_sum, min=1e-9)
+            full_routing_weights /= top_k_sum
+
+        # 转换回输入数据类型
+        full_routing_weights = full_routing_weights.to(hidden_states.dtype)
+
+        final_hidden_states = torch.zeros(
+            (batch_size * sequence_length, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
+        )
+
+        # 遍历所有专家（而非仅被选中的专家）
+        for expert_idx in range(self.num_experts):
+            expert_layer = self.experts[expert_idx]
+            # 获取当前专家的权重（未激活的专家此处权重为0）
+            expert_weights = full_routing_weights[:, expert_idx, None]  # 形状: (batch*seq, 1)
+            # 所有样本都参与当前专家的计算，但权重可能为0
+            current_hidden_states = expert_layer(hidden_states) * expert_weights
+            # 累加所有专家的输出（权重为0的专家不影响结果）
+            final_hidden_states += current_hidden_states
+
+        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+        return final_hidden_states, router_logits
+
+
+def patch_qwen3_omni_moe_thinker_text_sparse_moe_block():
+    modeling_qwen3_omni_moe.Qwen3OmniMoeThinkerTextSparseMoeBlock = Qwen3OmniMoeThinkerTextSparseMoeBlock
 
 
 def patch_tokenizer(tokenizer: "PreTrainedTokenizer", model_args: "ModelArguments") -> None:
@@ -135,6 +205,10 @@ def patch_config(
 
     if getattr(config, "model_type", None) == "internlm3" and not is_transformers_version_greater_than("4.47.1"):
         raise RuntimeError("InternLM3 model requires transformers>=4.47.1, please upgrade it.")
+
+    if getattr(config, "model_type", None) == "qwen3_omni_moe_thinker":
+        # breakpoint()
+        patch_qwen3_omni_moe_thinker_text_sparse_moe_block()
 
     # deepspeed zero3 is not compatible with low_cpu_mem_usage
     init_kwargs["low_cpu_mem_usage"] = model_args.low_cpu_mem_usage and (not is_deepspeed_zero3_enabled())

--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -22,7 +22,6 @@ from torch.nn import functional as F
 from transformers import GenerationMixin, PreTrainedModel, PreTrainedTokenizerBase
 from transformers.integrations import is_deepspeed_zero3_enabled
 from transformers.modeling_utils import is_fsdp_enabled
-from transformers.models.qwen3_omni_moe import modeling_qwen3_omni_moe
 
 from ..extras import logging
 from ..extras.misc import infer_optim_dtype
@@ -45,6 +44,9 @@ if TYPE_CHECKING:
     from trl import AutoModelForCausalLMWithValueHead
 
     from ..hparams import ModelArguments
+
+if is_transformers_version_greater_than("4.57.0"):
+    from transformers.models.qwen3_omni_moe import modeling_qwen3_omni_moe
 
 
 logger = logging.get_logger(__name__)
@@ -114,7 +116,8 @@ class Qwen3OmniMoeThinkerTextSparseMoeBlock(nn.Module):
 
 
 def patch_qwen3_omni_moe_thinker_text_sparse_moe_block():
-    modeling_qwen3_omni_moe.Qwen3OmniMoeThinkerTextSparseMoeBlock = Qwen3OmniMoeThinkerTextSparseMoeBlock
+    if is_transformers_version_greater_than("4.57.0"):
+        modeling_qwen3_omni_moe.Qwen3OmniMoeThinkerTextSparseMoeBlock = Qwen3OmniMoeThinkerTextSparseMoeBlock
 
 
 def patch_tokenizer(tokenizer: "PreTrainedTokenizer", model_args: "ModelArguments") -> None:

--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -17,8 +17,6 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 from peft import PeftModel
-from torch import nn
-from torch.nn import functional as F
 from transformers import GenerationMixin, PreTrainedModel, PreTrainedTokenizerBase
 from transformers.integrations import is_deepspeed_zero3_enabled
 from transformers.modeling_utils import is_fsdp_enabled
@@ -52,71 +50,10 @@ if is_transformers_version_greater_than("4.57.0"):
 logger = logging.get_logger(__name__)
 
 
-class Qwen3OmniMoeThinkerTextSparseMoeBlock(nn.Module):
-    def __init__(self, config):
-        super().__init__()
-        self.num_experts = config.num_experts
-        self.top_k = config.num_experts_per_tok
-        self.norm_topk_prob = config.norm_topk_prob
-
-        # gating
-        self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
-        self.experts = nn.ModuleList(
-            [
-                modeling_qwen3_omni_moe.Qwen3OmniMoeThinkerTextMLP(
-                    config, intermediate_size=config.moe_intermediate_size
-                )
-                for _ in range(self.num_experts)
-            ]
-        )
-
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        batch_size, sequence_length, hidden_dim = hidden_states.shape
-        hidden_states = hidden_states.view(-1, hidden_dim)
-        # router_logits: (batch * sequence_length, n_experts)
-        router_logits = self.gate(hidden_states)
-
-        # Calculate the routing weights for all experts
-        routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
-
-        # Retain the weight of the top_k and reset the rest of the expert rights to 0 (instead of retaining only top_k experts)
-        top_k_weights, top_k_indices = torch.topk(routing_weights, self.top_k, dim=-1)
-        # Initialize the all-zero weight matrix (same shape as all experts)
-        full_routing_weights = torch.zeros_like(routing_weights)
-        # Only the weight of top_k experts is retained, and the weight of the rest of the experts remains at 0
-        full_routing_weights.scatter_(1, top_k_indices, top_k_weights)
-
-        # Normalized top_k weights (keep the original logic consistent)
-        if self.norm_topk_prob:
-            # Calculate the sum of the weights top_k each row (for normalization)
-            top_k_sum = full_routing_weights.sum(dim=-1, keepdim=True)
-            # Avoid dividing by zero
-            top_k_sum = torch.clamp(top_k_sum, min=1e-9)
-            full_routing_weights /= top_k_sum
-
-        # Convert back to the input data type
-        full_routing_weights = full_routing_weights.to(hidden_states.dtype)
-
-        final_hidden_states = torch.zeros(
-            (batch_size * sequence_length, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
-        )
-
-        # Go through all the experts (not just the selected ones)
-        for expert_idx in range(self.num_experts):
-            expert_layer = self.experts[expert_idx]
-            # Get the weight of the current expert (inactive expert has a weight of 0 here)
-            expert_weights = full_routing_weights[:, expert_idx, None]  # shape: (batch*seq, 1)
-            # All samples participate in the calculations of the current expert, the weight may be equal to 0
-            current_hidden_states = expert_layer(hidden_states) * expert_weights
-            # Add-up to all expert outputs (experts with a weight of 0 do not affect the result)
-            final_hidden_states += current_hidden_states
-
-        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
-        return final_hidden_states, router_logits
-
-
 def patch_qwen3_omni_moe_thinker_text_sparse_moe_block():
     if is_transformers_version_greater_than("4.57.0"):
+        from .model_utils.moe import Qwen3OmniMoeThinkerTextSparseMoeBlock
+
         modeling_qwen3_omni_moe.Qwen3OmniMoeThinkerTextSparseMoeBlock = Qwen3OmniMoeThinkerTextSparseMoeBlock
 
 


### PR DESCRIPTION
# What does this PR do?

修复Qwen3omni 在使用deepspeed zero2/zero3 进行微调的时候卡住的问题 #9403  #9474 

qwen3omni的moe负载不均衡，在deepspeed zero2/zero3中对不同卡上未激活的专家反向hook获取不到其梯度，激活专家数量不同强行通信导致卡住。
改写qwen3omni相关的moe forward实现，使得所有专家均参与前向运算过程规避，永久解决需要qwen3omni团队对deepspeed进行适配

测试通过配置文件：
```yaml
### model
model_name_or_path: /data/lcx/Qwen3-Omni-30B-A3B-Instruct
trust_remote_code: true

### method
ddp_find_unused_parameters: True
stage: sft
do_train: true
finetuning_type: lora
deepspeed: examples/deepspeed/ds_z2_config.json  # choices: [ds_z0_config.json, ds_z2_config.json, ds_z3_config.json]

### dataset
dataset: mllm_demo,identity
template: qwen3_omni
cutoff_len: 2048
max_samples: 1000
overwrite_cache: true
preprocessing_num_workers: 16
dataloader_num_workers: 4

### output
output_dir: saves/full/sft
logging_steps: 10
save_steps: 500
plot_loss: true
overwrite_output_dir: true
save_only_model: false
report_to: none  # choices: [none, wandb, tensorboard, swanlab, mlflow]

### train
per_device_train_batch_size: 1
gradient_accumulation_steps: 2
learning_rate: 1.0e-5
num_train_epochs: 3.0
lr_scheduler_type: cosine
warmup_ratio: 0.1
bf16: true
ddp_timeout: 180000000
resume_from_checkpoint: null

### eval
# eval_dataset: alpaca_en_demo
# val_size: 0.1
# per_device_eval_batch_size: 1
# eval_strategy: steps
# eval_steps: 500

```

<img width="917" height="549" alt="image" src="https://github.com/user-attachments/assets/5b85aaee-ba77-4781-8d5f-f74ce3037d8c" />

备注：这个模型减层之后用纯ddp跑多卡依旧有问题，会出现如下报错：
RuntimeError: Expected to mark a variable ready only once. This error is caused by one of the following reasons: 1) Use of a module parameter outside the forward function. Please make sure model parameters are not shared across multiple concurrent forward-backward passes. or try to use _set_static_graph() as a workaround if this module graph does not change during training loop.2) Reused parameters in multiple reentrant backward passes. For example, if you use multiple checkpoint functions to wrap the same part of your model, it would result in the same set of parameters been used by different reentrant backward passes multiple times, and hence marking a variable ready multiple times. DDP does not support such use cases in default. You can try to use _set_static_graph() as a workaround if your module graph does not change over iterations.

