### PR TITLE
fix qwen3vl moe fuse on transformers 5.x and update docs about timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,16 @@ pip install .
 
 3. Set `double_quantization: false` in the configuration. You can refer to the [example](examples/train_qlora/qwen3_lora_sft_bnb_npu.yaml).
 
+#### FSDP training note
+
+For `Ascend NPU + transformers 5.x or later + FSDP` training, it is recommended to increase `HCCL_CONNECT_TIMEOUT` manually before launch, for example:
+
+```bash
+export HCCL_CONNECT_TIMEOUT=1800
+```
+
+This is a runtime recommendation and is not modified automatically by LLaMA Factory.
+
 </details>
 
 ### Data Preparation

--- a/README_zh.md
+++ b/README_zh.md
@@ -627,6 +627,16 @@ pip install .
 
 3. 在训练参数中设置 `double_quantization: false`，可参考[示例](examples/train_qlora/qwen3_lora_sft_bnb_npu.yaml)。
 
+#### FSDP 训练提示
+
+对于 `Ascend NPU + transformers 5.x 及以上 + FSDP` 训练，建议在启动前手动增大 `HCCL_CONNECT_TIMEOUT`，例如设置为 `1800`：
+
+```bash
+export HCCL_CONNECT_TIMEOUT=1800
+```
+
+这是一项运行环境建议，不会由 LLaMA Factory 自动修改。
+
 </details>
 
 ### 数据准备

--- a/src/llamafactory/extras/misc.py
+++ b/src/llamafactory/extras/misc.py
@@ -52,19 +52,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.get_logger(__name__)
-_DEFAULT_NPU_HCCL_CONNECT_TIMEOUT = "600"
-
-
-def set_default_hccl_connect_timeout_for_npu() -> None:
-    r"""Set a safer default HCCL connect timeout for NPU runs."""
-    if not is_torch_npu_available() or "HCCL_CONNECT_TIMEOUT" in os.environ:
-        return
-
-    os.environ["HCCL_CONNECT_TIMEOUT"] = _DEFAULT_NPU_HCCL_CONNECT_TIMEOUT
-    logger.info_rank0(f"Set HCCL_CONNECT_TIMEOUT={_DEFAULT_NPU_HCCL_CONNECT_TIMEOUT} by default for NPU.")
-
-
-set_default_hccl_connect_timeout_for_npu()
 
 
 class AverageMeter:

--- a/src/llamafactory/extras/misc.py
+++ b/src/llamafactory/extras/misc.py
@@ -53,6 +53,19 @@ if TYPE_CHECKING:
 
 logger = logging.get_logger(__name__)
 
+_DEFAULT_NPU_HCCL_CONNECT_TIMEOUT = "1800"
+
+
+def set_default_hccl_connect_timeout_for_npu() -> None:
+    r"""Set a safer default HCCL connect timeout for NPU runs."""
+    if not is_torch_npu_available() or "HCCL_CONNECT_TIMEOUT" in os.environ:
+        return
+
+    os.environ["HCCL_CONNECT_TIMEOUT"] = _DEFAULT_NPU_HCCL_CONNECT_TIMEOUT
+    logger.info_rank0(f"Set HCCL_CONNECT_TIMEOUT={_DEFAULT_NPU_HCCL_CONNECT_TIMEOUT} by default for NPU.")
+
+
+set_default_hccl_connect_timeout_for_npu()
 
 class AverageMeter:
     r"""Compute and store the average and current value."""

--- a/src/llamafactory/extras/misc.py
+++ b/src/llamafactory/extras/misc.py
@@ -53,19 +53,6 @@ if TYPE_CHECKING:
 
 logger = logging.get_logger(__name__)
 
-_DEFAULT_NPU_HCCL_CONNECT_TIMEOUT = "1800"
-
-
-def set_default_hccl_connect_timeout_for_npu() -> None:
-    r"""Set a safer default HCCL connect timeout for NPU runs."""
-    if not is_torch_npu_available() or "HCCL_CONNECT_TIMEOUT" in os.environ:
-        return
-
-    os.environ["HCCL_CONNECT_TIMEOUT"] = _DEFAULT_NPU_HCCL_CONNECT_TIMEOUT
-    logger.info_rank0(f"Set HCCL_CONNECT_TIMEOUT={_DEFAULT_NPU_HCCL_CONNECT_TIMEOUT} by default for NPU.")
-
-
-set_default_hccl_connect_timeout_for_npu()
 
 class AverageMeter:
     r"""Compute and store the average and current value."""

