### PR TITLE
feat: clearer train_result metrics log through calculate_tps function

### DIFF
--- a/src/llamafactory/extras/misc.py
+++ b/src/llamafactory/extras/misc.py
@@ -101,8 +101,10 @@ def check_dependencies() -> None:
     check_version("trl>=0.18.0,<=0.24.0")
 
 
-def calculate_tps(dataset: list[dict[str, Any]], metrics: dict[str, float], stage: Literal["sft", "rm"]) -> float:
-    r"""Calculate effective tokens per second."""
+def calculate_tps(
+    dataset: list[dict[str, Any]], metrics: dict[str, float], stage: Literal["sft", "rm"]
+) -> dict[str, Union[int, float]]:
+    r"""Calculate effective tokens per second and related dataset-level metrics."""
     effective_token_num = 0
     for data in dataset:
         if stage == "sft":
@@ -110,8 +112,21 @@ def calculate_tps(dataset: list[dict[str, Any]], metrics: dict[str, float], stag
         elif stage == "rm":
             effective_token_num += len(data["chosen_input_ids"]) + len(data["rejected_input_ids"])
 
-    result = effective_token_num * metrics["epoch"] / metrics["train_runtime"]
-    return result / dist.get_world_size() if dist.is_initialized() else result
+    train_runtime = metrics["train_runtime"]
+    epoch = metrics["epoch"]
+    world_size = dist.get_world_size() if dist.is_initialized() else 1
+    num_samples = len(dataset)
+
+    effective_tokens_per_sec_all_device = effective_token_num * epoch / train_runtime if train_runtime > 0 else 0.0
+    effective_tokens_per_sec_per_device = effective_tokens_per_sec_all_device / world_size
+    average_effective_tokens_per_sample = effective_token_num / num_samples if num_samples > 0 else 0.0
+
+    return {
+        "effective_tokens_per_sec_per_device": effective_tokens_per_sec_per_device,
+        "effective_tokens_per_sec_all_device": effective_tokens_per_sec_all_device,
+        "num_samples_per_epoch": num_samples,
+        "average_effective_tokens_per_sample": average_effective_tokens_per_sample,
+    }
 
 
 def count_parameters(model: "torch.nn.Module") -> tuple[int, int]:

--- a/src/llamafactory/train/dpo/workflow.py
+++ b/src/llamafactory/train/dpo/workflow.py
@@ -81,9 +81,8 @@ def run_dpo(
         train_result = trainer.train(resume_from_checkpoint=training_args.resume_from_checkpoint)
         trainer.save_model()
         if finetuning_args.include_effective_tokens_per_second:
-            train_result.metrics["effective_tokens_per_sec"] = calculate_tps(
-                dataset_module["train_dataset"], train_result.metrics, stage="rm"
-            )
+            train_dataset = dataset_module["train_dataset"]
+            train_result.metrics.update(calculate_tps(train_dataset, train_result.metrics, stage="rm"))
 
         trainer.log_metrics("train", train_result.metrics)
         trainer.save_metrics("train", train_result.metrics)

--- a/src/llamafactory/train/hyper_parallel/workflow.py
+++ b/src/llamafactory/train/hyper_parallel/workflow.py
@@ -198,9 +198,8 @@ def run_sft(
         train_result = trainer.train(resume_from_checkpoint=training_args.resume_from_checkpoint)
         trainer.save_model()
         if finetuning_args.include_effective_tokens_per_second:
-            train_result.metrics["effective_tokens_per_sec"] = calculate_tps(
-                dataset_module["train_dataset"], train_result.metrics, stage="sft"
-            )
+            train_dataset = dataset_module["train_dataset"]
+            train_result.metrics.update(calculate_tps(train_dataset, train_result.metrics, stage="sft"))
 
         trainer.log_metrics("train", train_result.metrics)
         trainer.save_metrics("train", train_result.metrics)

--- a/src/llamafactory/train/mca/workflow.py
+++ b/src/llamafactory/train/mca/workflow.py
@@ -341,9 +341,8 @@ def run_dpo(
     train_result = trainer.train(training_args.resume_from_checkpoint)
     trainer.save_model()
     if finetuning_args.include_effective_tokens_per_second:
-        train_result.metrics["effective_tokens_per_sec"] = calculate_tps(
-            dataset_module["train_dataset"], train_result.metrics, stage="rm"
-        )
+        train_dataset = dataset_module["train_dataset"]
+        train_result.metrics.update(calculate_tps(train_dataset, train_result.metrics, stage="rm"))
 
     trainer.log_metrics("train", train_result.metrics)
     trainer.save_metrics("train", train_result.metrics)

--- a/src/llamafactory/train/sft/workflow.py
+++ b/src/llamafactory/train/sft/workflow.py
@@ -121,9 +121,8 @@ def run_sft(
         train_result = trainer.train(resume_from_checkpoint=training_args.resume_from_checkpoint)
         trainer.save_model()
         if finetuning_args.include_effective_tokens_per_second:
-            train_result.metrics["effective_tokens_per_sec"] = calculate_tps(
-                dataset_module["train_dataset"], train_result.metrics, stage="sft"
-            )
+            train_dataset = dataset_module["train_dataset"]
+            train_result.metrics.update(calculate_tps(train_dataset, train_result.metrics, stage="sft"))
 
         trainer.log_metrics("train", train_result.metrics)
         trainer.save_metrics("train", train_result.metrics)


### PR DESCRIPTION
# What does this PR do?

Update the `calculate_tps` function to provide clearer `train_result` metrics log when `finetuning_args.include_effective_tokens_per_second` is set:
- Current `effective_tokens_per_sec` metric is actually reporting the effective tokens per second per device (divided by world size). I think it may be clearer to rename it as `effective_tokens_per_sec_per_device` and log an additional metric for `effective_tokens_per_sec_all_device`.
- Meanwhile, I add logging for additional TPS-related `train_result` metrics that are useful in practice, such as `num_samples_per_epoch` and `average_effective_tokens_per_sample` (I usually need these). Since original `calculate_tps` function *already has these metrics calculated*, logging them won't incur additional computation cost but help users better understand the context of runtime performance.
- The calls to `calculate_tps` function in the training workflows have been updated accordingly (to use a dictionary return type for simplicity).

After the update, the `train_results.json` would look like:
```
{
    "average_effective_tokens_per_sample": 2552.2842,
    "effective_tokens_per_sec_per_device": 2288.610098352505,
    "effective_tokens_per_sec_all_device": 18308.88078682004,
    "epoch": 10.0,
    "num_samples_per_epoch": 5000,
    "total_flos": 255516030173184.0,
    "train_loss": 0.3681937620986866,
    "train_runtime": 6970.0716,
    "train_samples_per_second": 7.174,
    "train_steps_per_second": 0.113
}
```

## Before submitting

- [X] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
