### PR TITLE
fix: add None check for feature_extractor in Gemma4Plugin audio processing

### DIFF
--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -668,7 +668,9 @@ class Gemma4Plugin(BasePlugin):
     ) -> dict[str, Union[list[int], "torch.Tensor"]]:
         image_processor = getattr(processor, "image_processor", None)
         video_processor = getattr(processor, "video_processor", None)
-        feature_extractor = getattr(processor, "feature_extractor", None)
+        feature_extractor = getattr(processor, "feature_extractor", None) or getattr(
+            processor, "audio_processor", None
+        )
         mm_inputs = {}
 
         if len(images) != 0:
@@ -744,6 +746,9 @@ class Gemma4Plugin(BasePlugin):
         image_token: str = getattr(processor, "image_token")
         video_token: str = getattr(processor, "video_token")
         audio_token: str = getattr(processor, "audio_token")
+        feature_extractor = getattr(processor, "feature_extractor", None) or getattr(
+            processor, "audio_processor", None
+        )
 
         if self.expand_mm_tokens:
             mm_inputs = self._get_mm_inputs(images, videos, audios, processor)
@@ -786,7 +791,6 @@ class Gemma4Plugin(BasePlugin):
                 # The Gemma4 processor may be loaded without `feature_extractor`
                 # (text-only checkpoints, partial offline loads); guard before
                 # reading `.sampling_rate` to prevent an AttributeError crash.
-                feature_extractor = getattr(processor, "feature_extractor", None)
                 if self.expand_mm_tokens and feature_extractor is not None:
                     num_audio_tokens = processor._compute_audio_num_tokens(
                         current_audio, feature_extractor.sampling_rate

--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -783,9 +783,13 @@ class Gemma4Plugin(BasePlugin):
 
             while AUDIO_PLACEHOLDER in content:
                 current_audio = next(audio_iter)
-                if self.expand_mm_tokens:
+                # The Gemma4 processor may be loaded without `feature_extractor`
+                # (text-only checkpoints, partial offline loads); guard before
+                # reading `.sampling_rate` to prevent an AttributeError crash.
+                feature_extractor = getattr(processor, "feature_extractor", None)
+                if self.expand_mm_tokens and feature_extractor is not None:
                     num_audio_tokens = processor._compute_audio_num_tokens(
-                        current_audio, processor.feature_extractor.sampling_rate
+                        current_audio, feature_extractor.sampling_rate
                     )
                     audio_str = f"{boa_token}{audio_token * num_audio_tokens}{eoa_token}"
                 else:

--- a/tests/data/test_mm_plugin.py
+++ b/tests/data/test_mm_plugin.py
@@ -243,6 +243,46 @@ def test_gemma4_plugin():
     _check_plugin(**check_inputs)
 
 
+def test_gemma4_plugin_uses_audio_processor_fallback(monkeypatch):
+    class AudioProcessor:
+        sampling_rate = 16000
+
+        def __call__(self, audios, **kwargs):
+            return {}
+
+    class Processor:
+        image_token = "<|image|>"
+        video_token = "<|video|>"
+        audio_token = "<|audio|>"
+        boi_token = "<start_of_image>"
+        eoi_token = "<end_of_image>"
+        boa_token = "<start_of_audio>"
+        eoa_token = "<end_of_audio>"
+        audio_processor = AudioProcessor()
+
+        @staticmethod
+        def _compute_audio_num_tokens(audio, sampling_rate):
+            assert sampling_rate == 16000
+            return 2
+
+    gemma4_plugin = get_mm_plugin(name="gemma4", audio_token="<|audio|>")
+    monkeypatch.setattr(
+        gemma4_plugin,
+        "_regularize_audios",
+        lambda audios, **kwargs: {"audios": audios},
+    )
+    messages = [{"role": "user", "content": "<audio>"}]
+
+    processed = gemma4_plugin.process_messages(messages, NO_IMAGES, NO_VIDEOS, AUDIOS, Processor())
+
+    assert processed == [
+        {
+            "role": "user",
+            "content": "<start_of_audio><|audio|><|audio|><end_of_audio>",
+        }
+    ]
+
+
 @pytest.mark.runs_on(["cpu", "mps"])
 @pytest.mark.skipif(not is_transformers_version_greater_than("4.52.0"), reason="Requires transformers>=4.52.0")
 def test_internvl_plugin():


### PR DESCRIPTION
## Summary
- Fix potential `AttributeError` in `Gemma4Plugin.process_messages()` when `processor.feature_extractor` is None
- Use the same safe `getattr(processor, "feature_extractor", None)` pattern already used in `_get_mm_inputs()` at line 657

## Problem
Line 763 accesses `processor.feature_extractor.sampling_rate` directly without a None check. If the processor doesn't have a `feature_extractor` attribute, this crashes with `AttributeError: 'NoneType' object has no attribute 'sampling_rate'`.

## Fix
```python
# Before (unsafe)
if self.expand_mm_tokens:
    num_audio_tokens = processor._compute_audio_num_tokens(current_audio, processor.feature_extractor.sampling_rate)

# After (safe, consistent with line 657)
feature_extractor = getattr(processor, "feature_extractor", None)
if self.expand_mm_tokens and feature_extractor is not None:
    num_audio_tokens = processor._compute_audio_num_tokens(current_audio, feature_extractor.sampling_rate)
```

## Test plan
- [x] Verified fix is consistent with existing safe access pattern at line 657
- [x] No other direct `processor.feature_extractor.` accesses in codebase