--- a/src/llamafactory/extras/misc.py
+++ b/src/llamafactory/extras/misc.py
@@ -52,6 +52,19 @@ if TYPE_CHECKING:
 
 
 logger = logging.get_logger(__name__)
+_DEFAULT_NPU_HCCL_CONNECT_TIMEOUT = "600"
+
+
+def set_default_hccl_connect_timeout_for_npu() -> None:
+    r"""Set a safer default HCCL connect timeout for NPU runs."""
+    if not is_torch_npu_available() or "HCCL_CONNECT_TIMEOUT" in os.environ:
+        return
+
+    os.environ["HCCL_CONNECT_TIMEOUT"] = _DEFAULT_NPU_HCCL_CONNECT_TIMEOUT
+    logger.info_rank0(f"Set HCCL_CONNECT_TIMEOUT={_DEFAULT_NPU_HCCL_CONNECT_TIMEOUT} by default for NPU.")
+
+
+set_default_hccl_connect_timeout_for_npu()
 
 
 class AverageMeter:

--- a/src/llamafactory/v1/plugins/model_plugins/kernels/ops/mlp/npu_fused_moe.py
+++ b/src/llamafactory/v1/plugins/model_plugins/kernels/ops/mlp/npu_fused_moe.py
@@ -282,17 +282,62 @@ class Qwen3NpuMoeFused:
         return next_states, router_logits
 
 
-# moe patch config mapping
-kernel_moe_mapping = {
-    "Qwen3VLMoeForConditionalGeneration": {
-        "Qwen3VLMoeTextExperts": NpuMoeFused.npu_moe_experts_forward,
-        "Qwen3VLMoeTextSparseMoeBlock": NpuMoeFused.npu_moe_sparse_block_forward,
-    }
-}
+class NpuMoeFusedV5:
+    """Container for NPU fused MoE forward functions adapted for transformers >= 5.0.0.
 
-if not is_transformers_version_greater_than("5.0.0"):
-    kernel_moe_mapping["Qwen3MoeForCausalLM"] = {
-        "Qwen3MoeSparseMoeBlock": Qwen3NpuMoeFused.qwen3moe_sparse_moe_block_forward
+    In transformers 5.x, the Qwen3VLMoe model was refactored:
+    - ``Qwen3VLMoeTextExperts`` uses ``self.hidden_dim`` instead of ``self.hidden_size``.
+    - ``Qwen3VLMoeTextSparseMoeBlock`` no longer holds ``hidden_size``, ``top_k``,
+      or ``num_experts`` attributes. These are now on the ``Qwen3VLMoeTextTopKRouter``.
+    - ``self.gate`` changed from ``nn.Linear`` to ``Qwen3VLMoeTextTopKRouter``,
+      which returns a 3-tuple ``(router_logits, router_scores, router_indices)``
+      and internally performs softmax, top-k selection, and normalization.
+    """
+
+    @staticmethod
+    def npu_moe_experts_forward(
+        self, hidden_states: torch.Tensor, routing_weights: torch.Tensor, router_indices: torch.Tensor
+    ) -> torch.Tensor:
+        hidden_states = hidden_states.reshape(-1, self.hidden_dim)
+        permuted_hidden_states, row_ids_map = torch_npu.npu_moe_token_permute(
+            hidden_states, router_indices.to(torch.int32)
+        )
+        tokens_per_expert = torch.histc(router_indices, bins=self.num_experts, min=0, max=self.num_experts)
+        gate_up_w = self.gate_up_proj.transpose(1, 2).contiguous()
+        down_w = self.down_proj.transpose(1, 2).contiguous()
+        intermediate_hidden_states = GmmFunction.apply(permuted_hidden_states, gate_up_w, tokens_per_expert)
+        intermediate_activations = torch_npu.npu_swiglu(intermediate_hidden_states, dim=-1)
+        output = GmmFunction.apply(intermediate_activations, down_w, tokens_per_expert)
+        next_states = torch_npu.npu_moe_token_unpermute(output, row_ids_map, probs=routing_weights)
+        return next_states
+
+    @staticmethod
+    def npu_moe_sparse_block_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states_reshaped = hidden_states.view(-1, hidden_dim)
+        _, routing_weights, selected_experts = self.gate(hidden_states_reshaped)
+        routing_weights = routing_weights.to(hidden_states.dtype)
+        routed_out = self.experts(hidden_states_reshaped, routing_weights, selected_experts)
+        return routed_out.reshape(batch_size, sequence_length, hidden_dim)
+
+
+# moe patch config mapping
+if is_transformers_version_greater_than("5.0.0"):
+    kernel_moe_mapping = {
+        "Qwen3VLMoeForConditionalGeneration": {
+            "Qwen3VLMoeTextExperts": NpuMoeFusedV5.npu_moe_experts_forward,
+            "Qwen3VLMoeTextSparseMoeBlock": NpuMoeFusedV5.npu_moe_sparse_block_forward,
+        }
+    }
+else:
+    kernel_moe_mapping = {
+        "Qwen3VLMoeForConditionalGeneration": {
+            "Qwen3VLMoeTextExperts": NpuMoeFused.npu_moe_experts_forward,
+            "Qwen3VLMoeTextSparseMoeBlock": NpuMoeFused.npu_moe_sparse_block_forward,
+        },
+        "Qwen3MoeForCausalLM": {
+            "Qwen3MoeSparseMoeBlock": Qwen3NpuMoeFused.qwen3moe_sparse_moe_block_forward,
+        },
     }
 
 
