### PR TITLE
fix: materialize FSDP2 model on CPU when CPU offloading is enabled

### DIFF
--- a/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
+++ b/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
@@ -195,7 +195,10 @@ class FSDP2Engine:
         if self.rank == 0:
             logger.info("Materializing sharded model params...")
 
-        device = get_current_accelerator()
+        # When CPU offloading is enabled, FSDP2 requires parameters to be materialized on CPU.
+        # Materializing on the accelerator device causes a RuntimeError because FSDP2's
+        # CPUOffloadPolicy expects parameters to reside on CPU before sharding begins.
+        device = "cpu" if self.offload_params else get_current_accelerator()
         model.to_empty(device=device)
 
         if dcp_path and os.path.exists(dcp_path):


### PR DESCRIPTION
Fixes #10318

## Problem

When using FSDP2 with `fsdp_offload_params: true` and `fsdp_cpu_ram_efficient_loading: true`, training fails with:

```
RuntimeError: FSDP parameters should be materialized on CPU when enabling CPU offloading.
Found following parameters on non-CPU device:
  [('model.embed_tokens.weight', device(type='npu', index=6)),
   ('model.norm.weight', device(type='npu', index=6)),
   ('lm_head.weight', device(type='npu', index=6))]
```

In `materialize_and_load`, the model is always materialized on the accelerator device (GPU/NPU) regardless of the offload policy. However, FSDP2's `CPUOffloadPolicy` requires parameters to be on CPU when sharding begins — parameters placed on GPU/NPU before or during sharding violate this constraint.

## Solution

Use `device="cpu"` for `model.to_empty()` when `self.offload_params` is `True`. This ensures the local parameter shards are allocated on CPU, satisfying FSDP2's requirement. When offloading is disabled, the original accelerator device is used as before.

## Testing

- No existing behavior is changed when `offload_params=False`.
- When `offload_params=True`, parameters are now correctly materialized on CPU before `_load_weights_from_hf_checkpoint` copies weights into the DTensor local shards (which also reside on CPU under CPUOffloadPolicy).