### PR TITLE
[deps] Add libibverbs for RDMA support

### DIFF
--- a/docker/docker-cuda/Dockerfile.base
+++ b/docker/docker-cuda/Dockerfile.base
@@ -37,6 +37,11 @@ RUN apt-get update && \
     apt-get install -y gcc g++ && \
     apt-get clean
 
+# Install libibverbs for RDMA support
+RUN apt-get update && \
+    apt-get install -y libibverbs-dev && \
+    apt-get clean
+
 # Change pip source
 RUN pip config set global.index-url "${PIP_INDEX}" && \
     pip config set global.extra-index-url "${PIP_INDEX}" && \


### PR DESCRIPTION
# What does this PR do?

Add `libibverbs-dev` library to the `Dockerfile.base` to support Remote Direct Memory Access (RDMA). This optimization enables faster node-to-node communication, leading to a significant reduction in distributed training times.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