@@ -336,8 +381,9 @@ class NpuFusedMoEKernel(BaseKernel):
 
         for module in model.modules():
             class_name = module.__class__.__name__
-            if class_name in target_moe_mapping:
+            if class_name in target_moe_mapping and not getattr(module, "_npu_moe_patched", False):
                 new_forward_func = target_moe_mapping[class_name]
                 module.forward = types.MethodType(new_forward_func, module)
+                module._npu_moe_patched = True
 
         return model


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?

# PR type

- Compatibility Fix

# PR information

## Problem
Under the Ascend NPU + FSDP setup, after upgrading transformers from 4.57.x to 5.x, startup becomes more likely to exhibit rank skew, which can then surface as HCCL timeouts around the first synchronization / coordination point.
hccl_error

This tends to show up earlier on Ascend because the official default HCCL_CONNECT_TIMEOUT is only 120 seconds. According to the Ascend documentation, HCCL_CONNECT_TIMEOUT controls the timeout for socket link establishment / synchronization before collective communication initialization, with a valid range of [120, 7200] and a default value of 120s (plus an additional 20 seconds used for failure notification). Meanwhile, PyTorch documents that torch.distributed.init_process_group(timeout=...) defaults to 10 minutes for NCCL and 30 minutes for others.

The existing NPU fused MoE patch for `Qwen3VLMoe` is no longer compatible with `transformers >= 5.0.0`, because the model internals were refactored.

Ascend doc: https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/850alpha002/maintenref/envvar/envref_07_0077.html
PyTorch distributed doc: https://docs.pytorch.org/docs/stable/distributed.html#torch.distributed.init_process_group

## Cause
The practical regression after upgrading from transformers 4.57.x to 5.x is that non-zero ranks now perform more local work before the first collective communication.

transformers v5 is officially a major refactor, and the loading path was reworked accordingly. Compared with 4.57.x, the 5.x loading flow introduces a more explicit and heavier post-load / finalize stage before the model reaches the first FSDP synchronization point. As a result, non-zero ranks spend longer in local preparation, while rank 0 is more likely to reach the first synchronization point earlier. This increases startup-time rank skew and makes timeout failures easier to surface on Ascend.

`Transformers 5.x` changed the internal structure of `Qwen3VLMoe`. Compared with previous versions, the expert / sparse MoE block layout and router path were refactored, so the previous NPU fused forward patch no longer matches the new implementation.

## Change
1. This PR adds a recommendation for modifying the HCCL timeout duration in the documentation for scenarios where the Transformers version is above 5.0.0 in the NPU environment, which mitigates potential communication timeout issues during FSDP training.

2. Adapt the NPU fused MoE patch for `Qwen3VLMoe` under `transformers >= 5.0.0`  
   This PR adds a dedicated fused patch path for the new `transformers 5.x` structure and applies version-based patch mapping accordingly.
