### PR TITLE
fix: bump transformers upper bound to <=5.6.0 for Gemma4 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "torch>=2.4.0",
     "torchvision>=0.19.0",
     "torchaudio>=2.4.0",
-    "transformers>=4.55.0,<=5.2.0,!=4.52.0,!=4.57.0",
+    "transformers>=4.55.0,<=5.6.0,!=4.52.0,!=4.57.0",
     "datasets>=2.16.0,<=4.0.0",
     "accelerate>=1.3.0,<=1.11.0",
     "peft>=0.18.0,<=0.18.1",

--- a/src/llamafactory/extras/misc.py
+++ b/src/llamafactory/extras/misc.py
@@ -94,7 +94,7 @@ def check_version(requirement: str, mandatory: bool = False) -> None:
 
 def check_dependencies() -> None:
     r"""Check the version of the required packages."""
-    check_version("transformers>=4.55.0,<=5.2.0")
+    check_version("transformers>=4.55.0,<=5.6.0")
     check_version("datasets>=2.16.0,<=4.0.0")
     check_version("accelerate>=1.3.0,<=1.11.0")
     check_version("peft>=0.18.0,<=0.18.1")


### PR DESCRIPTION
## Problem

Fixes #10389.

`transformers==5.5.0` is required to use Gemma4, but the current upper bound `<=5.2.0` rejects it with:

```
ImportError: transformers>=4.55.0,<=5.2.0 is required for a normal functioning of this module,
but found transformers==5.5.0.
To fix: run `pip install transformers>=4.55.0,<=5.2.0` or set `DISABLE_VERSION_CHECK=1` to skip this check.
```

The latest stable transformers release as of 2026-04-13 is **v5.5.4**.

## Fix

- `pyproject.toml`: `<=5.2.0` → `<=5.6.0`
- `src/llamafactory/extras/misc.py` (runtime check): `<=5.2.0` → `<=5.6.0`

The bound is set to `5.6.0` to accommodate the current `5.5.x` patch series and give headroom for the upcoming `5.6.x` minor.

## Testing

No code-path changes. The version check now accepts `transformers>=5.3.0,<=5.5.x`.