### PR TITLE
[WIP][V1] fix meta init training for full/freeze/lora

### DIFF
--- a/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
+++ b/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
@@ -14,6 +14,7 @@
 
 import gc
 import os
+import copy
 
 import torch
 import torch.nn as nn
@@ -213,10 +214,49 @@ class FSDP2Engine:
 
         return model
 
+    def _save_non_persistent_buffers(self, model: HFModel) -> dict:
+        """save non-persistent buffers, such as inv_freq"""
+        saved = {}
+        for mod_name, module in model.named_modules():
+            for buf_name in module._non_persistent_buffers_set:
+                fqn = f"{mod_name}.{buf_name}" if mod_name else buf_name
+                buf = getattr(module, buf_name, None)
+                if buf is not None:
+                    saved[fqn] = copy.deepcopy(buf)
+        if self.rank == 0 and saved:
+            logger.info(f"Saved {len(saved)} non-persistent buffers")
+        return saved
+
+    def _restore_non_persistent_buffers(self, model: HFModel, saved_buffers: dict):
+        """register saved non-persistent buffers to model."""
+        if not saved_buffers:
+            return
+        device = get_current_accelerator()
+        for fqn, buf in saved_buffers.items():
+            buf = buf.to(device)
+            if "." in fqn:
+                parent_fqn, buf_name = fqn.rsplit(".", 1)
+                parent_module = model.get_submodule(parent_fqn)
+            else:
+                buf_name = fqn
+                parent_module = model
+            parent_module.register_buffer(buf_name, buf, persistent=False)
+        if self.rank == 0:
+            logger.info(f"Restored {len(saved_buffers)} non-persistent buffers")
+
     def shard_model(self, model: HFModel) -> HFModel:
         if model.device.type == "meta":
+            
+            non_persistent_buffers = self._save_non_persistent_buffers(model)
+
+            if getattr(model.config, "tie_word_embeddings", None):
+                model.tie_weights()
+            
             model = self.prepare_model(model)
             model = self.materialize_and_load(model, hf_model_path=model.config.name_or_path, dcp_path=self.dcp_path)
+
+            self._restore_non_persistent_buffers(model, non_persistent_buffers)
+
         else:
             model = self.prepare_model(model)
         return model


### PR DESCRIPTION
# What does this PR do?


This PR improves the consistency and correctness of **FSDP2 + meta initialization** under different training workflows (full / freeze / LoRA), ensuring deterministic initialization behavior and robust checkpoint loading.

### 1. Fix meta initialization completeness for full / freeze training

For full-parameter and freeze scenarios, we ensure that all necessary steps are properly handled before and after meta materialization:

* Preserve and restore **non-persistent buffers** across meta initialization.
* Correctly handle `tie_word_embeddings` to maintain parameter sharing relationships.
* Guarantee that model state and parameter aliasing remain consistent after materialization.

---

### 2. Adjust LoRA weight restoration order under meta mode

For LoRA training with existing adapters:

* First construct the LoRA module structure based on `PeftConfig`.
* Perform meta materialization.
* Then load the actual adapter weights.

This avoids attempting to copy real weights into meta tensors, which is invalid and leads to silent failures or inconsistencies.

Additionally, we explicitly enforce the following constraint:

> **Meta + LoRA training does not support automatically creating new adapters.**
> `adapter_name_or_path` must be explicitly provided.

---

### 3. Introduce unified PEFT name-mapping mechanism (DCP and non-DCP)

To address parameter name drift introduced by PEFT/LoRA wrapping, this PR introduces a unified alias-based mapping mechanism that works for both standard checkpoints (`.bin` / `.safetensors`) and DCP.

#### Key components:

* **`iter_name_aliases`**
  Parses wrapped PEFT/LoRA parameter names and generates all valid candidate aliases corresponding to their original checkpoint names.

* **`_get_param_map`**
  Builds a relaxed alias → real tensor mapping table, enabling robust loading of standard checkpoint formats.

* **`_build_dcp_load_state_dict`**
  Dynamically renames local `state_dict` keys according to DCP metadata, strictly aligning with distributed checkpoint naming rules to pass DCP validation.

* **`_load_adapter_weights`**
  Safely injects LoRA adapter weights using the alias mapping mechanism, resolving key mismatches caused by PEFT name transformations.

### Tests

for full/lora, I test three different training methods:

- default training + hf
- meta training + hf
- meta training + dcp

And loss and gradnorm could be same if I set the seed by following code:

```
def make_training_deterministic(seed: int = 42):
    import os
    import random
    import numpy as np
    import torch

    os.environ["PYTHONHASHSEED"] = str(seed)
    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"

    random.seed(seed)
    np.random.seed(seed)

    torch.manual_seed(seed)
    torch.cuda.manual_seed(seed)
    torch.cuda.manual_seed_all(seed)

    torch.use_deterministic_algorithms(True)

    torch.backends.cudnn.deterministic = True
    torch.backends.cudnn.benchmark = False

make_training_deterministic(42)
```

<img width="1503" height="459" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/6d2fc715-93a3-45ec-98b4-4208fc10f7d5" />

<img width="1463" height="458" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/44925fee-07e3-4edb-aa35-1e185c41d751" />

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
