### PR TITLE
feat: add LightOnOCR-2 integration for LoRA/QLoRA fine-tuning

### DIFF
--- a/LIGHTONOCR-2.md
+++ b/LIGHTONOCR-2.md
@@ -1,0 +1,317 @@
+# LightOnOCR-2 Integration for LLaMA-Factory
+
+## Overview
+
+[LightOnOCR-2-1B](https://huggingface.co/lightonai/LightOnOCR-2-1B) is a compact 1B-parameter
+end-to-end multilingual vision-language model for state-of-the-art OCR. It converts document
+images (PDFs, scans, photos) into clean, naturally ordered text without brittle multi-stage
+OCR pipelines.
+
+- **Paper**: [arXiv:2601.14251](https://arxiv.org/abs/2601.14251)
+- **Blog**: <https://huggingface.co/blog/lightonai/lightonocr-2>
+- **License**: Apache 2.0
+
+### Architecture
+
+| Component              | Detail                                                       |
+|------------------------|--------------------------------------------------------------|
+| Vision Encoder         | Pixtral ViT (from Mistral-Small-3.1), native resolution, patch size 14 |
+| Multimodal Projector   | 2-layer MLP with GELU, spatial merge factor 2 (4x token reduction) |
+| Language Model Decoder | Qwen3 (28 layers, 1024 hidden, 16 heads, 8 KV heads)        |
+| Parameters             | ~1B total                                                    |
+| Max Resolution         | 1540 px longest edge                                         |
+| model_type             | `lighton_ocr` (auto-patched from `mistral3`)                 |
+| Chat Format            | ChatML (`<\|im_start\|>` / `<\|im_end\|>`)                  |
+| Image Token            | `<\|image_pad\|>`                                            |
+
+### Key Difference from GLM-OCR
+
+LightOnOCR-2 performs OCR **without explicit task prompts**. The extraction behavior is
+embedded in the model weights. The user message contains only the image — no
+"Text Recognition:" text is needed. The model natively outputs Markdown with LaTeX math spans.
+
+---
+
+## Available Checkpoints
+
+All checkpoints are registered in LLaMA-Factory with `template=lighton_ocr`:
+
+| Model Name                     | HuggingFace ID                              | Description                                |
+|--------------------------------|---------------------------------------------|--------------------------------------------|
+| `LightOnOCR-2-1B`             | `lightonai/LightOnOCR-2-1B`                | Best OCR model (base + RLVR)              |
+| `LightOnOCR-2-1B-base`        | `lightonai/LightOnOCR-2-1B-base`           | Supervised pretraining baseline            |
+| `LightOnOCR-2-1B-bbox`        | `lightonai/LightOnOCR-2-1B-bbox`           | OCR + image bounding box prediction        |
+| `LightOnOCR-2-1B-bbox-base`   | `lightonai/LightOnOCR-2-1B-bbox-base`      | Bbox variant supervised baseline           |
+| `LightOnOCR-2-1B-bbox-soup`   | `lightonai/LightOnOCR-2-1B-bbox-soup`      | Task-arithmetic merge (OCR + bbox)         |
+| `LightOnOCR-2-1B-ocr-soup`    | `lightonai/LightOnOCR-2-1B-ocr-soup`       | Checkpoint averaged OCR variant            |
+
+**Recommended for fine-tuning**: `LightOnOCR-2-1B-base` (clean supervised checkpoint,
+no RLVR artifacts that could interfere with domain-specific fine-tuning).
+
+---
+
+## Integration Details
+
+### Files Modified
+
+**`src/llamafactory/data/template.py`** — Registered the `lighton_ocr` template:
+
+```python
+register_template(
+    name="lighton_ocr",
+    format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),
+    format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
+    stop_words=["<|im_end|>"],
+    replace_eos=True,
+    mm_plugin=get_mm_plugin(name="pixtral", image_token="<|image_pad|>"),
+)
+```
+
+Design decisions:
+
+- **ChatML format** matches the model's Jinja chat template from `tokenizer_config.json`.
+- **`pixtral` mm_plugin** because the vision encoder is Pixtral-based (from Mistral-Small-3.1).
+  The `PixtralPlugin` correctly handles `image_break_token` (`<|vision_pad|>`) and
+  `image_end_token` (`<|vision_end|>`) from the processor at runtime.
+- **`<|image_pad|>` image token** matches the model's tokenizer configuration.
+- **`replace_eos=True`** so `<|im_end|>` becomes the EOS token (matching the model config
+  where `eos_token_id=151645` = `<|im_end|>`).
+- **No `default_system`** because LightOnOCR-2 is trained without explicit system prompts.
+
+**`src/llamafactory/extras/constants.py`** — Registered all 6 LightOnOCR-2 checkpoints
+with `template="lighton_ocr"` and `multimodal=True`.
+
+**`src/llamafactory/model/model_utils/visual.py`** — Registered `lighton_ocr` composite model
+with correct weight names (different from Mistral3):
+
+```python
+_register_composite_model(
+    model_type="lighton_ocr",
+    projector_key="model.vision_projection",
+    vision_model_keys=["vision_encoder"],
+)
+```
+
+**`src/llamafactory/model/model_utils/lightonocr.py`** — Auto-patcher module that
+transparently fixes LightOnOCR-2 configs at load time (see below).
+
+**`src/llamafactory/model/loader.py`** — Calls the auto-patcher before any
+`AutoConfig` / `AutoProcessor` loading.
+
+### Config Auto-Patching (Important)
+
+LightOnOCR-2 models on HuggingFace ship with `model_type: "mistral3"` in their
+`config.json`.  However, transformers >= 5.1 has a **native** `lighton_ocr` model
+type that uses the correct weight naming (`vision_encoder` / `vision_projection`
+instead of Mistral3's `vision_tower` / `multi_modal_projector`).  Without patching,
+**the vision encoder loads with random weights** and training is useless.
+
+Additionally, the `processor_config.json` stores `patch_size` as a bare integer,
+causing thousands of noisy log messages during training.
+
+**This is handled automatically.**  When LlamaFactory loads any LightOnOCR-2 model,
+the auto-patcher (`model_utils/lightonocr.py`) detects and fixes both issues
+in-place.  The patch is idempotent and only runs when needed.
+
+You can also run the standalone script manually:
+
+```bash
+# Patch a specific model
+python scripts/patch_lightonocr.py lightonai/LightOnOCR-2-1B-base
+
+# Patch all cached LightOnOCR models
+python scripts/patch_lightonocr.py --all
+```
+
+### Files NOT Modified (no changes needed)
+
+- **`src/llamafactory/data/collator.py`**: LightOnOCR-2 does NOT use mRoPE (unlike
+  GLM-OCR / Qwen2-VL), so no 3D position ID handling is needed.
+
+---
+
+## Dataset Preparation
+
+### 1. Convert PAGE-XML / ALTO-XML to ShareGPT Format
+
+Use the provided conversion script:
+
+```bash
+python convert_pagexml_to_lightonocr_sharegpt.py \
+    --input_dir /path/to/your/xml-dataset \
+    --output_dir ./data \
+    --dataset_name my_ocr_dataset \
+    --format auto \
+    --unicode_form NFC
+```
+
+This produces:
+- `data/my_ocr_dataset.json` — ShareGPT-format JSON
+- `data/my_ocr_dataset/` — Cropped image files
+
+The key difference from the GLM-OCR conversion script is the **user prompt format**:
+
+| Model         | User Content                      |
+|---------------|-----------------------------------|
+| GLM-OCR       | `<image>Text Recognition:`        |
+| LightOnOCR-2  | `<image>`                         |
+
+### 2. Register the Dataset
+
+Add to `data/dataset_info.json`:
+
+```json
+{
+  "my_ocr_dataset": {
+    "file_name": "my_ocr_dataset.json",
+    "formatting": "sharegpt",
+    "columns": {
+      "messages": "messages",
+      "images": "images"
+    },
+    "tags": {
+      "role_tag": "role",
+      "content_tag": "content",
+      "user_tag": "user",
+      "assistant_tag": "assistant"
+    }
+  }
+}
+```
+
+### 3. Sample JSON Entry
+
+```json
+{
+  "messages": [
+    {"role": "user", "content": "<image>"},
+    {"role": "assistant", "content": "transcribed text here"}
+  ],
+  "images": ["my_ocr_dataset/abc123def456.png"]
+}
+```
+
+---
+
+## Training
+
+### LoRA SFT (recommended)
+
+Use the provided example config:
+
+```bash
+llamafactory-cli train lightonocr_lora_sft.yaml
+```
+
+Or with a custom config:
+
+```yaml
+### model
+model_name_or_path: lightonai/LightOnOCR-2-1B-base
+trust_remote_code: true
+
+### method
+stage: sft
+do_train: true
+finetuning_type: lora
+lora_rank: 8
+lora_target: all
+
+### dataset
+dataset: my_ocr_dataset
+template: lighton_ocr
+cutoff_len: 4096
+
+### output
+output_dir: saves/lightonocr/my-dataset-lora/sft
+logging_steps: 100
+save_steps: 2000
+plot_loss: true
+overwrite_output_dir: true
+
+### train
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 8
+learning_rate: 1.0e-4
+num_train_epochs: 5
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+bf16: true
+
+### eval
+do_eval: true
+val_size: 0.1
+per_device_eval_batch_size: 4
+eval_strategy: steps
+eval_steps: 2000
+
+### early stopping
+load_best_model_at_end: true
+metric_for_best_model: eval_loss
+greater_is_better: false
+early_stopping_steps: 3  # stop after 3 evals without improvement
+```
+
+### GPU Memory Requirements
+
+| GPU             | Batch Size | Grad Accum | Effective Batch | Quantization |
+|-----------------|------------|------------|-----------------|--------------|
+| RTX 3060 12GB   | 2          | 8          | 16              | 4-bit (QLoRA)|
+| RTX 3090 24GB   | 4          | 4          | 16              | Optional     |
+| A100 40GB       | 8          | 2          | 16              | None needed  |
+
+### Training Tips
+
+- **`cutoff_len: 4096`** — LightOnOCR-2 supports up to 6144 tokens during pretraining.
+  For line-level OCR crops 1024–2048 is enough; for full pages use 4096.
+- **`learning_rate: 1e-4`** — LoRA benefits from a higher learning rate than full fine-tuning
+  because updates are inherently smaller (scaled by `lora_alpha / lora_rank`). The original
+  paper used `6e-5` for full-weight training; for LoRA, `1e-4` to `2e-4` is standard.
+- **`lora_target: all`** — LoRA is applied to all linear modules. The `lighton_ocr` composite
+  model registration ensures the vision encoder is excluded by default when
+  `freeze_vision_tower: true` (the default).
+- **Avoid truncation** for multimodal inputs — image token counts depend on resolution,
+  and truncating can cause token mismatches with the vision encoder.
+
+---
+
+## Comparison with GLM-OCR
+
+| Feature                | GLM-OCR                          | LightOnOCR-2                     |
+|------------------------|----------------------------------|----------------------------------|
+| Template name          | `glm_ocr`                        | `lighton_ocr`                    |
+| model_type             | `glm_ocr`                        | `lighton_ocr` (auto-patched)     |
+| Vision encoder         | GLM4V (Qwen2-VL style)          | Pixtral ViT (Mistral-Small-3.1) |
+| mm_plugin              | `glm4v`                          | `pixtral`                        |
+| Image token            | `<\|image\|>`                    | `<\|image_pad\|>`               |
+| User prompt            | `<image>Text Recognition:`       | `<image>` (image only)           |
+| Position IDs           | 3D mRoPE required                | Standard (no mRoPE)              |
+| Language decoder       | GLM4 / ChatGLM                   | Qwen3                            |
+| Output format          | Plain text                       | Markdown with LaTeX              |
+| Parameters             | ~1.5B                            | ~1B                              |
+| Conversion script      | `convert_pagexml_to_glmocr_sharegpt.py` | `convert_pagexml_to_lightonocr_sharegpt.py` |
+
+---
+
+## Conversion Script Options
+
+```
+usage: convert_pagexml_to_lightonocr_sharegpt.py [-h] --input_dir INPUT_DIR
+    [--output_dir OUTPUT_DIR] [--dataset_name DATASET_NAME]
+    [--format {pagexml,alto,auto}] [--unicode_form {NFC,NFD,NFKC,NFKD}]
+    [--min_text_length N] [--min_crop_size N]
+    [--include_full_pages] [--no_full_pages]
+    [--include_paragraphs] [--no_paragraphs]
+    [--paragraph_min_lines N] [--paragraph_max_lines N]
+    [--line_separator SEP] [--batch_size N]
+    [--image_format {png,jpg,jpeg}] [--symlink_images]
+    [--image_dir DIR] [--verbose] [--max-files N]
+```
+
+The script creates three levels of training samples:
+1. **Line-level**: Individual text lines cropped from polygon coordinates
+2. **Paragraph-level**: Groups of 5–10 consecutive lines merged into one crop
+3. **Full-page**: The entire page image with all transcriptions joined
+
+All samples use `<image>` as the user content (no text prompt).

--- a/lightonocr_lora_sft.yaml
+++ b/lightonocr_lora_sft.yaml
@@ -1,0 +1,62 @@
+### model
+model_name_or_path: lightonai/LightOnOCR-2-1B-base
+trust_remote_code: true
+quantization_bit: 4               # QLoRA: 4-bit base weights (like the old unsloth script)
+quantization_method: bitsandbytes
+
+### method
+stage: sft
+do_train: true
+finetuning_type: lora
+lora_rank: 8
+lora_target: all
+
+### vision / projector — unfreeze for OCR domain adaptation
+freeze_vision_tower: false
+freeze_multi_modal_projector: false
+
+### image processing — cap resolution to save VRAM (old script used 700px)
+image_max_pixels: 490000           # ~700x700 max pixels (like longest_edge=700)
+
+### dataset
+dataset: sam_44_mss
+template: lighton_ocr
+cutoff_len: 4096
+tokenized_path: saves/lightonocr/sam_44_mss-tokenized
+# max_samples: 1000   # use all samples
+preprocessing_num_workers: 4
+dataloader_num_workers: 2
+
+### output
+output_dir: saves/lightonocr/sam_44_mss-lora/sft
+logging_steps: 100
+save_steps: 2000
+plot_loss: true
+overwrite_output_dir: true
+save_only_model: false
+report_to: none  # choices: [none, wandb, tensorboard, swanlab, mlflow]
+
+### train
+# RTX 3060 12GB: small batch + high grad_accum to fit VRAM
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 8   # effective batch = 16
+learning_rate: 1.0e-4
+num_train_epochs: 10
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+bf16: true
+ddp_timeout: 180000000
+resume_from_checkpoint: null
+
+### eval
+do_eval: true
+val_size: 0.1
+per_device_eval_batch_size: 4
+eval_strategy: steps
+eval_steps: 2000
+
+### early stopping
+load_best_model_at_end: true
+metric_for_best_model: eval_loss
+greater_is_better: false
+early_stopping_steps: 3  # stop after 3 evals (= 6000 steps) without eval_loss improvement

--- a/scripts/convert_pagexml_to_glmocr_sharegpt.py
+++ b/scripts/convert_pagexml_to_glmocr_sharegpt.py
@@ -1,0 +1,744 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+PAGE-XML / ALTO-XML to ShareGPT Format Converter for GLM-OCR
+
+Converts PAGE-XML or ALTO-XML OCR datasets to the ShareGPT format expected by
+LLaMA-Factory for training GLM-OCR (https://github.com/zai-org/GLM-OCR) with
+LoRA or full fine-tuning.
+
+Output format (ShareGPT for multimodal SFT):
+{
+  "messages": [
+    {"role": "user", "content": "<image>Text Recognition:"},
+    {"role": "assistant", "content": "transcribed text"}
+  ],
+  "images": ["dataset_name/unique_id.png"]
+}
+
+Image paths are relative to LLaMA-Factory's data/ directory. Place the output
+JSON and image folder in data/ and register in dataset_info.json.
+
+Usage:
+    python convert_pagexml_to_glmocr_sharegpt.py \\
+        --input_dir /mnt/d/datasets/cmmhwr26 \\
+        --output_dir ./data \\
+        --dataset_name cmmhwr26 \\
+        --format auto \\
+        --unicode_form NFC
+"""
+
+import argparse
+import gc
+import hashlib
+import json
+import os
+import random
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import xml.etree.ElementTree as ET
+
+try:
+    from PIL import Image, ImageDraw
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+
+try:
+    import numpy as np
+    from scipy.spatial import ConvexHull
+    SCIPY_AVAILABLE = True
+except ImportError:
+    SCIPY_AVAILABLE = False
+
+try:
+    from tqdm import tqdm
+    TQDM_AVAILABLE = True
+except ImportError:
+    TQDM_AVAILABLE = False
+
+
+# PAGE-XML namespace schemas
+PAGE_NAMESPACES = {
+    "2009-03-16": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2009-03-16",
+    "2010-01-12": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2010-01-12",
+    "2010-03-19": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2010-03-19",
+    "2013-07-15": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15",
+    "2014-08-26": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2014-08-26",
+    "2016-07-15": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2016-07-15",
+    "2017-07-15": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2017-07-15",
+    "2018-07-15": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2018-07-15",
+    "2019-07-15": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15",
+}
+
+# ALTO-XML namespace schemas
+ALTO_NAMESPACES = {
+    "v2": "http://www.loc.gov/standards/alto/ns-v2#",
+    "v3": "http://www.loc.gov/standards/alto/ns-v3#",
+    "v4": "http://www.loc.gov/standards/alto/ns-v4#",
+}
+
+# GLM-OCR predefined prompts (from GLM-OCR-finetuning.md)
+GLM_OCR_PROMPTS = {
+    "text": "Text Recognition:",
+    "table": "Table Recognition:",
+    "formula": "Formula Recognition:",
+}
+
+
+def normalize_unicode(text: str, form: str = "NFC") -> str:
+    """Normalize Unicode text."""
+    import unicodedata
+    if not text:
+        return ""
+    return unicodedata.normalize(form, text.strip())
+
+
+def detect_xml_format(xml_file: Path) -> Tuple[str, str]:
+    """
+    Detect XML format (PAGE-XML or ALTO-XML) and namespace.
+    Returns (format_type, namespace).
+    """
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        namespace = None
+        if root.tag.startswith("{"):
+            namespace = root.tag.split("}")[0][1:]
+        else:
+            xmlns = root.get("{http://www.w3.org/2000/xmlns/}xmlns")
+            if xmlns:
+                namespace = xmlns
+
+        if namespace:
+            for _, alto_ns in ALTO_NAMESPACES.items():
+                if namespace == alto_ns:
+                    return ("alto", alto_ns)
+            for _, alto_ns in ALTO_NAMESPACES.items():
+                if alto_ns in namespace or "alto" in namespace.lower():
+                    return ("alto", ALTO_NAMESPACES["v4"])
+
+        if namespace:
+            for _, page_ns in PAGE_NAMESPACES.items():
+                if namespace == page_ns:
+                    return ("pagexml", page_ns)
+            for _, page_ns in PAGE_NAMESPACES.items():
+                if page_ns in namespace or "page" in namespace.lower():
+                    return ("pagexml", PAGE_NAMESPACES["2019-07-15"])
+
+        root_tag = root.tag.split("}")[-1] if "}" in root.tag else root.tag
+        if root_tag.lower() == "alto":
+            return ("alto", ALTO_NAMESPACES["v4"])
+        if "page" in root_tag.lower():
+            return ("pagexml", PAGE_NAMESPACES["2019-07-15"])
+
+        return ("pagexml", PAGE_NAMESPACES["2019-07-15"])
+    except Exception as e:
+        print(f"Warning: Could not detect format for {xml_file}: {e}")
+        return ("pagexml", PAGE_NAMESPACES["2019-07-15"])
+
+
+def parse_polygon_coords(polygon_str: str, format_type: str = "pagexml") -> List[Tuple[int, int]]:
+    """Parse polygon coordinate string to list of (x, y) tuples."""
+    if not polygon_str:
+        return []
+
+    points = []
+    if format_type == "alto":
+        coords = polygon_str.strip().split()
+        for i in range(0, len(coords) - 1, 2):
+            try:
+                points.append((int(float(coords[i])), int(float(coords[i + 1]))))
+            except (ValueError, IndexError):
+                continue
+    else:
+        for coord in polygon_str.strip().split():
+            try:
+                if "," in coord:
+                    x, y = coord.split(",", 1)
+                    points.append((int(float(x)), int(float(y))))
+            except (ValueError, IndexError):
+                continue
+    return points
+
+
+def extract_textlines_from_pagexml(
+    xml_file: Path, namespace: str
+) -> List[Dict[str, Any]]:
+    """Extract textline polygon coordinates and transcriptions from PAGE-XML."""
+    textlines = []
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        for textline in root.findall(f".//{{{namespace}}}TextLine"):
+            coords_elem = textline.find(f"{{{namespace}}}Coords")
+            if coords_elem is None:
+                continue
+            polygon_str = coords_elem.get("points")
+            if not polygon_str:
+                continue
+            coords = parse_polygon_coords(polygon_str, "pagexml")
+            if len(coords) < 3:
+                continue
+            text_equiv = textline.find(f"{{{namespace}}}TextEquiv")
+            transcription = ""
+            if text_equiv is not None:
+                unicode_elem = text_equiv.find(f"{{{namespace}}}Unicode")
+                if unicode_elem is not None and unicode_elem.text:
+                    transcription = unicode_elem.text.strip()
+            if transcription:
+                textlines.append({"coords": coords, "transcription": transcription})
+    except Exception as e:
+        print(f"Error parsing {xml_file}: {e}")
+    return textlines
+
+
+def extract_textlines_from_alto(xml_file: Path, namespace: str) -> List[Dict[str, Any]]:
+    """Extract textline polygon coordinates and transcriptions from ALTO-XML."""
+    textlines = []
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        for textline in root.findall(f".//{{{namespace}}}TextLine"):
+            coords = []
+            shape_elem = textline.find(f"{{{namespace}}}Shape")
+            if shape_elem is not None:
+                polygon_elem = shape_elem.find(f"{{{namespace}}}Polygon")
+                if polygon_elem is not None and polygon_elem.get("POINTS"):
+                    coords = parse_polygon_coords(polygon_elem.get("POINTS"), "alto")
+            if not coords or len(coords) < 3:
+                try:
+                    hpos = int(textline.get("HPOS", 0))
+                    vpos = int(textline.get("VPOS", 0))
+                    width = int(textline.get("WIDTH", 0))
+                    height = int(textline.get("HEIGHT", 0))
+                    if width > 0 and height > 0:
+                        coords = [
+                            (hpos, vpos),
+                            (hpos + width, vpos),
+                            (hpos + width, vpos + height),
+                            (hpos, vpos + height),
+                        ]
+                except (ValueError, TypeError):
+                    pass
+            transcription_parts = []
+            for s in textline.findall(f"{{{namespace}}}String"):
+                content = s.get("CONTENT", "")
+                if content:
+                    transcription_parts.append(content)
+            transcription = " ".join(transcription_parts).strip()
+            if not transcription and textline.text:
+                transcription = textline.text.strip()
+            if coords and len(coords) >= 3 and transcription:
+                textlines.append({"coords": coords, "transcription": transcription})
+    except Exception as e:
+        print(f"Error parsing {xml_file}: {e}")
+    return textlines
+
+
+def get_image_filename_from_pagexml(xml_file: Path, namespace: str) -> Optional[str]:
+    """Extract referenced image filename from PAGE-XML Page imageFilename attribute."""
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        page = root.find(f".//{{{namespace}}}Page")
+        if page is not None:
+            fn = page.get("imageFilename")
+            if fn and fn.strip():
+                return fn.strip()
+    except Exception:
+        pass
+    return None
+
+
+def get_image_filename_from_alto(xml_file: Path, namespace: str) -> Optional[str]:
+    """Extract referenced image filename from ALTO sourceImageInformation."""
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        desc = root.find(f".//{{{namespace}}}Description")
+        if desc is None:
+            return None
+        sii = desc.find(f"{{{namespace}}}sourceImageInformation")
+        if sii is None:
+            return None
+        fn = sii.find(f"{{{namespace}}}fileName")
+        if fn is not None and fn.text:
+            return fn.text.strip()
+    except Exception:
+        pass
+    return None
+
+
+def find_image_file(
+    xml_file: Path,
+    alto_namespace: Optional[str] = None,
+    page_namespace: Optional[str] = None,
+    image_dir: Optional[Path] = None,
+    input_dir: Optional[Path] = None,
+) -> Optional[Path]:
+    """
+    Find corresponding image file for an XML file.
+    Searches: same dir as XML, then (if image_dir set) image_dir/relative_path.
+    Uses imageFilename from PAGE-XML or ALTO when available (handles merged datasets
+    where one subdataset uses .jpg and another uses .png).
+    """
+    search_dirs: List[Path] = [xml_file.parent]
+    if image_dir is not None and input_dir is not None:
+        try:
+            rel = xml_file.parent.relative_to(input_dir)
+            search_dirs.insert(0, image_dir / rel)
+        except ValueError:
+            search_dirs.insert(0, image_dir)
+
+    def try_filename(fn: str) -> Optional[Path]:
+        """Try exact filename, then base+ext variants."""
+        for base_dir in search_dirs:
+            candidate = base_dir / fn
+            if candidate.exists():
+                return candidate
+            base = Path(fn).stem
+            for ext in [".jpg", ".jpeg", ".png", ".tiff", ".tif", ".JPG", ".JPEG", ".PNG", ".TIFF", ".TIF"]:
+                candidate = base_dir / (base + ext)
+                if candidate.exists():
+                    return candidate
+        return None
+
+    # PAGE-XML: try imageFilename first (handles merged jpg/png datasets)
+    if page_namespace:
+        fn = get_image_filename_from_pagexml(xml_file, page_namespace)
+        if fn:
+            result = try_filename(fn)
+            if result:
+                return result
+
+    # Use stem + ext (not with_suffix) to handle names with dots, e.g. BCUF_Ms._L_2057_027.xml
+    stem = xml_file.stem
+    for base_dir in search_dirs:
+        for ext in [".jpg", ".jpeg", ".png", ".tiff", ".tif", ".JPG", ".JPEG", ".PNG", ".TIFF", ".TIF"]:
+            candidate = base_dir / (stem + ext)
+            if candidate.exists():
+                return candidate
+
+    # ALTO: try sourceImageInformation/fileName
+    if alto_namespace:
+        fn = get_image_filename_from_alto(xml_file, alto_namespace)
+        if fn:
+            result = try_filename(fn)
+            if result:
+                return result
+    return None
+
+
+def crop_image_from_polygon(
+    image: Image.Image,
+    polygon: List[Tuple[int, int]],
+    padding: int = 5,
+) -> Image.Image:
+    """Crop image region using polygon mask (keeps polygon area, white elsewhere)."""
+    if not polygon or len(polygon) < 3:
+        return image
+    xs, ys = [p[0] for p in polygon], [p[1] for p in polygon]
+    x_min = max(0, min(xs) - padding)
+    y_min = max(0, min(ys) - padding)
+    x_max = min(image.width, max(xs) + padding)
+    y_max = min(image.height, max(ys) + padding)
+    adjusted = [(x - x_min, y - y_min) for x, y in polygon]
+    cropped = image.crop((x_min, y_min, x_max, y_max))
+    mask = Image.new("L", cropped.size, 0)
+    ImageDraw.Draw(mask).polygon(adjusted, fill=255)
+    background = Image.new("RGB", cropped.size, (255, 255, 255))
+    return Image.composite(cropped, background, mask)
+
+
+def merge_polygons_to_surrounding(
+    polygons: List[List[Tuple[int, int]]]
+) -> List[Tuple[int, int]]:
+    """Merge polygons into one surrounding polygon (convex hull or bbox)."""
+    all_points = []
+    for p in polygons:
+        if p and len(p) >= 3:
+            all_points.extend(p)
+    if len(all_points) < 3:
+        return []
+    if SCIPY_AVAILABLE:
+        try:
+            arr = np.array(all_points)
+            hull = ConvexHull(arr)
+            return [tuple(arr[v]) for v in hull.vertices]
+        except Exception:
+            pass
+    xs, ys = [p[0] for p in all_points], [p[1] for p in all_points]
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+    return [(x_min, y_min), (x_max, y_min), (x_max, y_max), (x_min, y_max)]
+
+
+def group_lines_into_paragraphs(
+    textlines: List[Dict[str, Any]],
+    min_lines: int = 5,
+    max_lines: int = 10,
+) -> List[List[Dict[str, Any]]]:
+    """Group consecutive lines into paragraphs."""
+    if len(textlines) < min_lines:
+        return []
+    paragraphs = []
+    i = 0
+    while i < len(textlines):
+        sz = random.randint(min_lines, max_lines)
+        group = textlines[i : i + sz]
+        if len(group) >= min_lines:
+            paragraphs.append(group)
+        i += sz
+    return paragraphs
+
+
+def unique_image_id(xml_stem: str, sample_type: str, index: int) -> str:
+    """Generate a unique image filename to avoid collisions."""
+    raw = f"{xml_stem}_{sample_type}_{index}"
+    return hashlib.md5(raw.encode()).hexdigest()[:12] + ".png"
+
+
+def convert_to_sharegpt(
+    input_dir: str,
+    output_dir: str,
+    dataset_name: str,
+    format_type: str = "auto",
+    unicode_form: str = "NFC",
+    prompt: str = "text",
+    min_text_length: int = 1,
+    min_crop_size: int = 32,
+    include_full_pages: bool = True,
+    include_paragraphs: bool = True,
+    paragraph_min_lines: int = 5,
+    paragraph_max_lines: int = 10,
+    line_separator: str = "\n",
+    batch_size: int = 100,
+    image_format: str = "png",
+    symlink_images: bool = False,
+    image_dir: Optional[str] = None,
+    verbose: bool = False,
+    max_files: Optional[int] = None,
+) -> None:
+    """
+    Convert PAGE-XML or ALTO-XML dataset to ShareGPT format for GLM-OCR.
+
+    Memory-efficient: processes files in batches, writes images immediately,
+    keeps only small sample dicts in memory.
+    """
+    image_dir_path = Path(image_dir) if image_dir else None
+
+    if not PIL_AVAILABLE:
+        print("Error: PIL/Pillow is required. pip install Pillow")
+        sys.exit(1)
+
+    input_path = Path(input_dir)
+    output_path = Path(output_dir)
+    images_dir = output_path / dataset_name
+    images_dir.mkdir(parents=True, exist_ok=True)
+
+    xml_files = sorted(
+        list(input_path.rglob("*.xml")) + list(input_path.rglob("*.XML"))
+    )
+    if max_files is not None:
+        xml_files = xml_files[:max_files]
+        print(f"Limiting to first {len(xml_files)} files (--max-files)")
+    if not xml_files:
+        print(f"No XML files found in {input_dir}")
+        return
+
+    prompt_text = GLM_OCR_PROMPTS.get(
+        prompt, prompt if prompt.endswith(":") else prompt + ":"
+    )
+    user_content = f"<image>{prompt_text}"
+
+    samples: List[Dict[str, Any]] = []
+    skipped = 0
+    line_count = paragraph_count = page_count = 0
+
+    def progress(iterable, desc):
+        return tqdm(iterable, desc=desc) if TQDM_AVAILABLE else iterable
+
+    for batch_start in progress(range(0, len(xml_files), batch_size), "Converting"):
+        batch_end = min(batch_start + batch_size, len(xml_files))
+        batch = xml_files[batch_start:batch_end]
+
+        for xml_file in batch:
+            try:
+                fmt, namespace = detect_xml_format(xml_file)
+                alto_ns = namespace if fmt == "alto" else None
+                page_ns = namespace if fmt == "pagexml" else None
+                image_file = find_image_file(
+                    xml_file,
+                    alto_namespace=alto_ns,
+                    page_namespace=page_ns,
+                    image_dir=image_dir_path,
+                    input_dir=input_path,
+                )
+                if not image_file:
+                    skipped += 1
+                    if verbose:
+                        print(f"[SKIP] No image found for: {xml_file}")
+                    continue
+
+                try:
+                    full_image = Image.open(image_file).convert("RGB")
+                except Exception as e:
+                    if verbose:
+                        print(f"[SKIP] Could not load {image_file}: {e}")
+                    skipped += 1
+                    continue
+
+                if fmt == "alto":
+                    textlines = extract_textlines_from_alto(xml_file, namespace)
+                else:
+                    textlines = extract_textlines_from_pagexml(xml_file, namespace)
+
+                if not textlines:
+                    skipped += 1
+                    if verbose:
+                        print(f"[SKIP] No textlines in: {xml_file}")
+                    del full_image
+                    gc.collect()
+                    continue
+
+                page_transcriptions: List[str] = []
+                sample_idx = 0
+
+                # Line-level samples
+                for line_data in textlines:
+                    trans = normalize_unicode(line_data["transcription"], unicode_form)
+                    if len(trans) < min_text_length:
+                        continue
+                    page_transcriptions.append(trans)
+                    try:
+                        cropped = crop_image_from_polygon(
+                            full_image, line_data["coords"], padding=5
+                        )
+                    except Exception:
+                        continue
+                    if cropped.width < min_crop_size or cropped.height < min_crop_size:
+                        continue
+                    img_id = unique_image_id(xml_file.stem, "line", sample_idx)
+                    img_path = images_dir / img_id
+                    cropped.save(img_path, format=image_format.upper())
+                    rel_path = f"{dataset_name}/{img_id}"
+                    samples.append({
+                        "messages": [
+                            {"role": "user", "content": user_content},
+                            {"role": "assistant", "content": trans},
+                        ],
+                        "images": [rel_path],
+                    })
+                    sample_idx += 1
+                    line_count += 1
+                    del cropped
+
+                # Paragraph-level samples
+                if include_paragraphs and len(textlines) >= paragraph_min_lines:
+                    for pg_group in group_lines_into_paragraphs(
+                        textlines, paragraph_min_lines, paragraph_max_lines
+                    ):
+                        trans_parts = []
+                        polys = []
+                        for ld in pg_group:
+                            t = normalize_unicode(ld["transcription"], unicode_form)
+                            if len(t) >= min_text_length:
+                                trans_parts.append(t)
+                                polys.append(ld["coords"])
+                        if len(trans_parts) < paragraph_min_lines:
+                            continue
+                        surrounding = merge_polygons_to_surrounding(polys)
+                        if len(surrounding) < 3:
+                            continue
+                        try:
+                            pg_img = crop_image_from_polygon(
+                                full_image, surrounding, padding=5
+                            )
+                        except Exception:
+                            continue
+                        if pg_img.width < min_crop_size or pg_img.height < min_crop_size:
+                            continue
+                        pg_text = line_separator.join(trans_parts)
+                        if len(pg_text) < min_text_length:
+                            continue
+                        img_id = unique_image_id(xml_file.stem, "para", sample_idx)
+                        img_path = images_dir / img_id
+                        pg_img.save(img_path, format=image_format.upper())
+                        rel_path = f"{dataset_name}/{img_id}"
+                        samples.append({
+                            "messages": [
+                                {"role": "user", "content": user_content},
+                                {"role": "assistant", "content": pg_text},
+                            ],
+                            "images": [rel_path],
+                        })
+                        sample_idx += 1
+                        paragraph_count += 1
+                        del pg_img
+
+                # Full-page samples
+                if include_full_pages and page_transcriptions:
+                    full_text = line_separator.join(page_transcriptions)
+                    full_text = normalize_unicode(full_text, unicode_form)
+                    if len(full_text) >= min_text_length:
+                        img_id = unique_image_id(xml_file.stem, "page", 0)
+                        img_path = images_dir / img_id
+                        if symlink_images and image_file.exists():
+                            if img_path.exists():
+                                img_path.unlink()
+                            img_path.symlink_to(os.path.abspath(image_file))
+                        else:
+                            full_image.save(img_path, format=image_format.upper())
+                        rel_path = f"{dataset_name}/{img_id}"
+                        samples.append({
+                            "messages": [
+                                {"role": "user", "content": user_content},
+                                {"role": "assistant", "content": full_text},
+                            ],
+                            "images": [rel_path],
+                        })
+                        page_count += 1
+
+                del full_image
+                gc.collect()
+
+            except Exception as e:
+                print(f"Error processing {xml_file}: {e}")
+                skipped += 1
+                if verbose:
+                    import traceback
+                    traceback.print_exc()
+                continue
+
+    if not samples:
+        print("No samples created. Check input directory and image paths.")
+        return
+
+    random.shuffle(samples)
+    json_path = output_path / f"{dataset_name}.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(samples, f, ensure_ascii=False, indent=2)
+
+    print(f"\nConversion complete.")
+    print(f"  Samples: {len(samples):,} (line: {line_count}, paragraph: {paragraph_count}, page: {page_count})")
+    print(f"  Skipped files: {skipped}")
+    print(f"  JSON: {json_path}")
+    print(f"  Images: {images_dir}")
+    print(f"\nNext steps:")
+    print(f"  1. Ensure {dataset_name}.json and {dataset_name}/ are in LLaMA-Factory/data/")
+    print(f"  2. Add to data/dataset_info.json:")
+    print(f'     "{dataset_name}": {{')
+    print(f'       "file_name": "{dataset_name}.json",')
+    print(f'       "formatting": "sharegpt",')
+    print(f'       "columns": {{ "messages": "messages", "images": "images" }},')
+    print(f'       "tags": {{ "role_tag": "role", "content_tag": "content", "user_tag": "user", "assistant_tag": "assistant" }}')
+    print(f"     }}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert PAGE-XML/ALTO-XML to ShareGPT format for GLM-OCR",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--input_dir", required=True, help="Input directory with XML + images")
+    parser.add_argument(
+        "--output_dir",
+        default="./data",
+        help="Output directory (default: ./data). JSON and image folder go here.",
+    )
+    parser.add_argument(
+        "--dataset_name",
+        default=None,
+        help="Dataset name (folder + JSON name). Default: derived from input_dir.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["pagexml", "alto", "auto"],
+        default="auto",
+        help="XML format (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--unicode_form",
+        choices=["NFC", "NFD", "NFKC", "NFKD"],
+        default="NFC",
+        help="Unicode normalization (default: NFC)",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="text",
+        help="GLM-OCR prompt: 'text', 'table', 'formula', or custom (e.g. 'Text Recognition:')",
+    )
+    parser.add_argument("--min_text_length", type=int, default=1)
+    parser.add_argument("--min_crop_size", type=int, default=32)
+    parser.add_argument("--include_full_pages", action="store_true", default=True)
+    parser.add_argument("--no_full_pages", action="store_false", dest="include_full_pages")
+    parser.add_argument("--include_paragraphs", action="store_true", default=True)
+    parser.add_argument("--no_paragraphs", action="store_false", dest="include_paragraphs")
+    parser.add_argument("--paragraph_min_lines", type=int, default=5)
+    parser.add_argument("--paragraph_max_lines", type=int, default=10)
+    parser.add_argument("--line_separator", default="\n")
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=100,
+        help="Files per batch for memory efficiency (default: 100)",
+    )
+    parser.add_argument("--image_format", default="png", choices=["png", "jpg", "jpeg"])
+    parser.add_argument(
+        "--symlink_images",
+        action="store_true",
+        help="Symlink full-page images instead of copying (saves space if source is local)",
+    )
+    parser.add_argument(
+        "--image_dir",
+        default=None,
+        help="Alternative directory for images (mirrors input_dir structure). "
+        "Use when images are not co-located with XML files.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print reason for each skipped file.",
+    )
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        default=None,
+        help="Process only first N XML files (for debugging).",
+    )
+    args = parser.parse_args()
+
+    dataset_name = args.dataset_name or Path(args.input_dir).name
+    if not dataset_name:
+        dataset_name = "glm_ocr_dataset"
+
+    convert_to_sharegpt(
+        args.input_dir,
+        args.output_dir,
+        dataset_name,
+        format_type=args.format,
+        unicode_form=args.unicode_form,
+        prompt=args.prompt,
+        min_text_length=args.min_text_length,
+        min_crop_size=args.min_crop_size,
+        include_full_pages=args.include_full_pages,
+        include_paragraphs=args.include_paragraphs,
+        paragraph_min_lines=args.paragraph_min_lines,
+        paragraph_max_lines=args.paragraph_max_lines,
+        line_separator=args.line_separator,
+        batch_size=args.batch_size,
+        image_format=args.image_format,
+        symlink_images=args.symlink_images,
+        image_dir=args.image_dir,
+        verbose=args.verbose,
+        max_files=args.max_files,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_pagexml_to_lightonocr_sharegpt.py
+++ b/scripts/convert_pagexml_to_lightonocr_sharegpt.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+PAGE-XML / ALTO-XML to ShareGPT Format Converter for LightOnOCR-2
+
+Converts PAGE-XML or ALTO-XML OCR datasets to the ShareGPT format expected by
+LlamaFactory for training LightOnOCR-2 (https://huggingface.co/lightonai/LightOnOCR-2-1B)
+with LoRA or full fine-tuning.
+
+LightOnOCR-2 differs from GLM-OCR in that:
+  - The user prompt contains ONLY the image placeholder (no "Text Recognition:" text).
+    The OCR behavior is embedded in the model weights.
+  - The model natively outputs Markdown with LaTeX math spans.
+  - Vision encoder is Pixtral-based (not GLM4V-based).
+
+Output format (ShareGPT for multimodal SFT):
+{
+  "messages": [
+    {"role": "user", "content": "<image>"},
+    {"role": "assistant", "content": "transcribed text"}
+  ],
+  "images": ["dataset_name/unique_id.png"]
+}
+
+Image paths are relative to LlamaFactory's data/ directory. Place the output
+JSON and image folder in data/ and register in dataset_info.json.
+
+Usage:
+    python convert_pagexml_to_lightonocr_sharegpt.py \\
+        --input_dir /mnt/d/datasets/cmmhwr26 \\
+        --output_dir ./data \\
+        --dataset_name cmmhwr26_lightonocr \\
+        --format auto \\
+        --unicode_form NFC
+"""
+
+import argparse
+import gc
+import hashlib
+import json
+import os
+import random
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import xml.etree.ElementTree as ET
+
+try:
+    from PIL import Image, ImageDraw
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+
+try:
+    import numpy as np
+    from scipy.spatial import ConvexHull
+    SCIPY_AVAILABLE = True
+except ImportError:
+    SCIPY_AVAILABLE = False
+
+try:
+    from tqdm import tqdm
+    TQDM_AVAILABLE = True
+except ImportError:
+    TQDM_AVAILABLE = False
+
+
+# PAGE-XML namespace schemas
+PAGE_NAMESPACES = {
+    "2009-03-16": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2009-03-16",
+    "2010-01-12": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2010-01-12",
+    "2010-03-19": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2010-03-19",
+    "2013-07-15": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15",
+    "2014-08-26": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2014-08-26",
+    "2016-07-15": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2016-07-15",
+    "2017-07-15": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2017-07-15",
+    "2018-07-15": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2018-07-15",
+    "2019-07-15": "http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15",
+}
+
+# ALTO-XML namespace schemas
+ALTO_NAMESPACES = {
+    "v2": "http://www.loc.gov/standards/alto/ns-v2#",
+    "v3": "http://www.loc.gov/standards/alto/ns-v3#",
+    "v4": "http://www.loc.gov/standards/alto/ns-v4#",
+}
+
+
+def normalize_unicode(text: str, form: str = "NFC") -> str:
+    """Normalize Unicode text."""
+    import unicodedata
+    if not text:
+        return ""
+    return unicodedata.normalize(form, text.strip())
+
+
+def detect_xml_format(xml_file: Path) -> Tuple[str, str]:
+    """
+    Detect XML format (PAGE-XML or ALTO-XML) and namespace.
+    Returns (format_type, namespace).
+    """
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        namespace = None
+        if root.tag.startswith("{"):
+            namespace = root.tag.split("}")[0][1:]
+        else:
+            xmlns = root.get("{http://www.w3.org/2000/xmlns/}xmlns")
+            if xmlns:
+                namespace = xmlns
+
+        if namespace:
+            for _, alto_ns in ALTO_NAMESPACES.items():
+                if namespace == alto_ns:
+                    return ("alto", alto_ns)
+            for _, alto_ns in ALTO_NAMESPACES.items():
+                if alto_ns in namespace or "alto" in namespace.lower():
+                    return ("alto", ALTO_NAMESPACES["v4"])
+
+        if namespace:
+            for _, page_ns in PAGE_NAMESPACES.items():
+                if namespace == page_ns:
+                    return ("pagexml", page_ns)
+            for _, page_ns in PAGE_NAMESPACES.items():
+                if page_ns in namespace or "page" in namespace.lower():
+                    return ("pagexml", PAGE_NAMESPACES["2019-07-15"])
+
+        root_tag = root.tag.split("}")[-1] if "}" in root.tag else root.tag
+        if root_tag.lower() == "alto":
+            return ("alto", ALTO_NAMESPACES["v4"])
+        if "page" in root_tag.lower():
+            return ("pagexml", PAGE_NAMESPACES["2019-07-15"])
+
+        return ("pagexml", PAGE_NAMESPACES["2019-07-15"])
+    except Exception as e:
+        print(f"Warning: Could not detect format for {xml_file}: {e}")
+        return ("pagexml", PAGE_NAMESPACES["2019-07-15"])
+
+
+def parse_polygon_coords(polygon_str: str, format_type: str = "pagexml") -> List[Tuple[int, int]]:
+    """Parse polygon coordinate string to list of (x, y) tuples."""
+    if not polygon_str:
+        return []
+
+    points = []
+    if format_type == "alto":
+        coords = polygon_str.strip().split()
+        for i in range(0, len(coords) - 1, 2):
+            try:
+                points.append((int(float(coords[i])), int(float(coords[i + 1]))))
+            except (ValueError, IndexError):
+                continue
+    else:
+        for coord in polygon_str.strip().split():
+            try:
+                if "," in coord:
+                    x, y = coord.split(",", 1)
+                    points.append((int(float(x)), int(float(y))))
+            except (ValueError, IndexError):
+                continue
+    return points
+
+
+def extract_textlines_from_pagexml(
+    xml_file: Path, namespace: str
+) -> List[Dict[str, Any]]:
+    """Extract textline polygon coordinates and transcriptions from PAGE-XML."""
+    textlines = []
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        for textline in root.findall(f".//{{{namespace}}}TextLine"):
+            coords_elem = textline.find(f"{{{namespace}}}Coords")
+            if coords_elem is None:
+                continue
+            polygon_str = coords_elem.get("points")
+            if not polygon_str:
+                continue
+            coords = parse_polygon_coords(polygon_str, "pagexml")
+            if len(coords) < 3:
+                continue
+            text_equiv = textline.find(f"{{{namespace}}}TextEquiv")
+            transcription = ""
+            if text_equiv is not None:
+                unicode_elem = text_equiv.find(f"{{{namespace}}}Unicode")
+                if unicode_elem is not None and unicode_elem.text:
+                    transcription = unicode_elem.text.strip()
+            if transcription:
+                textlines.append({"coords": coords, "transcription": transcription})
+    except Exception as e:
+        print(f"Error parsing {xml_file}: {e}")
+    return textlines
+
+
+def extract_textlines_from_alto(xml_file: Path, namespace: str) -> List[Dict[str, Any]]:
+    """Extract textline polygon coordinates and transcriptions from ALTO-XML."""
+    textlines = []
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        for textline in root.findall(f".//{{{namespace}}}TextLine"):
+            coords = []
+            shape_elem = textline.find(f"{{{namespace}}}Shape")
+            if shape_elem is not None:
+                polygon_elem = shape_elem.find(f"{{{namespace}}}Polygon")
+                if polygon_elem is not None and polygon_elem.get("POINTS"):
+                    coords = parse_polygon_coords(polygon_elem.get("POINTS"), "alto")
+            if not coords or len(coords) < 3:
+                try:
+                    hpos = int(textline.get("HPOS", 0))
+                    vpos = int(textline.get("VPOS", 0))
+                    width = int(textline.get("WIDTH", 0))
+                    height = int(textline.get("HEIGHT", 0))
+                    if width > 0 and height > 0:
+                        coords = [
+                            (hpos, vpos),
+                            (hpos + width, vpos),
+                            (hpos + width, vpos + height),
+                            (hpos, vpos + height),
+                        ]
+                except (ValueError, TypeError):
+                    pass
+            transcription_parts = []
+            for s in textline.findall(f"{{{namespace}}}String"):
+                content = s.get("CONTENT", "")
+                if content:
+                    transcription_parts.append(content)
+            transcription = " ".join(transcription_parts).strip()
+            if not transcription and textline.text:
+                transcription = textline.text.strip()
+            if coords and len(coords) >= 3 and transcription:
+                textlines.append({"coords": coords, "transcription": transcription})
+    except Exception as e:
+        print(f"Error parsing {xml_file}: {e}")
+    return textlines
+
+
+def get_image_filename_from_pagexml(xml_file: Path, namespace: str) -> Optional[str]:
+    """Extract referenced image filename from PAGE-XML Page imageFilename attribute."""
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        page = root.find(f".//{{{namespace}}}Page")
+        if page is not None:
+            fn = page.get("imageFilename")
+            if fn and fn.strip():
+                return fn.strip()
+    except Exception:
+        pass
+    return None
+
+
+def get_image_filename_from_alto(xml_file: Path, namespace: str) -> Optional[str]:
+    """Extract referenced image filename from ALTO sourceImageInformation."""
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        desc = root.find(f".//{{{namespace}}}Description")
+        if desc is None:
+            return None
+        sii = desc.find(f"{{{namespace}}}sourceImageInformation")
+        if sii is None:
+            return None
+        fn = sii.find(f"{{{namespace}}}fileName")
+        if fn is not None and fn.text:
+            return fn.text.strip()
+    except Exception:
+        pass
+    return None
+
+
+def find_image_file(
+    xml_file: Path,
+    alto_namespace: Optional[str] = None,
+    page_namespace: Optional[str] = None,
+    image_dir: Optional[Path] = None,
+    input_dir: Optional[Path] = None,
+) -> Optional[Path]:
+    """
+    Find corresponding image file for an XML file.
+    Searches: same dir as XML, then (if image_dir set) image_dir/relative_path.
+    Uses imageFilename from PAGE-XML or ALTO when available (handles merged datasets
+    where one subdataset uses .jpg and another uses .png).
+    """
+    search_dirs: List[Path] = [xml_file.parent]
+    if image_dir is not None and input_dir is not None:
+        try:
+            rel = xml_file.parent.relative_to(input_dir)
+            search_dirs.insert(0, image_dir / rel)
+        except ValueError:
+            search_dirs.insert(0, image_dir)
+
+    def try_filename(fn: str) -> Optional[Path]:
+        """Try exact filename, then base+ext variants."""
+        for base_dir in search_dirs:
+            candidate = base_dir / fn
+            if candidate.exists():
+                return candidate
+            base = Path(fn).stem
+            for ext in [".jpg", ".jpeg", ".png", ".tiff", ".tif", ".JPG", ".JPEG", ".PNG", ".TIFF", ".TIF"]:
+                candidate = base_dir / (base + ext)
+                if candidate.exists():
+                    return candidate
+        return None
+
+    # PAGE-XML: try imageFilename first (handles merged jpg/png datasets)
+    if page_namespace:
+        fn = get_image_filename_from_pagexml(xml_file, page_namespace)
+        if fn:
+            result = try_filename(fn)
+            if result:
+                return result
+
+    # Use stem + ext (not with_suffix) to handle names with dots, e.g. BCUF_Ms._L_2057_027.xml
+    stem = xml_file.stem
+    for base_dir in search_dirs:
+        for ext in [".jpg", ".jpeg", ".png", ".tiff", ".tif", ".JPG", ".JPEG", ".PNG", ".TIFF", ".TIF"]:
+            candidate = base_dir / (stem + ext)
+            if candidate.exists():
+                return candidate
+
+    # ALTO: try sourceImageInformation/fileName
+    if alto_namespace:
+        fn = get_image_filename_from_alto(xml_file, alto_namespace)
+        if fn:
+            result = try_filename(fn)
+            if result:
+                return result
+    return None
+
+
+def crop_image_from_polygon(
+    image: Image.Image,
+    polygon: List[Tuple[int, int]],
+    padding: int = 5,
+) -> Image.Image:
+    """Crop image region using polygon mask (keeps polygon area, white elsewhere)."""
+    if not polygon or len(polygon) < 3:
+        return image
+    xs, ys = [p[0] for p in polygon], [p[1] for p in polygon]
+    x_min = max(0, min(xs) - padding)
+    y_min = max(0, min(ys) - padding)
+    x_max = min(image.width, max(xs) + padding)
+    y_max = min(image.height, max(ys) + padding)
+    adjusted = [(x - x_min, y - y_min) for x, y in polygon]
+    cropped = image.crop((x_min, y_min, x_max, y_max))
+    mask = Image.new("L", cropped.size, 0)
+    ImageDraw.Draw(mask).polygon(adjusted, fill=255)
+    background = Image.new("RGB", cropped.size, (255, 255, 255))
+    return Image.composite(cropped, background, mask)
+
+
+def merge_polygons_to_surrounding(
+    polygons: List[List[Tuple[int, int]]]
+) -> List[Tuple[int, int]]:
+    """Merge polygons into one surrounding polygon (convex hull or bbox)."""
+    all_points = []
+    for p in polygons:
+        if p and len(p) >= 3:
+            all_points.extend(p)
+    if len(all_points) < 3:
+        return []
+    if SCIPY_AVAILABLE:
+        try:
+            arr = np.array(all_points)
+            hull = ConvexHull(arr)
+            return [tuple(arr[v]) for v in hull.vertices]
+        except Exception:
+            pass
+    xs, ys = [p[0] for p in all_points], [p[1] for p in all_points]
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+    return [(x_min, y_min), (x_max, y_min), (x_max, y_max), (x_min, y_max)]
+
+
+def group_lines_into_paragraphs(
+    textlines: List[Dict[str, Any]],
+    min_lines: int = 5,
+    max_lines: int = 10,
+) -> List[List[Dict[str, Any]]]:
+    """Group consecutive lines into paragraphs."""
+    if len(textlines) < min_lines:
+        return []
+    paragraphs = []
+    i = 0
+    while i < len(textlines):
+        sz = random.randint(min_lines, max_lines)
+        group = textlines[i : i + sz]
+        if len(group) >= min_lines:
+            paragraphs.append(group)
+        i += sz
+    return paragraphs
+
+
+def unique_image_id(xml_stem: str, sample_type: str, index: int) -> str:
+    """Generate a unique image filename to avoid collisions."""
+    raw = f"{xml_stem}_{sample_type}_{index}"
+    return hashlib.md5(raw.encode()).hexdigest()[:12] + ".png"
+
+
+def convert_to_sharegpt(
+    input_dir: str,
+    output_dir: str,
+    dataset_name: str,
+    format_type: str = "auto",
+    unicode_form: str = "NFC",
+    min_text_length: int = 1,
+    min_crop_size: int = 32,
+    include_full_pages: bool = True,
+    include_paragraphs: bool = True,
+    paragraph_min_lines: int = 5,
+    paragraph_max_lines: int = 10,
+    line_separator: str = "\n",
+    batch_size: int = 100,
+    image_format: str = "png",
+    symlink_images: bool = False,
+    image_dir: Optional[str] = None,
+    verbose: bool = False,
+    max_files: Optional[int] = None,
+) -> None:
+    """
+    Convert PAGE-XML or ALTO-XML dataset to ShareGPT format for LightOnOCR-2.
+
+    Unlike GLM-OCR, the user message contains only the image placeholder
+    (no "Text Recognition:" prompt) because LightOnOCR-2 is trained to
+    perform OCR from images without explicit task instructions.
+
+    Memory-efficient: processes files in batches, writes images immediately,
+    keeps only small sample dicts in memory.
+    """
+    image_dir_path = Path(image_dir) if image_dir else None
+
+    if not PIL_AVAILABLE:
+        print("Error: PIL/Pillow is required. pip install Pillow")
+        sys.exit(1)
+
+    input_path = Path(input_dir)
+    output_path = Path(output_dir)
+    images_dir = output_path / dataset_name
+    images_dir.mkdir(parents=True, exist_ok=True)
+
+    xml_files = sorted(
+        list(input_path.rglob("*.xml")) + list(input_path.rglob("*.XML"))
+    )
+    if max_files is not None:
+        xml_files = xml_files[:max_files]
+        print(f"Limiting to first {len(xml_files)} files (--max-files)")
+    if not xml_files:
+        print(f"No XML files found in {input_dir}")
+        return
+
+    # LightOnOCR-2: user content is only the image placeholder, no text prompt
+    user_content = "<image>"
+
+    samples: List[Dict[str, Any]] = []
+    skipped = 0
+    line_count = paragraph_count = page_count = 0
+
+    def progress(iterable, desc):
+        return tqdm(iterable, desc=desc) if TQDM_AVAILABLE else iterable
+
+    for batch_start in progress(range(0, len(xml_files), batch_size), "Converting"):
+        batch_end = min(batch_start + batch_size, len(xml_files))
+        batch = xml_files[batch_start:batch_end]
+
+        for xml_file in batch:
+            try:
+                fmt, namespace = detect_xml_format(xml_file)
+                alto_ns = namespace if fmt == "alto" else None
+                page_ns = namespace if fmt == "pagexml" else None
+                image_file = find_image_file(
+                    xml_file,
+                    alto_namespace=alto_ns,
+                    page_namespace=page_ns,
+                    image_dir=image_dir_path,
+                    input_dir=input_path,
+                )
+                if not image_file:
+                    skipped += 1
+                    if verbose:
+                        print(f"[SKIP] No image found for: {xml_file}")
+                    continue
+
+                try:
+                    full_image = Image.open(image_file).convert("RGB")
+                except Exception as e:
+                    if verbose:
+                        print(f"[SKIP] Could not load {image_file}: {e}")
+                    skipped += 1
+                    continue
+
+                if fmt == "alto":
+                    textlines = extract_textlines_from_alto(xml_file, namespace)
+                else:
+                    textlines = extract_textlines_from_pagexml(xml_file, namespace)
+
+                if not textlines:
+                    skipped += 1
+                    if verbose:
+                        print(f"[SKIP] No textlines in: {xml_file}")
+                    del full_image
+                    gc.collect()
+                    continue
+
+                page_transcriptions: List[str] = []
+                sample_idx = 0
+
+                # Line-level samples
+                for line_data in textlines:
+                    trans = normalize_unicode(line_data["transcription"], unicode_form)
+                    if len(trans) < min_text_length:
+                        continue
+                    page_transcriptions.append(trans)
+                    try:
+                        cropped = crop_image_from_polygon(
+                            full_image, line_data["coords"], padding=5
+                        )
+                    except Exception:
+                        continue
+                    if cropped.width < min_crop_size or cropped.height < min_crop_size:
+                        continue
+                    img_id = unique_image_id(xml_file.stem, "line", sample_idx)
+                    img_path = images_dir / img_id
+                    cropped.save(img_path, format=image_format.upper())
+                    rel_path = f"{dataset_name}/{img_id}"
+                    samples.append({
+                        "messages": [
+                            {"role": "user", "content": user_content},
+                            {"role": "assistant", "content": trans},
+                        ],
+                        "images": [rel_path],
+                    })
+                    sample_idx += 1
+                    line_count += 1
+                    del cropped
+
+                # Paragraph-level samples
+                if include_paragraphs and len(textlines) >= paragraph_min_lines:
+                    for pg_group in group_lines_into_paragraphs(
+                        textlines, paragraph_min_lines, paragraph_max_lines
+                    ):
+                        trans_parts = []
+                        polys = []
+                        for ld in pg_group:
+                            t = normalize_unicode(ld["transcription"], unicode_form)
+                            if len(t) >= min_text_length:
+                                trans_parts.append(t)
+                                polys.append(ld["coords"])
+                        if len(trans_parts) < paragraph_min_lines:
+                            continue
+                        surrounding = merge_polygons_to_surrounding(polys)
+                        if len(surrounding) < 3:
+                            continue
+                        try:
+                            pg_img = crop_image_from_polygon(
+                                full_image, surrounding, padding=5
+                            )
+                        except Exception:
+                            continue
+                        if pg_img.width < min_crop_size or pg_img.height < min_crop_size:
+                            continue
+                        pg_text = line_separator.join(trans_parts)
+                        if len(pg_text) < min_text_length:
+                            continue
+                        img_id = unique_image_id(xml_file.stem, "para", sample_idx)
+                        img_path = images_dir / img_id
+                        pg_img.save(img_path, format=image_format.upper())
+                        rel_path = f"{dataset_name}/{img_id}"
+                        samples.append({
+                            "messages": [
+                                {"role": "user", "content": user_content},
+                                {"role": "assistant", "content": pg_text},
+                            ],
+                            "images": [rel_path],
+                        })
+                        sample_idx += 1
+                        paragraph_count += 1
+                        del pg_img
+
+                # Full-page samples
+                if include_full_pages and page_transcriptions:
+                    full_text = line_separator.join(page_transcriptions)
+                    full_text = normalize_unicode(full_text, unicode_form)
+                    if len(full_text) >= min_text_length:
+                        img_id = unique_image_id(xml_file.stem, "page", 0)
+                        img_path = images_dir / img_id
+                        if symlink_images and image_file.exists():
+                            if img_path.exists():
+                                img_path.unlink()
+                            img_path.symlink_to(os.path.abspath(image_file))
+                        else:
+                            full_image.save(img_path, format=image_format.upper())
+                        rel_path = f"{dataset_name}/{img_id}"
+                        samples.append({
+                            "messages": [
+                                {"role": "user", "content": user_content},
+                                {"role": "assistant", "content": full_text},
+                            ],
+                            "images": [rel_path],
+                        })
+                        page_count += 1
+
+                del full_image
+                gc.collect()
+
+            except Exception as e:
+                print(f"Error processing {xml_file}: {e}")
+                skipped += 1
+                if verbose:
+                    import traceback
+                    traceback.print_exc()
+                continue
+
+    if not samples:
+        print("No samples created. Check input directory and image paths.")
+        return
+
+    random.shuffle(samples)
+    json_path = output_path / f"{dataset_name}.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(samples, f, ensure_ascii=False, indent=2)
+
+    print(f"\nConversion complete.")
+    print(f"  Samples: {len(samples):,} (line: {line_count}, paragraph: {paragraph_count}, page: {page_count})")
+    print(f"  Skipped files: {skipped}")
+    print(f"  JSON: {json_path}")
+    print(f"  Images: {images_dir}")
+    print(f"\nNext steps:")
+    print(f"  1. Ensure {dataset_name}.json and {dataset_name}/ are in LlamaFactory/data/")
+    print(f"  2. Add to data/dataset_info.json:")
+    print(f'     "{dataset_name}": {{')
+    print(f'       "file_name": "{dataset_name}.json",')
+    print(f'       "formatting": "sharegpt",')
+    print(f'       "columns": {{ "messages": "messages", "images": "images" }},')
+    print(f'       "tags": {{ "role_tag": "role", "content_tag": "content", "user_tag": "user", "assistant_tag": "assistant" }}')
+    print(f"     }}")
+    print(f"  3. Use template: lighton_ocr")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert PAGE-XML/ALTO-XML to ShareGPT format for LightOnOCR-2",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--input_dir", required=True, help="Input directory with XML + images")
+    parser.add_argument(
+        "--output_dir",
+        default="./data",
+        help="Output directory (default: ./data). JSON and image folder go here.",
+    )
+    parser.add_argument(
+        "--dataset_name",
+        default=None,
+        help="Dataset name (folder + JSON name). Default: derived from input_dir.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["pagexml", "alto", "auto"],
+        default="auto",
+        help="XML format (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--unicode_form",
+        choices=["NFC", "NFD", "NFKC", "NFKD"],
+        default="NFC",
+        help="Unicode normalization (default: NFC)",
+    )
+    parser.add_argument("--min_text_length", type=int, default=1)
+    parser.add_argument("--min_crop_size", type=int, default=32)
+    parser.add_argument("--include_full_pages", action="store_true", default=True)
+    parser.add_argument("--no_full_pages", action="store_false", dest="include_full_pages")
+    parser.add_argument("--include_paragraphs", action="store_true", default=True)
+    parser.add_argument("--no_paragraphs", action="store_false", dest="include_paragraphs")
+    parser.add_argument("--paragraph_min_lines", type=int, default=5)
+    parser.add_argument("--paragraph_max_lines", type=int, default=10)
+    parser.add_argument("--line_separator", default="\n")
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=100,
+        help="Files per batch for memory efficiency (default: 100)",
+    )
+    parser.add_argument("--image_format", default="png", choices=["png", "jpg", "jpeg"])
+    parser.add_argument(
+        "--symlink_images",
+        action="store_true",
+        help="Symlink full-page images instead of copying (saves space if source is local)",
+    )
+    parser.add_argument(
+        "--image_dir",
+        default=None,
+        help="Alternative directory for images (mirrors input_dir structure). "
+        "Use when images are not co-located with XML files.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print reason for each skipped file.",
+    )
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        default=None,
+        help="Process only first N XML files (for debugging).",
+    )
+    args = parser.parse_args()
+
+    dataset_name = args.dataset_name or Path(args.input_dir).name
+    if not dataset_name:
+        dataset_name = "lightonocr_dataset"
+
+    convert_to_sharegpt(
+        args.input_dir,
+        args.output_dir,
+        dataset_name,
+        format_type=args.format,
+        unicode_form=args.unicode_form,
+        min_text_length=args.min_text_length,
+        min_crop_size=args.min_crop_size,
+        include_full_pages=args.include_full_pages,
+        include_paragraphs=args.include_paragraphs,
+        paragraph_min_lines=args.paragraph_min_lines,
+        paragraph_max_lines=args.paragraph_max_lines,
+        line_separator=args.line_separator,
+        batch_size=args.batch_size,
+        image_format=args.image_format,
+        symlink_images=args.symlink_images,
+        image_dir=args.image_dir,
+        verbose=args.verbose,
+        max_files=args.max_files,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/patch_lightonocr.py
+++ b/scripts/patch_lightonocr.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Patch LightOnOCR-2 model configs for compatibility with transformers >= 5.1.
+
+LightOnOCR-2 models on HuggingFace Hub ship with ``model_type: "mistral3"`` in
+their config.json, but transformers >= 5.1 provides a native ``lighton_ocr``
+model type with the correct weight naming.  Without this patch, the vision
+encoder weights fail to load (they appear as MISSING in the load report).
+
+Additionally, the processor_config.json stores ``patch_size`` as a bare integer,
+which causes thousands of INFO-level log messages during training.
+
+Usage
+-----
+    # Patch a specific model (downloads if not cached)
+    python scripts/patch_lightonocr.py lightonai/LightOnOCR-2-1B-base
+
+    # Patch a local model directory
+    python scripts/patch_lightonocr.py /path/to/local/model
+
+    # Patch all cached LightOnOCR-2 models
+    python scripts/patch_lightonocr.py --all
+
+Note: This script is idempotent — running it multiple times is safe.
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+
+def _needs_config_patch(data: dict) -> bool:
+    architectures = data.get("architectures", [])
+    model_type = data.get("model_type", "")
+    has_lightonocr = any("lightonocr" in a.lower() or "light_on_ocr" in a.lower() for a in architectures)
+    return has_lightonocr and model_type == "mistral3"
+
+
+def _needs_processor_patch(data: dict) -> bool:
+    image_processor = data.get("image_processor", {})
+    patch_size = image_processor.get("patch_size")
+    return isinstance(patch_size, int)
+
+
+def patch_config_json(filepath: str) -> bool:
+    with open(filepath, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    if not _needs_config_patch(data):
+        return False
+
+    old_type = data["model_type"]
+    data["model_type"] = "lighton_ocr"
+    data["architectures"] = [
+        "LightOnOcrForConditionalGeneration" if a == "LightOnOCRForConditionalGeneration" else a
+        for a in data.get("architectures", [])
+    ]
+
+    with open(filepath, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+    print(f"  [PATCHED] {filepath}")
+    print(f"           model_type: '{old_type}' -> 'lighton_ocr'")
+    print(f"           architectures: -> 'LightOnOcrForConditionalGeneration'")
+    return True
+
+
+def patch_processor_config_json(filepath: str) -> bool:
+    with open(filepath, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    if not _needs_processor_patch(data):
+        return False
+
+    ps = data["image_processor"]["patch_size"]
+    data["image_processor"]["patch_size"] = {"height": ps, "width": ps}
+
+    with open(filepath, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+    print(f"  [PATCHED] {filepath}")
+    print(f"           patch_size: {ps} -> {{'height': {ps}, 'width': {ps}}}")
+    return True
+
+
+def patch_model(model_path: str) -> int:
+    """Patch a single model directory or HF hub model.  Returns count of patches applied."""
+    patches = 0
+
+    # Resolve path: local dir or HF cache
+    if os.path.isdir(model_path):
+        config_path = os.path.join(model_path, "config.json")
+        processor_path = os.path.join(model_path, "processor_config.json")
+    else:
+        try:
+            from huggingface_hub import hf_hub_download
+
+            config_path = hf_hub_download(model_path, "config.json", local_files_only=True)
+            try:
+                processor_path = hf_hub_download(model_path, "processor_config.json", local_files_only=True)
+            except Exception:
+                processor_path = None
+        except Exception:
+            print(f"  [SKIP] Model '{model_path}' not found in cache. Download it first:")
+            print(f"         huggingface-cli download {model_path}")
+            return 0
+
+    if os.path.isfile(config_path):
+        if patch_config_json(config_path):
+            patches += 1
+        else:
+            print(f"  [OK] {config_path} (already patched or not LightOnOCR)")
+
+    if processor_path and os.path.isfile(processor_path):
+        if patch_processor_config_json(processor_path):
+            patches += 1
+        else:
+            print(f"  [OK] {processor_path} (already patched or no fix needed)")
+
+    return patches
+
+
+def find_all_cached_lightonocr() -> list[str]:
+    """Find all LightOnOCR model snapshot dirs in the HF cache."""
+    cache_dir = os.path.join(os.path.expanduser("~"), ".cache", "huggingface", "hub")
+    pattern = os.path.join(cache_dir, "models--*LightOnOCR*", "snapshots", "*")
+    return sorted(glob.glob(pattern))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Patch LightOnOCR-2 configs for transformers >= 5.1 compatibility",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "model",
+        nargs="?",
+        help="Model name or path (e.g. lightonai/LightOnOCR-2-1B-base or /path/to/model)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Patch all LightOnOCR models found in the HuggingFace cache",
+    )
+    args = parser.parse_args()
+
+    if not args.model and not args.all:
+        parser.print_help()
+        sys.exit(1)
+
+    total_patches = 0
+
+    if args.all:
+        dirs = find_all_cached_lightonocr()
+        if not dirs:
+            print("No cached LightOnOCR models found in ~/.cache/huggingface/hub/")
+            sys.exit(0)
+
+        print(f"Found {len(dirs)} cached LightOnOCR snapshot(s):\n")
+        for d in dirs:
+            print(f"--- {d} ---")
+            total_patches += patch_model(d)
+            print()
+    else:
+        print(f"--- {args.model} ---")
+        total_patches = patch_model(args.model)
+
+    print(f"\nDone. Applied {total_patches} patch(es).")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1309,6 +1309,21 @@ register_template(
 )
 
 
+# LightOnOCR-2 uses ChatML format with Pixtral vision encoder.
+# Architecture: Pixtral ViT + 2-layer MLP projector + Qwen3 decoder.
+# The model performs OCR without explicit task prompts; the extraction
+# behavior is embedded in the weights (user message contains only the image).
+register_template(
+    name="lighton_ocr",
+    format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),
+    format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
+    stop_words=["<|im_end|>"],
+    replace_eos=True,
+    mm_plugin=get_mm_plugin(name="pixtral", image_token="<|image_pad|>"),
+)
+
+
 register_template(
     name="llama2",
     format_user=StringFormatter(slots=[{"bos_token"}, "[INST] {{content}} [/INST]"]),

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -1459,6 +1459,32 @@ register_model_group(
 
 register_model_group(
     models={
+        "LightOnOCR-2-1B": {
+            DownloadSource.DEFAULT: "lightonai/LightOnOCR-2-1B",
+        },
+        "LightOnOCR-2-1B-base": {
+            DownloadSource.DEFAULT: "lightonai/LightOnOCR-2-1B-base",
+        },
+        "LightOnOCR-2-1B-bbox": {
+            DownloadSource.DEFAULT: "lightonai/LightOnOCR-2-1B-bbox",
+        },
+        "LightOnOCR-2-1B-bbox-base": {
+            DownloadSource.DEFAULT: "lightonai/LightOnOCR-2-1B-bbox-base",
+        },
+        "LightOnOCR-2-1B-bbox-soup": {
+            DownloadSource.DEFAULT: "lightonai/LightOnOCR-2-1B-bbox-soup",
+        },
+        "LightOnOCR-2-1B-ocr-soup": {
+            DownloadSource.DEFAULT: "lightonai/LightOnOCR-2-1B-ocr-soup",
+        },
+    },
+    template="lighton_ocr",
+    multimodal=True,
+)
+
+
+register_model_group(
+    models={
         "Llama-7B": {
             DownloadSource.DEFAULT: "huggyllama/llama-7b",
             DownloadSource.MODELSCOPE: "skyline2006/llama-7b",

--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -33,6 +33,7 @@ from ..extras.packages import is_torch_version_greater_than
 from .adapter import init_adapter
 from .model_utils.ktransformers import load_kt_pretrained_model
 from .model_utils.liger_kernel import apply_liger_kernel
+from .model_utils.lightonocr import patch_lightonocr_configs
 from .model_utils.misc import register_autoclass
 from .model_utils.mod import convert_pretrained_model_to_mod, load_mod_pretrained_model
 from .model_utils.unsloth import load_unsloth_pretrained_model
@@ -61,6 +62,15 @@ def _get_init_kwargs(model_args: "ModelArguments") -> dict[str, Any]:
     """
     skip_check_imports()
     model_args.model_name_or_path = try_download_model_from_other_hub(model_args)
+
+    # Auto-patch LightOnOCR-2 configs (model_type + processor patch_size)
+    patch_lightonocr_configs(
+        model_args.model_name_or_path,
+        cache_dir=model_args.cache_dir,
+        token=model_args.hf_hub_token,
+        revision=model_args.model_revision,
+    )
+
     return {
         "trust_remote_code": model_args.trust_remote_code,
         "cache_dir": model_args.cache_dir,

--- a/src/llamafactory/model/model_utils/lightonocr.py
+++ b/src/llamafactory/model/model_utils/lightonocr.py
@@ -1,0 +1,172 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Auto-patcher for LightOnOCR-2 model configs.
+
+LightOnOCR-2 models on HuggingFace Hub ship with ``model_type: "mistral3"`` in
+their ``config.json``, but transformers >= 5.1 has native ``lighton_ocr`` support
+with the correct weight naming (``vision_encoder`` / ``vision_projection`` instead
+of Mistral3's ``vision_tower`` / ``multi_modal_projector``).  Loading without this
+patch causes **all vision weights to be randomly initialized** (MISSING in the
+load report).
+
+Additionally, the ``processor_config.json`` stores ``patch_size`` as a bare
+integer (``14``), which triggers thousands of noisy INFO-level log messages from
+``image_processing_utils.get_size_dict`` on every image processed.
+
+This module provides :func:`patch_lightonocr_configs` which resolves and patches
+both files **in-place on disk** (HuggingFace cache or local directory) so that
+subsequent ``AutoConfig`` / ``AutoProcessor`` calls load the correct classes and
+suppress the log spam.  The function is idempotent — it only writes when a change
+is actually needed.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+from ...extras import logging
+
+
+logger = logging.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Architecture / model_type mapping
+# ---------------------------------------------------------------------------
+_LIGHTONOCR_ARCH_OLD = "LightOnOCRForConditionalGeneration"
+_LIGHTONOCR_ARCH_NEW = "LightOnOcrForConditionalGeneration"
+_MODEL_TYPE_OLD = "mistral3"
+_MODEL_TYPE_NEW = "lighton_ocr"
+
+
+def _resolve_cached_file(model_name_or_path: str, filename: str, **hub_kwargs) -> Optional[str]:
+    """Resolve a file inside a local directory or HuggingFace cache."""
+    local_path = os.path.join(model_name_or_path, filename)
+    if os.path.isfile(local_path):
+        return local_path
+
+    try:
+        from huggingface_hub import hf_hub_download
+
+        return hf_hub_download(
+            repo_id=model_name_or_path,
+            filename=filename,
+            cache_dir=hub_kwargs.get("cache_dir"),
+            token=hub_kwargs.get("token"),
+            revision=hub_kwargs.get("revision"),
+            local_files_only=True,
+        )
+    except Exception:
+        return None
+
+
+def _needs_config_patch(data: dict) -> bool:
+    """Check whether config.json needs the lighton_ocr model_type patch."""
+    architectures = data.get("architectures", [])
+    model_type = data.get("model_type", "")
+    has_lightonocr_arch = any("lightonocr" in a.lower() or "light_on_ocr" in a.lower() for a in architectures)
+    return has_lightonocr_arch and model_type == _MODEL_TYPE_OLD
+
+
+def _needs_processor_patch(data: dict) -> bool:
+    """Check whether processor_config.json needs the patch_size dict patch."""
+    image_processor = data.get("image_processor", {})
+    patch_size = image_processor.get("patch_size")
+    return isinstance(patch_size, int)
+
+
+def _patch_config_json(filepath: str) -> bool:
+    """Patch config.json in-place.  Returns True if a change was made."""
+    with open(filepath, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    if not _needs_config_patch(data):
+        return False
+
+    data["model_type"] = _MODEL_TYPE_NEW
+    data["architectures"] = [
+        _LIGHTONOCR_ARCH_NEW if a == _LIGHTONOCR_ARCH_OLD else a
+        for a in data.get("architectures", [])
+    ]
+
+    with open(filepath, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+    return True
+
+
+def _patch_processor_config_json(filepath: str) -> bool:
+    """Patch processor_config.json in-place.  Returns True if a change was made."""
+    with open(filepath, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    if not _needs_processor_patch(data):
+        return False
+
+    ps = data["image_processor"]["patch_size"]
+    data["image_processor"]["patch_size"] = {"height": ps, "width": ps}
+
+    with open(filepath, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+    return True
+
+
+def patch_lightonocr_configs(model_name_or_path: str, **hub_kwargs) -> None:
+    """Auto-detect and patch LightOnOCR-2 config files if necessary.
+
+    Call this **before** ``AutoConfig.from_pretrained`` /
+    ``AutoProcessor.from_pretrained`` to ensure the correct model class is
+    loaded and the processor doesn't spam INFO logs.
+
+    Parameters
+    ----------
+    model_name_or_path : str
+        Local directory or HuggingFace Hub model id.
+    **hub_kwargs
+        Forwarded to ``hf_hub_download`` (``cache_dir``, ``token``,
+        ``revision``).
+    """
+    config_path = _resolve_cached_file(model_name_or_path, "config.json", **hub_kwargs)
+    if config_path is not None:
+        try:
+            with open(config_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if _needs_config_patch(data):
+                if _patch_config_json(config_path):
+                    logger.info_rank0(
+                        "Patched LightOnOCR-2 config.json: "
+                        f"model_type '{_MODEL_TYPE_OLD}' -> '{_MODEL_TYPE_NEW}', "
+                        f"architecture -> '{_LIGHTONOCR_ARCH_NEW}'"
+                    )
+        except Exception as e:
+            logger.warning_rank0(f"Failed to patch LightOnOCR-2 config.json: {e}")
+
+    processor_path = _resolve_cached_file(model_name_or_path, "processor_config.json", **hub_kwargs)
+    if processor_path is not None:
+        try:
+            with open(processor_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if _needs_processor_patch(data):
+                if _patch_processor_config_json(processor_path):
+                    logger.info_rank0(
+                        "Patched LightOnOCR-2 processor_config.json: "
+                        "patch_size int -> dict"
+                    )
+        except Exception as e:
+            logger.warning_rank0(f"Failed to patch LightOnOCR-2 processor_config.json: {e}")

--- a/src/llamafactory/model/model_utils/visual.py
+++ b/src/llamafactory/model/model_utils/visual.py
@@ -309,6 +309,13 @@ _register_composite_model(
 
 
 _register_composite_model(
+    model_type="lighton_ocr",
+    projector_key="model.vision_projection",
+    vision_model_keys=["vision_encoder"],
+)
+
+
+_register_composite_model(
     model_type="mistral3",
     projector_key="model.multi_modal_projector",
 )


### PR DESCRIPTION
Add full support for fine-tuning LightOnOCR-2 (1B) OCR models in LlamaFactory, including:

- Register "lighton_ocr" chat template (ChatML + Pixtral mm_plugin)
- Register all 6 LightOnOCR-2 checkpoints in constants.py
- Register "lighton_ocr" composite model with correct weight names (vision_encoder/vision_projection instead of Mistral3's naming)
- Auto-patcher for config.json (model_type) and processor_config.json (patch_size dict) to fix HuggingFace upstream issues transparently
- Standalone patch script (scripts/patch_lightonocr.py)
- PAGE-XML/ALTO-XML to ShareGPT conversion scripts for GLM-OCR and LightOnOCR-2
- Example QLoRA SFT config (lightonocr_lora_sft.yaml)
- Comprehensive documentation (LIGHTONOCR-2.md)

# What does this PR do?

Feature #

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
