### PR TITLE
fix: use json.loads with Path.read_text() instead of json.load with Path

### DIFF
--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -77,7 +77,7 @@ def read_args(args: dict[str, Any] | list[str] | None = None) -> dict[str, Any] 
         return OmegaConf.to_container(OmegaConf.merge(dict_config, override_config))
     elif len(sys.argv) > 1 and sys.argv[1].endswith(".json"):
         override_config = OmegaConf.from_cli(sys.argv[2:])
-        dict_config = OmegaConf.create(json.load(Path(sys.argv[1]).absolute()))
+        dict_config = OmegaConf.create(json.loads(Path(sys.argv[1]).absolute().read_text()))
         return OmegaConf.to_container(OmegaConf.merge(dict_config, override_config))
     else:
         return sys.argv[1:]

--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import os
 import sys
 from pathlib import Path
@@ -77,7 +76,7 @@ def read_args(args: dict[str, Any] | list[str] | None = None) -> dict[str, Any] 
         return OmegaConf.to_container(OmegaConf.merge(dict_config, override_config))
     elif len(sys.argv) > 1 and sys.argv[1].endswith(".json"):
         override_config = OmegaConf.from_cli(sys.argv[2:])
-        dict_config = OmegaConf.create(json.loads(Path(sys.argv[1]).absolute().read_text()))
+        dict_config = OmegaConf.load(Path(sys.argv[1]).absolute())
         return OmegaConf.to_container(OmegaConf.merge(dict_config, override_config))
     else:
         return sys.argv[1:]


### PR DESCRIPTION
## Summary

`json.load()` expects a file-like object, not a `pathlib.Path`. Passing a `Path` directly raises:

```
AttributeError: 'PosixPath' object has no attribute 'read'
```

This happens whenever a `.json` config file is passed as the first CLI argument (e.g. `llamafactory-cli train config.json`).

## Root Cause

In `src/llamafactory/hparams/parser.py`, the JSON branch of `read_args()`:

```python
# Before (broken)
dict_config = OmegaConf.create(json.load(Path(sys.argv[1]).absolute()))
```

The YAML branch correctly uses `OmegaConf.load()` which accepts `Path` objects, but `json.load()` does not.

## Fix

```python
# After (fixed)
dict_config = OmegaConf.create(json.loads(Path(sys.argv[1]).absolute().read_text()))
```

Using `Path.read_text()` reads the file content as a string, and `json.loads()` parses a string - no file object needed.

Fixes #10316