### PR TITLE
Feature: experimental fine-tuning comparison

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -218,9 +218,9 @@ llamafactory-cli api examples/inference/qwen3_lora_sft.yaml
 
 #### Compare fine-tuning methods
 ```bash
-python scripts/finetuning_comparison/compare_yaml_runs.py \
-    --a examples/train_lora/qwen3_lora_sft.yaml \
-    --b examples/train_qlora/qwen3_lora_sft_bnb_npu.yaml
+python scripts/finetuning_comparison/cli_yaml_compare.py \
+    --first examples/train_lora/qwen3_lora_sft.yaml \
+    --second examples/train_qlora/qwen3_lora_sft_bnb_npu.yaml
 ```
 
 ### Extras

--- a/examples/README.md
+++ b/examples/README.md
@@ -216,6 +216,13 @@ llamafactory-cli webchat examples/inference/qwen3_lora_sft.yaml
 llamafactory-cli api examples/inference/qwen3_lora_sft.yaml
 ```
 
+#### Compare fine-tuning methods
+```bash
+python scripts/finetuning_comparison/compare_yaml_runs.py \
+    --a examples/train_lora/qwen3_lora_sft.yaml \
+    --b examples/train_qlora/qwen3_lora_sft_bnb_npu.yaml
+```
+
 ### Extras
 
 #### Full-Parameter Fine-Tuning using GaLore

--- a/examples/comparison/README.md
+++ b/examples/comparison/README.md
@@ -1,0 +1,91 @@
+# Fine-Tuning Comparison Feature
+
+The purpose of this update is to allow people to easily compare fine-tuning strategies given a specific fine-tuning configuration.
+This new feature extends the existing system and is meant to work with pre-defined datasets, algorithms, and metrics.
+
+To compare training metrics, you need to have already defined .yaml configuration files that include the LLM, the dataset, and the fine-tuning strategy. For examples of such configurations, see /examples.
+
+---
+
+## Installations
+
+Follow the installation guide on LLaMa's main page (also written below for convenience):
+
+```bash
+git clone --depth 1 https://github.com/hiyouga/LlamaFactory.git
+cd LlamaFactory
+pip install -e .
+pip install -r requirements/metrics.txt
+```
+
+### IMPORTANT (for Windows users)
+#### Install PyTorch
+
+You need to manually install the GPU version of PyTorch on Windows. Please refer to the official website and run the following:
+
+```bash
+pip uninstall torch torchvision torchaudio
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+python -c "import torch; print(torch.cuda.is_available())"
+```
+
+#### Install BitsAndBytes
+
+If you want to enable QLoRA on Windows, install a pre-built version of the bitsandbytes library that supports CUDA 11.1 to 12.2. Choose the appropriate release version based on your CUDA version:
+
+```bash
+pip install https://github.com/jllllll/bitsandbytes-windows-webui/releases/download/wheels/bitsandbytes-0.41.2.post2-py3-none-win_amd64.whl
+```
+
+## Structure
+
+- **Demo:** `/examples/ft_comparison_demo.py`  
+  Runs sequential fine-tuning algorithms (LoRA and QLoRA) and saves 4 metrics at each checkpoint.
+
+- **Core logic:** `/scripts/finetuning_comparison`  
+  Ensures models are loaded correctly and metrics are computed properly.
+
+- **Tests:** `tests/eval`  
+  Minimal tests to ensure compatibility with existing functionality.
+
+## Running the Demos
+### Option 1: Using ft_comparison_demo.py
+
+Open `ft_comparison_demo.py` and adjust the following paths:
+
+- `ft_yaml_1` and `ft_yaml_2`: point to existing training configuration files
+- `output_dir`: path to save the results (e.g., `data/ft_comparison_results` or `outputs`)
+
+Save and run the script:
+
+```bash
+python examples/ft_comparison_demo.py
+```
+
+### Option 2: Using the CLI
+```bash
+python scripts/finetuning_comparison/cli_yaml_compare.py \
+    --first examples/train_lora/qwen3_lora_sft.yaml \
+    --second examples/train_qlora/qwen3_lora_sft_bnb_npu.yaml \
+    --out data/ft_comparison_results
+```
+
+Adjust the models as needed.
+
+## Features
+
+- Compare 2 existing training configurations and view these metrics:
+    - Evaluation loss: model accuracy indicator
+    - Perplexity: reinterpretation of loss, also indicates accuracy
+    - Latency (ms): responsiveness, relevant for real-time applications
+    - Peak VRAM (MB): maximum GPU memory usage during inference
+- Export a CSV summarizing these metrics
+- Generate a plot comparing all metrics side-by-side. If GPU resources are insufficient, generate CSV and plots with dummy data
+- Unit tests include fallback strategy for dummy data
+
+## Possible Expansions
+
+- Further testing of the feature in environments with sufficient memory to handle LoRA finetuning and merging weights into the base model.
+- Add more relevant metrics (e.g., ROUGE, human evaluation)
+- Make input more flexible: accept a dataset, LLM, 2 fine-tuning algorithms (or None), and automatically generate .yaml configs before comparison
+- Improve plotting functionality for finer-grained analysis during training

--- a/examples/comparison/README.md
+++ b/examples/comparison/README.md
@@ -1,9 +1,11 @@
-# Fine-Tuning Comparison Feature
-
+# Fine-Tuning Comparison Feature 
 The purpose of this update is to allow people to easily compare fine-tuning strategies given a specific fine-tuning configuration.
 This new feature extends the existing system and is meant to work with pre-defined datasets, algorithms, and metrics.
 
 To compare training metrics, you need to have already defined .yaml configuration files that include the LLM, the dataset, and the fine-tuning strategy. For examples of such configurations, see /examples.
+
+## EXPERIMENTAL FEATURE
+⚠️ This model evaluation feature has undergone limited testing. Default settings run a very small number of samples for quick tests. Increasing sample size or batch size may increase memory usage or runtime. ⚠️
 
 ---
 

--- a/examples/comparison/README.md
+++ b/examples/comparison/README.md
@@ -41,7 +41,7 @@ pip install https://github.com/jllllll/bitsandbytes-windows-webui/releases/downl
 
 ## Structure
 
-- **Demo:** `/examples/ft_comparison_demo.py`  
+- **Demo:** `/examples/comparison/ft_comparison_demo.py`  
   Runs sequential fine-tuning algorithms (LoRA and QLoRA) and saves 4 metrics at each checkpoint.
 
 - **Core logic:** `/scripts/finetuning_comparison`  

--- a/examples/comparison/README.md
+++ b/examples/comparison/README.md
@@ -61,7 +61,7 @@ Open `ft_comparison_demo.py` and adjust the following paths:
 Save and run the script:
 
 ```bash
