### PR TITLE
[WIP][V1] Add checkpoint saving and fix buffer and tied weight for meta training in full

### DIFF
--- a/src/llamafactory/v1/config/training_args.py
+++ b/src/llamafactory/v1/config/training_args.py
@@ -81,6 +81,18 @@ class TrainingArguments:
         default=None,
         metadata={"help": "Learning rate scheduler configuration for training."},
     )
+    save_steps: int | None = field(
+        default=None,
+        metadata={"help": "Save checkpoint every X steps. If None, checkpoints are not saved by steps."},
+    )
+    save_epochs: int | None = field(
+        default=None,
+        metadata={"help": "Save checkpoint every X epochs. If None, checkpoints are not saved by epochs."},
+    )
+    save_total_limit: int | None = field(
+        default=None,
+        metadata={"help": "Maximum number of checkpoints to keep. Older checkpoints are deleted."},
+    )
 
     def __post_init__(self) -> None:
         self.dist_config = get_plugin_config(self.dist_config)

--- a/src/llamafactory/v1/core/base_trainer.py
+++ b/src/llamafactory/v1/core/base_trainer.py
@@ -27,6 +27,7 @@ Train Phase:
 
 """
 
+import os
 from abc import abstractmethod
 
 import torch
@@ -61,6 +62,9 @@ class BaseTrainer:
         # info
         self.global_step = 0
 
+        # checkpoint management
+        self._checkpoint_folders = []  # Track saved checkpoints for cleanup
+
         # cached variables
         self.device = DistributedInterface().current_device
         self.dp_size = DistributedInterface().get_world_size(Dim.DP)
@@ -77,6 +81,7 @@ class BaseTrainer:
             self.model.gradient_checkpointing_enable({"use_reentrant": False})
 
         self._accelerate_engine = None
+        self._deepspeed_engine = None
         dist_name = self.args.dist_config.name if self.args.dist_config is not None else None
 
         if dist_name == "deepspeed":
@@ -98,6 +103,14 @@ class BaseTrainer:
             self._shard_model()
             self._init_optimizer()
             self._init_lr_scheduler()
+
+            # Log whether model was loaded from DCP
+            if dist_name == "fsdp2" and hasattr(self.model, "_fsdp2_loaded_from_dcp"):
+                loaded_from_dcp = self.model._fsdp2_loaded_from_dcp  # type: ignore[attr-defined]
+                if loaded_from_dcp:
+                    logger.info_rank0("Model loaded from DCP checkpoint, will save checkpoints in DCP format.")
+                else:
+                    logger.info_rank0("Model loaded from HF checkpoint, will save checkpoints in HF format.")
 
     def _create_batch_generator(self) -> None:
         self.train_batch_generator = BatchGenerator(
@@ -219,6 +232,79 @@ class BaseTrainer:
                 if self.global_step >= self.num_training_steps:
                     logger.info_rank0(f"Reached max_steps ({self.num_training_steps}), stopping training.")
                     return
+
+                # Save checkpoint if save_steps is set
+                if self.args.save_steps is not None and self.global_step % self.args.save_steps == 0:
+                    self._save_checkpoint_with_cleanup(checkpoint_type="step")
+
+            # Save checkpoint at the end of each epoch if save_epochs is set
+            # Note: epoch is 0-indexed, so we save at epoch+1
+            if self.args.save_epochs is not None and (epoch + 1) % self.args.save_epochs == 0:
+                self._save_checkpoint_with_cleanup(checkpoint_type="epoch", epoch=epoch + 1)
+
+    def _save_checkpoint_with_cleanup(self, checkpoint_type: str = "step", epoch: int | None = None) -> None:
+        """Save checkpoint and manage checkpoint rotation based on save_total_limit.
+
+        Args:
+            checkpoint_type: Type of checkpoint - "step" or "epoch"
+            epoch: Epoch number (only used when checkpoint_type="epoch")
+        """
+        if checkpoint_type == "epoch" and epoch is not None:
+            checkpoint_dir = os.path.join(self.args.output_dir, f"checkpoint-epoch-{epoch}")
+            logger.info_rank0(f"Saving checkpoint at epoch {epoch} (step {self.global_step}) to {checkpoint_dir}")
+        else:
+            checkpoint_dir = os.path.join(self.args.output_dir, f"checkpoint-{self.global_step}")
+            logger.info_rank0(f"Saving checkpoint at step {self.global_step} to {checkpoint_dir}")
+
+        self.save_checkpoint(output_dir=checkpoint_dir)
+
+        # Track this checkpoint
+        self._checkpoint_folders.append(checkpoint_dir)
+
+        # Clean up old checkpoints if save_total_limit is set
+        if self.args.save_total_limit is not None and len(self._checkpoint_folders) > self.args.save_total_limit:
+            # Only delete on rank 0 to avoid race conditions
+            if DistributedInterface().get_rank() == 0:
+                num_to_delete = len(self._checkpoint_folders) - self.args.save_total_limit
+                for _ in range(num_to_delete):
+                    checkpoint_to_delete = self._checkpoint_folders.pop(0)
+                    if os.path.exists(checkpoint_to_delete):
+                        import shutil
+
+                        checkpoint_to_delete.startswith(os.path.join(self.args.output_dir, "checkpoint"))
+
+                        logger.info_rank0(f"Deleting old checkpoint: {checkpoint_to_delete}")
+                        shutil.rmtree(checkpoint_to_delete)
+            else:
+                # Non-rank-0 processes just update the list
+                num_to_delete = len(self._checkpoint_folders) - self.args.save_total_limit
+                for _ in range(num_to_delete):
+                    self._checkpoint_folders.pop(0)
+
+            # Sync to make sure deletion is complete before continuing
+            DistributedInterface().sync()
+
+    def save_checkpoint(self, output_dir: str | None = None) -> None:
+        """Save checkpoint during training.
+
+        Args:
+            output_dir: Output directory. If None, uses self.args.output_dir
+        """
+        if output_dir is None:
+            output_dir = self.args.output_dir
+
+        if self.args.dist_config is not None and self.args.dist_config.name in ("deepspeed", "fsdp2"):
+            from ..plugins.trainer_plugins.distributed.hub import DistributedPlugin
+
+            DistributedPlugin(self.args.dist_config.name).save_checkpoint(
+                self.model, output_dir, self.renderer.processor
+            )
+        else:
+            # For DDP or single GPU, just save the model normally
+            model_to_save = self.model.module if hasattr(self.model, "module") else self.model
+            model_to_save.save_pretrained(output_dir, max_shard_size="4GB")
+            self.renderer.processor.save_pretrained(output_dir, max_shard_size="4GB")
+            logger.info_rank0(f"Checkpoint saved to {output_dir}")
 
     def save_model(self) -> None:
         """Save the model."""

--- a/src/llamafactory/v1/core/base_trainer.py
+++ b/src/llamafactory/v1/core/base_trainer.py
@@ -271,7 +271,7 @@ class BaseTrainer:
                     if os.path.exists(checkpoint_to_delete):
                         import shutil
 
-                        checkpoint_to_delete.startswith(os.path.join(self.args.output_dir, "checkpoint"))
+                        assert checkpoint_to_delete.startswith(os.path.join(self.args.output_dir, "checkpoint"))
 
                         logger.info_rank0(f"Deleting old checkpoint: {checkpoint_to_delete}")
                         shutil.rmtree(checkpoint_to_delete)

--- a/src/llamafactory/v1/plugins/trainer_plugins/distributed/deepspeed.py
+++ b/src/llamafactory/v1/plugins/trainer_plugins/distributed/deepspeed.py
@@ -109,6 +109,29 @@ class DeepSpeedEngine:
         return 0.0
 
 
+def save_checkpoint(model: HFModel, output_dir: str, processor: Processor) -> None:
+    """Save checkpoint during training using DeepSpeed's native format.
+
+    Note: DeepSpeed does not support DCP format.
+
+    Args:
+        model: The model to save
+        output_dir: Output directory
+        processor: Processor to save
+    """
+    accelerator: Accelerator = model._accelerator
+
+    unwrapped_model = accelerator.unwrap_model(model)
+    state_dict = accelerator.get_state_dict(model)
+
+    if accelerator.is_main_process:
+        unwrapped_model.save_pretrained(output_dir, state_dict=state_dict, max_shard_size="4GB")
+        processor.save_pretrained(output_dir, max_shard_size="4GB")
+
+    accelerator.wait_for_everyone()
+    logger.info_rank0(f"Checkpoint saved to {output_dir}")
+
+
 def save_model(model: HFModel, output_dir: str, processor: Processor) -> None:
     """Save model using accelerate's built-in ZeRO-aware utilities.
 
