### PR TITLE
fix(data): SeedToolUtils.tool_extractor returns content when no tool calls found

### DIFF
--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -758,7 +758,7 @@ class SeedToolUtils(ToolUtils):
 
             results.append(FunctionCall(func_name.strip(), json.dumps(args_dict, ensure_ascii=False)))
 
-        return results
+        return results if results else content
 
 
 class LingToolUtils(QwenToolUtils):


### PR DESCRIPTION
## Summary

`SeedToolUtils.tool_extractor` was returning an empty list `[]` instead of the original `content` string when no `<seed:tool_call>` tags were found in the model output.

## Root Cause

The method ended with a bare `return results`, so when no regex matches were found, the empty list was returned. Every other `ToolUtils` subclass guards correctly:

```python
# e.g. Qwen35ToolUtils, LFM2ToolUtils
return results if results else content
```

## Impact

Callers that check `isinstance(result, str)` to detect a plain-text response would incorrectly treat the response as an empty function-call list, silently discarding the actual model output.

## Fix

Changed line 761 in `src/llamafactory/data/tool_utils.py`:

```diff
-        return results
+        return results if results else content
```

Closes #10407

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>