### PR TITLE
[model] add gemma4_text template for text-only SFT/DPO training

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1046,6 +1046,19 @@ register_template(
 )
 
 
+# text-only template for gemma4 (no mm_plugin) — useful for SFT/DPO on text datasets with RTX 2080 Ti
+register_template(
+    name="gemma4_text",
+    format_user=StringFormatter(slots=["<|turn>user\n{{content}}<turn|>\n<|turn>model\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}<turn|>\n"]),
+    format_system=StringFormatter(slots=["<|turn>system\n{{content}}<turn|>\n"]),
+    format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
+    stop_words=["<turn|>"],
+    default_system="You are a helpful assistant.",
+    replace_eos=True,
+)
+
+
 register_template(
     name="glm4",
     format_user=StringFormatter(slots=["<|user|>\n{{content}}<|assistant|>"]),

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1046,21 +1046,23 @@ register_template(
 )
 
 
-# Text-only variant of gemma4 — identical to gemma4 but without mm_plugin.
-# Use this template when fine-tuning on text-only datasets to avoid the
-# "Processor was not found" error caused by the multimodal plugin attempting
-# to load a vision/audio processor that is not present in text-only setups.
+# Text-only variant of gemma4 (no mm_plugin). Use this template when fine-tuning
+# on text-only datasets to avoid "Processor was not found" errors from the
+# multimodal plugin. All reasoning, tool-use, and thought-masking features
+# are preserved; only image/video processing is disabled.
 register_template(
     name="gemma4_text",
     format_user=StringFormatter(slots=["<|turn>user\n{{content}}<turn|>\n<|turn>model\n"]),
     format_assistant=StringFormatter(slots=["{{content}}<turn|>\n"]),
-    format_system=StringFormatter(slots=["<|turn>system\n<|think|>{{content}}<turn|>\n"]),
-    format_observation=StringFormatter(slots=["<|turn>tool\n{{content}}<turn|>\n<|turn>model\n"]),
+    format_system=StringFormatter(slots=["<|turn>system\n<|think|>{{content}}<turn|>\n"]), #  default thought signal contained
+    format_observation=StringFormatter(
+        slots=["<|turn>tool\n{{content}}<turn|>\n<|turn>model\n"]
+    ),
     format_tools=ToolFormatter(tool_format="gemma4"),
     format_function=FunctionFormatter(slots=["<|tool>{{content}}<tool|>"], tool_format="gemma4"),
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
     stop_words=["<turn|>"],
-    default_system="You are a helpful assistant.",
+    default_system="You are a helpful assistant.", # important for thinking
     thought_words=("<|channel>thought\n", "<channel|>"),
     replace_eos=True,
     template_class=ReasoningTemplate,

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1046,16 +1046,24 @@ register_template(
 )
 
 
-# text-only template for gemma4 (no mm_plugin) — useful for SFT/DPO on text datasets with RTX 2080 Ti
+# Text-only variant of gemma4 — identical to gemma4 but without mm_plugin.
+# Use this template when fine-tuning on text-only datasets to avoid the
+# "Processor was not found" error caused by the multimodal plugin attempting
+# to load a vision/audio processor that is not present in text-only setups.
 register_template(
     name="gemma4_text",
     format_user=StringFormatter(slots=["<|turn>user\n{{content}}<turn|>\n<|turn>model\n"]),
     format_assistant=StringFormatter(slots=["{{content}}<turn|>\n"]),
-    format_system=StringFormatter(slots=["<|turn>system\n{{content}}<turn|>\n"]),
+    format_system=StringFormatter(slots=["<|turn>system\n<|think|>{{content}}<turn|>\n"]),
+    format_observation=StringFormatter(slots=["<|turn>tool\n{{content}}<turn|>\n<|turn>model\n"]),
+    format_tools=ToolFormatter(tool_format="gemma4"),
+    format_function=FunctionFormatter(slots=["<|tool>{{content}}<tool|>"], tool_format="gemma4"),
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
     stop_words=["<turn|>"],
     default_system="You are a helpful assistant.",
+    thought_words=("<|channel>thought\n", "<channel|>"),
     replace_eos=True,
+    template_class=ReasoningTemplate,
 )
 
 


### PR DESCRIPTION
## What does this PR do?

Adds `gemma4_text`: a text-only variant of the `gemma4` template that omits `mm_plugin`.

**Problem:** The existing `gemma4` template registers an `mm_plugin` with image/video token configuration. When users run SFT or DPO on text-only datasets, LlamaFactory attempts to instantiate a multimodal processor even though no vision inputs are present, raising:

```
ValueError: Processor was not found for google/gemma-4-E4B-it.
```

**Why a separate template rather than modifying `gemma4`?** Making `mm_plugin` optional inside `gemma4` would require changes to `get_mm_plugin`, the plugin dispatch logic, and potentially the YAML parser — a much larger surface area. A dedicated `gemma4_text` template is the same pattern used elsewhere in LlamaFactory (e.g. separate templates per modality variant) and carries zero risk of breaking the existing multimodal workflow.

**What is preserved:** All reasoning (`ReasoningTemplate`), tool-use (`format_tools`, `format_function`, `format_observation`), and thought-masking (`thought_words`, `<|think|>` in `format_system`) features are identical to `gemma4`. The only difference is the absence of `mm_plugin`.

## Example usage

```yaml
model_name_or_path: google/gemma-4-E4B-it
quantization_bit: 4
template: gemma4_text
stage: sft
finetuning_type: lora
fp16: true
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

**Note on tests:** This template is a strict subset of `gemma4` (identical slots, same `ReasoningTemplate` class) with only `mm_plugin` removed — no new logic is introduced. The `gemma4` template itself was merged without `test_template.py` additions in #10346, as the Gemma 4 tokenizer is a gated model requiring `HF_TOKEN` (tests would be `skipif` in CI). This PR follows the same precedent.

## Testing

Verified on `google/gemma-4-E4B-it` (released 2026-04-02) with 4-bit QLoRA (NF4) on RTX 2080 Ti (11 GB VRAM):

| Stage | Settings | Result |
|-------|----------|--------|
| SFT | lora_rank=16, fp16, batch_size=1, grad_accum=8 | ✅ 3 epochs, ~6 min |
| DPO | lora_rank=16, fp16, pref_loss=sigmoid | ✅ converged |
| Inference | chat with LoRA adapter loaded | ✅ working |

Without this template, all three stages fail with `ValueError: Processor was not found`.