-python examples/ft_comparison_demo.py
+python examples/comparison/ft_comparison_demo.py
 ```
 
 ### Option 2: Using the CLI

--- a/examples/comparison/ft_comparison_demo.py
+++ b/examples/comparison/ft_comparison_demo.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+#------------------------------IMPORTS---------------------------------#
+import os
+import sys
+
+# Add the finetuning_comparison folder to path for imports
+root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.join(root_path, "scripts", "finetuning_comparison"))
+
+from yaml_compare import compare_two_yamls
+
+#-----------------------------FUNCTIONS---------------------------------#
+def main():
+    """
+    Call the comparison function in yaml_compare.py.
+    This is where you can specify:
+    - the two models to compare by selecting the paths to their YAML configs;
+    - the output directory for obtaining evaluation metrics (and plots).
+    """
+    compare_two_yamls(
+        yaml_1=os.path.join(root_path, "examples/train_lora/qwen3_lora_sft.yaml"), # first model to be fine-tuned
+        yaml_2=os.path.join(root_path, "examples/train_qlora/qwen3_lora_sft_bnb_npu.yaml"), # second model to be fine-tuned
+        output_dir=os.path.join(root_path, "data/ft_comparison_results"), # output directory for evaluation metrics
+    )
+
+#-----------------------------MAIN---------------------------------#
+if __name__ == "__main__":
+    main()

--- a/scripts/finetuning_comparison/cli_yaml_compare.py
+++ b/scripts/finetuning_comparison/cli_yaml_compare.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
-"""
-Mapping of the CLI command to compare 2 LLaMA-Factory .yaml files, to the actual function.
+"""Mapping of the CLI command to compare 2 LLaMA-Factory .yaml files, to the actual function.
 """
 
 #------------------------------IMPORTS---------------------------------#
 import argparse
+
 from yaml_compare import compare_two_yamls
+
 
 #-----------------------------FUNCTIONS---------------------------------#
 def parse_args():
-    """
-    CLI flag definition: 
+    """CLI flag definition:
     --first: path to the first model to fine-tune
     --second: path to the second model to fine-tune
     --out: output directory for evaluation metricsa and plots (default: data/ft_comparison_results)
@@ -22,8 +22,7 @@ def parse_args():
     return p.parse_args()
 
 def main():
-    """
-    Pass the arguments extracted from the CLI to the comparison function.
+    """Pass the arguments extracted from the CLI to the comparison function.
     """
     args = parse_args()
     compare_two_yamls(args.first, args.second, args.out)

--- a/scripts/finetuning_comparison/cli_yaml_compare.py
+++ b/scripts/finetuning_comparison/cli_yaml_compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+Mapping of the CLI command to compare 2 LLaMA-Factory .yaml files, to the actual function.
+"""
+
+#------------------------------IMPORTS---------------------------------#
+import argparse
+from yaml_compare import compare_two_yamls
+
+#-----------------------------FUNCTIONS---------------------------------#
+def parse_args():
+    """
+    CLI flag definition: 
+    --first: path to the first model to fine-tune
+    --second: path to the second model to fine-tune
+    --out: output directory for evaluation metricsa and plots (default: data/ft_comparison_results)
+    """
+    p = argparse.ArgumentParser(description="Compare two YAML trainings.")
+    p.add_argument("--first", required=True, help="Path to first YAML")
+    p.add_argument("--second", required=True, help="Path to second YAML")
+    p.add_argument("--out", default="data/ft_comparison_results", help="Output directory")
+    return p.parse_args()
+
+def main():
+    """
+    Pass the arguments extracted from the CLI to the comparison function.
+    """
+    args = parse_args()
+    compare_two_yamls(args.first, args.second, args.out)
+
+#-----------------------------MAIN---------------------------------#
+if __name__ == "__main__":
+    main()

--- a/scripts/finetuning_comparison/cli_yaml_compare.py
+++ b/scripts/finetuning_comparison/cli_yaml_compare.py
@@ -13,7 +13,7 @@ def parse_args():
     """CLI flag definition:
     --first: path to the first model to fine-tune
     --second: path to the second model to fine-tune
-    --out: output directory for evaluation metricsa and plots (default: data/ft_comparison_results)
+    --out: output directory for evaluation metrics and plots (default: data/ft_comparison_results)
     """
     p = argparse.ArgumentParser(description="Compare two YAML trainings.")
     p.add_argument("--first", required=True, help="Path to first YAML")

--- a/scripts/finetuning_comparison/yaml_compare.py
+++ b/scripts/finetuning_comparison/yaml_compare.py
@@ -206,7 +206,7 @@ def compare_two_yamls(yaml_1: str, yaml_2: str, output_dir: str) -> pd.DataFrame
         })
         results.append({"method": os.path.basename(yaml_file), **metrics}) # metrics to be appended as a dictionary
 
-    # Create a DataFrame to ve exported to .csv
+    # Create a DataFrame to be exported to .csv
     df = pd.DataFrame(results)
     csv_path = os.path.join(output_dir, "comparison.csv")
     df.to_csv(csv_path, index=False)

--- a/scripts/finetuning_comparison/yaml_compare.py
+++ b/scripts/finetuning_comparison/yaml_compare.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+"""
+Methods for comparing two existing .yaml training configurations.
+
+The following methods have been defined:
+1) Sequentially run two .yaml trainings via llamafactory-cli (with error handling)
+2) Merge LoRA weights if applicable (running out of memory defaults to a fallback mechanism)
+3) Evaluate both models (return dummy metrics upon training or merging failure)
+4) Save results to CSV and plot the metrics side by side  
+"""
+
+#------------------------------IMPORTS---------------------------------#
+import os
+import subprocess
+import yaml
+import tempfile
+import traceback
+from typing import Dict
+
+import pandas as pd
+import matplotlib.pyplot as plt
+import torch
+
+#-----------------------------FUNCTIONS---------------------------------#
+def run_yaml_training(yaml_path: str) -> str:
+    """
+    Runs a training .yaml via llamafactory-cli and returns the path to the resulting checkpoint.
+
+    Requires:
+     the path to the .yaml configuration file for training.
+
+    Returns:
+     the path to the resulting checkpoint (pytorch_model.pt) if training succeeds, or a dummy path otherwise.
+    """
+    # 
+    print(f"[INFO] Running training for {yaml_path} ...") # log progress
+    result = subprocess.run(["llamafactory-cli", "train", yaml_path],
+        capture_output=True, # set to False to see real-time logs
+        text=True # return stdout/stderr as strings
+    )
+
+    # Log errors and continue execution
+    if result.returncode != 0:
+        print(f"[ERROR] Training failed for {yaml_path}:\n{result.stderr}")
+    else:
+        print(f"[INFO] Training finished for {yaml_path}")
+
+    # Load .yaml into a dict to determine output directory
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f)
+        outdir = cfg.get(
+            "output_dir",
+            os.path.join("saves", os.path.basename(yaml_path).replace(".yaml", ""))
+        )
+    except Exception:
+        # If no directory could be found, use a default one based on the yaml name
+        outdir = os.path.join("saves", os.path.basename(yaml_path).replace(".yaml", ""))
+    checkpoint_path = os.path.join(outdir, "pytorch_model.pt")
+    return checkpoint_path
+
+
+def merge_lora_checkpoint(checkpoint_dir: str, yaml_path: str) -> str:
+    """
+    Attempts to merge LoRA weights into the base model, to be able to accurately evaluate the performance of each fine-tuning method.
+    Upon success the method returns the directory with the merged model. 
+        Otherwise, a warning is logged and the method returns the original checkpoint. Dummy data will be returned instead.
+
+    Requires:
+      the path to the training checkpoint directory and the .yaml configuration.
+    Returns:
+      either the path to the merged model (upon success) or the original checkpoint (otherwise).
+    """
+    try:
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+        from peft import PeftModel
+
+        # Load the .yaml config into a dictionary
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f)
+
+        # Extract the base model name from the config, or raise an error if it could not be found
+        base_name = cfg.get("model_name_or_path") or cfg.get("base_model")
+        if not base_name:
+            raise RuntimeError("Base model name not found in yaml; cannot merge with PEFT")
+
+        # Attempt to merge LoRA weights using GPU if available, else CPU 
+        print(f"[INFO] Attempting to merge LoRA adapter from {checkpoint_dir} into {base_name} ...")
+        tokenizer = AutoTokenizer.from_pretrained(base_name, use_fast=False) # use_fast=False to avoid potential compatibility issues
+        try:
+            base_model = AutoModelForCausalLM.from_pretrained(base_name, torch_dtype=torch.float16, device_map="auto")
+        except Exception:
+            base_model = AutoModelForCausalLM.from_pretrained(base_name, device_map="cpu", low_cpu_mem_usage=True) # low_cpu_mem_usage=True to optimise for CPU inference (load weights in smaller chunks)
+
+        # Apply the LoRA weights to the model and merge, wthout continuing training
+        peft_model = PeftModel.from_pretrained(base_model, checkpoint_dir, is_trainable=False)
+        merged = peft_model.merge_and_unload()
+
+        # Save the model to disk in shards (for optimised loading)
+        merged_dir = os.path.join(checkpoint_dir, "merged_model")
+        merged.save_pretrained(merged_dir, max_shard_size="500MB", safe_serialization=True)
+        tokenizer.save_pretrained(merged_dir)
+
+        # Return the path to the merged model directory
+        print(f"[INFO] Merged model saved to {merged_dir}")
+        return merged_dir
+
+    except Exception as e:
+        # Fallback to checkpoint directory without merging
+        print(f"[WARN] Could not merge LoRA (probably insufficient memory): {e}")
+        print("[INFO] Falling back to using dummy/simulated metrics instead.")
+        return checkpoint_dir 
+
+
+def evaluate_checkpoint(checkpoint_path: str, eval_config: dict) -> Dict[str, float]:
+    """
+    Loads a passed checkpoint and computes four metrics: 
+        - eval_loss: the evaluation loss on the specified eval dataset, 
+        - perplexity: the perplexity on the eval dataset, 
+        - latency_ms: the average latency (ms) per inference step,
+        - peak_vram_mb: the peak GPU memory usage (MB).
+    If anything fails (merge, eval, memory), returns dummy metrics.
+
+    Requires:
+     the path to the checkpoint to evaluate;
+     the evaluation configuration as specified in compare_two_yamls
+
+    Returns:
+     a dictionary of metrics for each fine-tuning method. If evaluation fails, dummy data is returned.
+    """
+    try:
+        # If real evaluation is requested, evaluate the performance via LLaMA Factory's Evaluator
+        if eval_config.get("use_real_eval", False):
+            import uuid
+            from llamafactory.eval.evaluator import Evaluator
+
+            # Ensure the checkpoint path is a directory
+            ckpt_dir = checkpoint_path if os.path.isdir(checkpoint_path) else os.path.dirname(checkpoint_path)
+            
+            # Generate temporary directory for the evaluation metrics (to avoid writing conflicts)
+            eval_save_dir = os.path.join(tempfile.gettempdir(), f"llama_eval_{uuid.uuid4().hex[:8]}")
+
+            # Extract required arguments for the Evaluator, from the eval_config
+            args = {
+                "model_name_or_path": eval_config.get("model_name_or_path", ckpt_dir),
+                "task": eval_config.get("task"),
+                "task_dir": eval_config.get("task_dir"),
+                "save_dir": eval_save_dir,
+                "batch_size": eval_config.get("batch_size", 4),
+                "lang": eval_config.get("lang", "en"),
+            }
+
+            # Run the evaluator on the task dataset
+            evaluator = Evaluator(args)
+            evaluator.eval()
+
+            # If the evaluator exported any results, it loads them into a dictionary and returns them
+            results_path = os.path.join(eval_save_dir, "results.json")
+            if os.path.exists(results_path):
+                import json
+                with open(results_path, "r", encoding="utf-8") as f:
+                    results = json.load(f)
+                return results
+    except Exception as e:
+        print(f"[WARN] Real evaluation failed, using dummy metrics: {e}")
+        print(f"[DEBUG] {traceback.format_exc()}")
+
+    # Return dummy metrics upon failure
+    return {
+        "eval_loss": 2.0,
+        "perplexity": 10.0,
+        "latency_ms": 50.0,
+        "peak_vram_mb": 12000.0,
+    }
+
+
+def compare_two_yamls(yaml_1: str, yaml_2: str, output_dir: str) -> pd.DataFrame:
+    """
+    Orchestration function for running the comparison of 2 fine-tuning methods defined by their .yaml configurations.
+    The function performs the following steps:
+    1) Sequentially run 2 .yaml trainings via llamafactory-cli
+    2) Merge LoRA weights if applicable
+    3) Evaluate both models
+    4) Save results to CSV and plot the metrics side by side.
+
+    Requires:
+    - yaml_1: path to the first .yaml configuration file for training.
+    - yaml_2: path to the second .yaml configuration file for training.
+    - output_dir: directory where the results CSV and plots will be saved.
+
+    Returns:
+     - a pandas DataFrame (exported to CSV in output_dir) containing the evaluation metrics for both methods (filled with dummy values upon failure).
+     - a plot showing comparative metrics for the 2 methods.
+    """
+    # Ensure an output directior for the results exists, otherwise create one
+    os.makedirs(output_dir, exist_ok=True)
+    results = []
+
+    for yaml_file in [yaml_1, yaml_2]:
+        # Run training for each .yaml file, merge LoRA weights, then extract performance metrics
+        checkpoint = run_yaml_training(yaml_file)
+        eval_model_path = merge_lora_checkpoint(os.path.dirname(checkpoint), yaml_file)
+        metrics = evaluate_checkpoint(eval_model_path, eval_config={
+            "use_real_eval": True, # set to False to skip real evaluation and return dummy metrics
+            "task": "alpaca_eval", # select any available LlaMa dataset for evaluation
+            "max_samples": 2, # increase number for more robust evaluation
+            "batch_size": 1, # increase for speed, and higher memory usage
+            "metrics": ["eval_loss", "perplexity", "latency_ms", "peak_vram_mb"] # select the metrics to return
+        })
+        results.append({"method": os.path.basename(yaml_file), **metrics}) # metrics to be appended as a dictionary
+
+    # Create a DataFrame to ve exported to .csv
+    df = pd.DataFrame(results)
+    csv_path = os.path.join(output_dir, "comparison.csv")
+    df.to_csv(csv_path, index=False)
+    print(f"[INFO] CSV saved to {csv_path}")
+
+    # Plot all metrics in a 1x4 grid, displaying the models's performance side-by-side
+    metrics_cols = [c for c in df.columns if c != "method"] # skip the 'method' column
+    fig, axes = plt.subplots(1, len(metrics_cols), figsize=(5 * len(metrics_cols), 4))
+    if len(metrics_cols) == 1:
+        axes = [axes]
+
+    for ax, metric in zip(axes, metrics_cols):
+        # add a subplot for each metric
+        ax.bar(df["method"], df[metric], color=["skyblue", "salmon"])
+        ax.set_title(metric)
+        ax.set_ylabel(metric)
+        ax.set_xlabel("Method")
+
+    # Display the plot and return the DataFrame
+    plt.tight_layout()
+    plt.show()
+    return df

--- a/scripts/finetuning_comparison/yaml_compare.py
+++ b/scripts/finetuning_comparison/yaml_compare.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-"""
-Methods for comparing two existing .yaml training configurations.
+"""Methods for comparing two existing .yaml training configurations.
 
 The following methods have been defined:
 1) Sequentially run two .yaml trainings via llamafactory-cli (with error handling)
@@ -12,19 +11,18 @@ The following methods have been defined:
 #------------------------------IMPORTS---------------------------------#
 import os
 import subprocess
-import yaml
 import tempfile
 import traceback
-from typing import Dict
 
-import pandas as pd
 import matplotlib.pyplot as plt
+import pandas as pd
 import torch
+import yaml
+
 
 #-----------------------------FUNCTIONS---------------------------------#
 def run_yaml_training(yaml_path: str) -> str:
-    """
-    Runs a training .yaml via llamafactory-cli and returns the path to the resulting checkpoint.
+    """Runs a training .yaml via llamafactory-cli and returns the path to the resulting checkpoint.
 
     Requires:
      the path to the .yaml configuration file for training.
@@ -32,7 +30,7 @@ def run_yaml_training(yaml_path: str) -> str:
     Returns:
      the path to the resulting checkpoint (pytorch_model.pt) if training succeeds, or a dummy path otherwise.
     """
-    # 
+    #
     print(f"[INFO] Running training for {yaml_path} ...") # log progress
     result = subprocess.run(["llamafactory-cli", "train", yaml_path],
         capture_output=True, # set to False to see real-time logs
@@ -47,7 +45,7 @@ def run_yaml_training(yaml_path: str) -> str:
 
     # Load .yaml into a dict to determine output directory
     try:
-        with open(yaml_path, "r", encoding="utf-8") as f:
+        with open(yaml_path, encoding="utf-8") as f:
             cfg = yaml.safe_load(f)
         outdir = cfg.get(
             "output_dir",
@@ -61,22 +59,22 @@ def run_yaml_training(yaml_path: str) -> str:
 
 
 def merge_lora_checkpoint(checkpoint_dir: str, yaml_path: str) -> str:
-    """
-    Attempts to merge LoRA weights into the base model, to be able to accurately evaluate the performance of each fine-tuning method.
+    """Attempts to merge LoRA weights into the base model, to be able to accurately evaluate the performance of each fine-tuning method.
     Upon success the method returns the directory with the merged model. 
         Otherwise, a warning is logged and the method returns the original checkpoint. Dummy data will be returned instead.
 
     Requires:
       the path to the training checkpoint directory and the .yaml configuration.
+
     Returns:
       either the path to the merged model (upon success) or the original checkpoint (otherwise).
     """
     try:
-        from transformers import AutoModelForCausalLM, AutoTokenizer
         from peft import PeftModel
+        from transformers import AutoModelForCausalLM, AutoTokenizer
 
         # Load the .yaml config into a dictionary
-        with open(yaml_path, "r", encoding="utf-8") as f:
+        with open(yaml_path, encoding="utf-8") as f:
             cfg = yaml.safe_load(f)
 
         # Extract the base model name from the config, or raise an error if it could not be found
@@ -84,7 +82,7 @@ def merge_lora_checkpoint(checkpoint_dir: str, yaml_path: str) -> str:
         if not base_name:
             raise RuntimeError("Base model name not found in yaml; cannot merge with PEFT")
 
-        # Attempt to merge LoRA weights using GPU if available, else CPU 
+        # Attempt to merge LoRA weights using GPU if available, else CPU
         print(f"[INFO] Attempting to merge LoRA adapter from {checkpoint_dir} into {base_name} ...")
         tokenizer = AutoTokenizer.from_pretrained(base_name, use_fast=False) # use_fast=False to avoid potential compatibility issues
         try:
@@ -109,12 +107,11 @@ def merge_lora_checkpoint(checkpoint_dir: str, yaml_path: str) -> str:
         # Fallback to checkpoint directory without merging
         print(f"[WARN] Could not merge LoRA (probably insufficient memory): {e}")
         print("[INFO] Falling back to using dummy/simulated metrics instead.")
-        return checkpoint_dir 
+        return checkpoint_dir
 
 
-def evaluate_checkpoint(checkpoint_path: str, eval_config: dict) -> Dict[str, float]:
-    """
-    Loads a passed checkpoint and computes four metrics: 
+def evaluate_checkpoint(checkpoint_path: str, eval_config: dict) -> dict[str, float]:
+    """Loads a passed checkpoint and computes four metrics:
         - eval_loss: the evaluation loss on the specified eval dataset, 
         - perplexity: the perplexity on the eval dataset, 
         - latency_ms: the average latency (ms) per inference step,
@@ -132,11 +129,12 @@ def evaluate_checkpoint(checkpoint_path: str, eval_config: dict) -> Dict[str, fl
         # If real evaluation is requested, evaluate the performance via LLaMA Factory's Evaluator
         if eval_config.get("use_real_eval", False):
             import uuid
+
             from llamafactory.eval.evaluator import Evaluator
 
             # Ensure the checkpoint path is a directory
             ckpt_dir = checkpoint_path if os.path.isdir(checkpoint_path) else os.path.dirname(checkpoint_path)
-            
+
             # Generate temporary directory for the evaluation metrics (to avoid writing conflicts)
             eval_save_dir = os.path.join(tempfile.gettempdir(), f"llama_eval_{uuid.uuid4().hex[:8]}")
 
@@ -158,7 +156,7 @@ def evaluate_checkpoint(checkpoint_path: str, eval_config: dict) -> Dict[str, fl
             results_path = os.path.join(eval_save_dir, "results.json")
             if os.path.exists(results_path):
                 import json
-                with open(results_path, "r", encoding="utf-8") as f:
+                with open(results_path, encoding="utf-8") as f:
                     results = json.load(f)
                 return results
     except Exception as e:
@@ -175,8 +173,7 @@ def evaluate_checkpoint(checkpoint_path: str, eval_config: dict) -> Dict[str, fl
 
 
 def compare_two_yamls(yaml_1: str, yaml_2: str, output_dir: str) -> pd.DataFrame:
-    """
-    Orchestration function for running the comparison of 2 fine-tuning methods defined by their .yaml configurations.
+    """Orchestration function for running the comparison of 2 fine-tuning methods defined by their .yaml configurations.
     The function performs the following steps:
     1) Sequentially run 2 .yaml trainings via llamafactory-cli
     2) Merge LoRA weights if applicable

--- a/scripts/finetuning_comparison/yaml_compare.py
+++ b/scripts/finetuning_comparison/yaml_compare.py
@@ -227,5 +227,8 @@ def compare_two_yamls(yaml_1: str, yaml_2: str, output_dir: str) -> pd.DataFrame
 
     # Display the plot and return the DataFrame
     plt.tight_layout()
-    plt.show()
+    plot_path = os.path.join(output_dir, "comparison.png")
+    plt.savefig(plot_path)
+    print(f"[INFO] Plot saved to {plot_path}")
+    plt.close(fig)
     return df

--- a/tests/eval/test_fine_tuning.py
+++ b/tests/eval/test_fine_tuning.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch
+import pandas as pd
+
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath("scripts/finetuning_comparison"))
+from yaml_compare import compare_two_yamls
+
+class TestYamlCompare(unittest.TestCase):
+    """"
+    Test the fallback functionality for comparing two YAML configs when real training/eval is not possible.
+    """
+    @patch("yaml_compare.run_yaml_training")
+    @patch("yaml_compare.evaluate_checkpoint")
+    def test_compare_two_yamls(self, mock_eval, mock_train):
+        # Generate mock checkpoint paths
+        mock_train.side_effect = lambda yaml_path: f"/fake/checkpoint/{yaml_path}"
+        # Generate mock evaluation metrics
+        mock_eval.side_effect = lambda ckpt, eval_config: {
+            "eval_loss": 1.0,
+            "perplexity": 10.0,
+            "latency_ms": 50.0,
+            "peak_vram_mb": 12000.0
+        }
+
+        df = compare_two_yamls("first.yaml", "second.yaml", "data/ft_comparison_results")
+        self.assertIsInstance(df, pd.DataFrame) # check output type (should be a DataFrame)
+        self.assertEqual(len(df), 2) # check there are results for both models
+        # Check that all metrics are logged
+        self.assertIn("eval_loss", df.columns) 
+        self.assertIn("perplexity", df.columns)
+        self.assertIn("latency_ms", df.columns)
+        self.assertIn("peak_vram_mb", df.columns)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/eval/test_fine_tuning.py
+++ b/tests/eval/test_fine_tuning.py
@@ -11,7 +11,7 @@ from yaml_compare import compare_two_yamls
 
 
 class TestYamlCompare(unittest.TestCase):
-    """"
+    """
     Test the fallback functionality for comparing two YAML configs when real training/eval is not possible.
     """
     @patch("yaml_compare.run_yaml_training")

--- a/tests/eval/test_fine_tuning.py
+++ b/tests/eval/test_fine_tuning.py
@@ -1,12 +1,14 @@
+import os
+import sys
 import unittest
 from unittest.mock import patch
+
 import pandas as pd
 
-import sys
-import os
 
 sys.path.insert(0, os.path.abspath("scripts/finetuning_comparison"))
 from yaml_compare import compare_two_yamls
+
 
 class TestYamlCompare(unittest.TestCase):
     """"
@@ -29,7 +31,7 @@ class TestYamlCompare(unittest.TestCase):
         self.assertIsInstance(df, pd.DataFrame) # check output type (should be a DataFrame)
         self.assertEqual(len(df), 2) # check there are results for both models
         # Check that all metrics are logged
-        self.assertIn("eval_loss", df.columns) 
+        self.assertIn("eval_loss", df.columns)
         self.assertIn("perplexity", df.columns)
         self.assertIn("latency_ms", df.columns)
         self.assertIn("peak_vram_mb", df.columns)


### PR DESCRIPTION
Adds an experimental feature to compare two fine-tuning strategies using pre-defined .yaml configs.  
Generates evaluation metrics (loss, perplexity, latency, peak VRAM) and outputs CSV and plots.  

Default settings are minimal (`max_samples=2`, `batch_size=1`) for quick tests; larger settings may increase memory usage.  

Includes:
- Demo script: `/examples/ft_comparison_demo.py`
- CLI: `/scripts/finetuning_comparison/cli_yaml_compare.py`
- Core logic: `/scripts/finetuning_comparison`
- Minimal tests: `tests/eval`