### PR TITLE
avoid the EOFError issue when run chat with a sample prompt at a jupyter notebook

### DIFF
--- a/examples/train_lora/qwen3_lora_sft.yaml
+++ b/examples/train_lora/qwen3_lora_sft.yaml
@@ -10,7 +10,7 @@ lora_rank: 8
 lora_target: all
 
 ### dataset
-dataset: identity,alpaca_en_demo
+dataset: identity
 template: qwen3_nothink
 cutoff_len: 2048
 max_samples: 1000

--- a/src/llamafactory/chat/chat_model.py
+++ b/src/llamafactory/chat/chat_model.py
@@ -184,6 +184,8 @@ def run_chat() -> None:
     while True:
         try:
             query = input("\nUser: ")
+        except EOFError:
+            break
         except UnicodeDecodeError:
             print("Detected decoding error at the inputs, please set the terminal encoding to utf-8.")
             continue

--- a/src/llamafactory/chat/chat_model.py
+++ b/src/llamafactory/chat/chat_model.py
@@ -184,7 +184,7 @@ def run_chat() -> None:
     while True:
         try:
             query = input("\nUser: ")
-        except EOFError:
+        except (EOFError, KeyboardInterrupt):
             break
         except UnicodeDecodeError:
             print("Detected decoding error at the inputs, please set the terminal encoding to utf-8.")


### PR DESCRIPTION
# What does this PR do?
we plan to use "llamafactory-cli chat with a sample prompt" inside a jupyter notebook for workshop , like the command: !echo "上海有什么好吃的？" | llamafactory-cli chat examples/inference/qwen3_lora_sft.yaml. 
 But "chat" is designed for interactive usage, we see the error "EOFError: EOF when reading a line" 

this PR is used to avoid the error at this case.

Fixes # (issue)
Add the codes of "except EOFError:" to break the loop instead of crashing.

## Before submitting

- [ *] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ *] Did you write any new necessary tests?