@@ -116,7 +139,7 @@ def save_model(model: HFModel, output_dir: str, processor: Processor) -> None:
     Handles ZeRO-3 parameter gathering automatically via
     accelerator.get_state_dict().
     """
-    accelerator: Accelerator = model._accelerator  # type: ignore[union-attr]
+    accelerator: Accelerator = model._accelerator
 
     unwrapped_model = accelerator.unwrap_model(model)
     state_dict = accelerator.get_state_dict(model)

--- a/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
+++ b/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
@@ -14,6 +14,7 @@
 
 import gc
 import os
+import copy
 
 import torch
 import torch.nn as nn
@@ -213,10 +214,50 @@ class FSDP2Engine:
 
         return model
 
+    def _save_non_persistent_buffers(self, model: PreTrainedModel) -> dict:
+        """save non-persistent buffers, such as inv_freq"""
+        saved = {}
+        for mod_name, module in model.named_modules():
+            for buf_name in module._non_persistent_buffers_set:
+                fqn = f"{mod_name}.{buf_name}" if mod_name else buf_name
+                buf = getattr(module, buf_name, None)
+                if buf is not None:
+                    saved[fqn] = copy.deepcopy(buf)
+        if self.rank == 0 and saved:
+            logger.info(f"Saved {len(saved)} non-persistent buffers")
+        return saved
+
+    def _restore_non_persistent_buffers(self, model: PreTrainedModel, saved_buffers: dict):
+        """register saved non-persistent buffers to model."""
+        if not saved_buffers:
+            return
+        device = get_current_accelerator()
+        for fqn, buf in saved_buffers.items():
+            buf = buf.to(device)
+            if "." in fqn:
+                parent_fqn, buf_name = fqn.rsplit(".", 1)
+                parent_module = model.get_submodule(parent_fqn)
+            else:
+                buf_name = fqn
+                parent_module = model
+            parent_module.register_buffer(buf_name, buf, persistent=False)
+        if self.rank == 0:
+            logger.info(f"Restored {len(saved_buffers)} non-persistent buffers")
+
     def shard_model(self, model: HFModel) -> HFModel:
+        
         if model.device.type == "meta":
+
+            non_persistent_buffers = self._save_non_persistent_buffers(model)
+
+            if getattr(model.config, "tie_word_embeddings", None):
+                model.tie_weights()
+
             model = self.prepare_model(model)
             model = self.materialize_and_load(model, hf_model_path=model.config.name_or_path, dcp_path=self.dcp_path)
+            
+            self._restore_non_persistent_buffers(model, non_persistent_buffers)
+
         else:
             model = self.prepare_model(model)
         return model

--- a/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
+++ b/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import gc
 import os
-import copy
 
 import torch
 import torch.nn as nn
@@ -49,6 +49,51 @@ def get_transformer_layer_cls(model: HFModel) -> type[nn.Module] | None:
         return type(model.layers[0])
 
     return None
+
+
+def save_checkpoint(model: HFModel, output_dir: str, processor: Processor) -> None:
+    """Save checkpoint during training.
+
+    Automatically detects the format based on how the model was loaded:
+    - If loaded from DCP, saves in DCP format
+    - If loaded from HF, saves in HF format
+
+    Args:
+        model: The model to save
+        output_dir: Output directory
+        processor: Processor to save
+    """
+    import torch.distributed.checkpoint as dcp
+
+    # Auto-detect whether to use DCP based on how the model was loaded
+    use_dcp = getattr(model, "_fsdp2_loaded_from_dcp", False)
+
+    if use_dcp:
+        if DistributedInterface().get_rank() == 0:
+            logger.info(f"Saving checkpoint as DCP format to {output_dir} ...")
+            os.makedirs(output_dir, exist_ok=True)
+
+        checkpoint_dir = os.path.join(output_dir, "checkpoint")
+
+        options = StateDictOptions(full_state_dict=False, cpu_offload=True)
+        local_state_dict = get_model_state_dict(model, options=options)
+        dcp.save(state_dict=local_state_dict, checkpoint_id=checkpoint_dir)
+
+        if DistributedInterface().get_rank() == 0:
+            processor.save_pretrained(output_dir, max_shard_size="4GB")
+            logger.info(f"Checkpoint saved as DCP format to {output_dir}")
+    else:
+        if DistributedInterface().get_rank() == 0:
+            logger.info("Gathering full state dict for checkpoint saving...")
+
+        options = StateDictOptions(full_state_dict=True, cpu_offload=True)
+        state_dict = get_model_state_dict(model, options=options)
+
+        if DistributedInterface().get_rank() == 0:
+            model_to_save = model.module if hasattr(model, "module") else model
+            model_to_save.save_pretrained(output_dir, state_dict=state_dict, max_shard_size="4GB")
+            processor.save_pretrained(output_dir, max_shard_size="4GB")
+            logger.info(f"Checkpoint saved to {output_dir}")
 
 
 def save_model(model: HFModel, output_dir: str, processor: Processor) -> None:
@@ -203,19 +248,17 @@ class FSDP2Engine:
 
         if dcp_path and os.path.exists(dcp_path):
             if self.rank == 0:
-                logger.info(f"DCP path found at {dcp_path}. Using efficient Sharded Loading (DCP Load).")
+                logger.info(f"Loading from DCP checkpoint: {dcp_path}")
             self._load_from_dcp(model, dcp_path)
         else:
             if self.rank == 0:
-                if dcp_path:
-                    logger.warning(f"DCP path {dcp_path} not found.")
-                logger.info("Using HF Meta Loading (Chunk Load).")
+                logger.info(f"Loading from HF checkpoint: {hf_model_path}")
             self._load_weights_from_hf_checkpoint(model, hf_model_path)
 
         return model
 
-    def _save_non_persistent_buffers(self, model: PreTrainedModel) -> dict:
-        """save non-persistent buffers, such as inv_freq"""
+    def _save_non_persistent_buffers(self, model: HFModel) -> dict:
+        """Save non-persistent buffers, such as inv_freq."""
         saved = {}
         for mod_name, module in model.named_modules():
             for buf_name in module._non_persistent_buffers_set:
@@ -227,8 +270,8 @@ class FSDP2Engine:
             logger.info(f"Saved {len(saved)} non-persistent buffers")
         return saved
 
-    def _restore_non_persistent_buffers(self, model: PreTrainedModel, saved_buffers: dict):
-        """register saved non-persistent buffers to model."""
+    def _restore_non_persistent_buffers(self, model: HFModel, saved_buffers: dict):
+        """Register saved non-persistent buffers to model."""
         if not saved_buffers:
             return
         device = get_current_accelerator()
@@ -245,9 +288,7 @@ class FSDP2Engine:
             logger.info(f"Restored {len(saved_buffers)} non-persistent buffers")
 
     def shard_model(self, model: HFModel) -> HFModel:
-        
         if model.device.type == "meta":
-
             non_persistent_buffers = self._save_non_persistent_buffers(model)
 
             if getattr(model.config, "tie_word_embeddings", None):
@@ -255,11 +296,14 @@ class FSDP2Engine:
 
             model = self.prepare_model(model)
             model = self.materialize_and_load(model, hf_model_path=model.config.name_or_path, dcp_path=self.dcp_path)
-            
+
             self._restore_non_persistent_buffers(model, non_persistent_buffers)
 
         else:
             model = self.prepare_model(model)
+
+        # Store whether we loaded from DCP for later use in saving
+        model._fsdp2_loaded_from_dcp = self.dcp_path and os.path.exists(self.dcp_path)
         return model
 
     def _load_from_dcp(self, model: HFModel, dcp_path: str):

--- a/src/llamafactory/v1/plugins/trainer_plugins/distributed/hub.py
+++ b/src/llamafactory/v1/plugins/trainer_plugins/distributed/hub.py
@@ -43,6 +43,13 @@ def save_model_fsdp2(model: HFModel, output_dir: str, processor: Processor) -> N
     return save_model(model, output_dir, processor)
 
 
+@DistributedPlugin("fsdp2").register("save_checkpoint")
+def save_checkpoint_fsdp2(model: HFModel, output_dir: str, processor: Processor) -> None:
+    from .fsdp2 import save_checkpoint
+
+    return save_checkpoint(model, output_dir, processor)
+
+
 @DistributedPlugin("deepspeed").register()
 def shard_model_deepspeed(model: HFModel, dist_config: PluginConfig, **kwargs) -> HFModel:
     from .deepspeed import DeepSpeedEngine
@@ -59,3 +66,10 @@ def save_model_deepspeed(model: HFModel, output_dir: str, processor: Processor) 
     from .deepspeed import save_model
 
     return save_model(model, output_dir, processor)
+
+
+@DistributedPlugin("deepspeed").register("save_checkpoint")
+def save_checkpoint_deepspeed(model: HFModel, output_dir: str, processor: Processor) -> None:
+    from .deepspeed import save_checkpoint
+
+    return save_checkpoint(model, output_dir, processor)


### PR DESCRIPTION
# What does this PR do?

 Add checkpoint saving and fix buffer and tied weight for meta training in full.

## Checkpoint Saving:

- Supports saving checkpoints by step or by epoch.
- When loading from the DCP format, checkpoints will be saved in DCP format; similarly, when loading from the HF format, checkpoints will be saved in HF format.
- The save_total_limit parameter can be configured to retain only the most recent N checkpoints (e.g., keeping only the latest two at any given time).

## fix buffer and tied weight  for meta training in full.

For fixes, I tested three different full training with same seed and parameters.

- init wih meta, hf weight format
- init with default, hf weight format
- init with meta, dcp weight format 

And I trained same model by 10 steps. Both loss and gradienst are same.

<img width="1392" height="450" alt="image" src="https://github.com/user-attachments/assets/4fbb719e-de5e-4a63-99fe-ca94b98fe0b6" />


## TODO

- support resume training by checkpoint 
- add uts 

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
