### PR TITLE
[ray] fix placement group over-allocation and NCCL hang on GPU-less head node

### DIFF
--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -893,7 +893,7 @@ def get_swanlab_callback(finetuning_args: "FinetuningArguments") -> "TrainerCall
 
 def get_placement_group(num_workers: int) -> tuple["PlacementGroup", dict[str, int]]:
     r"""Get the Ray placement group for distributed training."""
-    bundle = {"CPU": 10}
+    bundle = {}
     device_name = get_device_name().upper()
     if device_name != "CPU":
         bundle[device_name] = 1
@@ -928,7 +928,7 @@ def get_ray_remote_config_for_worker(
             placement_group_bundle_index=bundle_idx,
         ),
         "runtime_env": {"env_vars": env},
-        "num_cpus": 10,
+        "num_cpus": 0,
     }
 
     device_name = get_device_name()
@@ -946,10 +946,12 @@ def get_ray_head_node_ip() -> str:
     return head_ip
 
 
-def sort_placement_group_by_node_ip(placement_group: "PlacementGroup", master_addr: str = None) -> list[int]:
+def sort_placement_group_by_node_ip(
+    placement_group: "PlacementGroup", master_addr: str = None
+) -> tuple[list[int], str]:
     r"""Sort the placement group bundles by their node IP addresses."""
 
-    @ray.remote
+    @ray.remote(num_cpus=0)
     def _get_node_ip():
         return ray.util.get_node_ip_address().strip("[]")
 
@@ -974,5 +976,11 @@ def sort_placement_group_by_node_ip(placement_group: "PlacementGroup", master_ad
         if preferred_indices:
             remaining = [i for i in sorted_bundle_indices if i not in preferred_indices]
             sorted_bundle_indices = preferred_indices + remaining
+        else:
+            rank0_ip = bundle_ips[sorted_bundle_indices[0]]
+            logger.warning(f"No bundle found on master_addr={master_addr}, falling back to rank 0 node IP: {rank0_ip}")
+            master_addr = rank0_ip
+    else:
+        master_addr = bundle_ips[sorted_bundle_indices[0]]
 
-    return sorted_bundle_indices
+    return sorted_bundle_indices, master_addr

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -893,7 +893,7 @@ def get_swanlab_callback(finetuning_args: "FinetuningArguments") -> "TrainerCall
 
 def get_placement_group(num_workers: int) -> tuple["PlacementGroup", dict[str, int]]:
     r"""Get the Ray placement group for distributed training."""
-    bundle = {}
+    bundle = {"CPU": 1}
     device_name = get_device_name().upper()
     if device_name != "CPU":
         bundle[device_name] = 1
@@ -928,7 +928,7 @@ def get_ray_remote_config_for_worker(
             placement_group_bundle_index=bundle_idx,
         ),
         "runtime_env": {"env_vars": env},
-        "num_cpus": 0,
+        "num_cpus": 1,
     }
 
     device_name = get_device_name()

--- a/src/llamafactory/train/tuner.py
+++ b/src/llamafactory/train/tuner.py
@@ -78,9 +78,7 @@ def _training_function(config: dict[str, Any]) -> None:
 
     if finetuning_args.stage == "sft" and finetuning_args.use_hyper_parallel:
         if not is_hyper_parallel_available():
-            raise ImportError(
-                "hyper_parallel is not installed. Please install it with `pip install hyper_parallel`."
-            )
+            raise ImportError("hyper_parallel is not installed. Please install it with `pip install hyper_parallel`.")
         from .hyper_parallel import run_sft as run_sft_hp
 
         run_sft_hp(model_args, data_args, training_args, finetuning_args, generating_args, callbacks)
@@ -293,12 +291,12 @@ def _ray_training_function(ray_args: "RayArguments", config: dict[str, Any]) -> 
             raise ValueError(f"The `master_addr` ({master_addr}) is not in Ray cluster or not alive ")
 
     # create placementgroup for resource management
-    pg, bundle = get_placement_group(total_devices)
+    pg, bundle = get_placement_group(num_workers)
     ray.get(pg.ready())
     logger.info(f"Create placement group with {num_workers} bundles: {bundle}")
 
     # get sorted_bundle_indices
-    sorted_bundle_indices = sort_placement_group_by_node_ip(pg, master_addr)
+    sorted_bundle_indices, master_addr = sort_placement_group_by_node_ip(pg, master_addr)
 
     # get master port
     if master_port is None:


### PR DESCRIPTION
# What does this PR do?

Fixes #10348

## Bug 1: Placement group over-allocates resources
- `get_placement_group()` was called with `total_devices` (all GPUs in the cluster) instead of `num_workers`, causing all GPUs to be reserved even when only a subset was requested.
- CPU per bundle was hardcoded to 10, causing scheduling failures on machines with fewer than 10 CPUs per GPU.

**Fix:**
- Pass `num_workers` instead of `total_devices` to `get_placement_group()`.
- Change CPU per bundle from 10 to 1 for broad compatibility.
- Change worker `num_cpus` from 10 to 1.

## Bug 2: NCCL hang when head node has no GPU
- When the head node has no GPU, `preferred_indices` is empty and `master_addr` points to the head node IP. Rank 0 starts TCPStore on a worker node, but other ranks try to connect to the head node IP, causing NCCL initialization to hang indefinitely.

**Fix:**
- `sort_placement_group_by_node_ip()` now returns `tuple[list[int], str]` (sorted indices + resolved master_addr).
- When `preferred_indices` is empty, fall back to rank 0's node IP as `master_addr` with a warning log.
- When `master_addr` is None, set it to rank 0's node IP.
- Add `num_cpus=0` to the `_get_node_ip` remote task (lightweight IP lookup, no CPU needed).

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
  - These bugs require a multi-node Ray cluster to reproduce; unit tests are not feasible.