### PR TITLE
fix: add ignore_mismatched_sizes option to model loader

### DIFF
--- a/src/llamafactory/hparams/model_args.py
+++ b/src/llamafactory/hparams/model_args.py
@@ -201,6 +201,16 @@ class BaseModelArguments:
         default=False,
         metadata={"help": "Whether to trust the execution of code from datasets/models defined on the Hub or not."},
     )
+    ignore_mismatched_sizes: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to ignore mismatched tensor shapes when loading model weights. "
+                "Useful for models with GQA or other architectural variants where checkpoint "
+                "shapes legitimately differ (e.g. GLM-OCR, GQA models)."
+            )
+        },
+    )
 
     def __post_init__(self):
         if self.model_name_or_path is None:

--- a/src/llamafactory/hparams/model_args.py
+++ b/src/llamafactory/hparams/model_args.py
@@ -207,7 +207,7 @@ class BaseModelArguments:
             "help": (
                 "Whether to ignore mismatched tensor shapes when loading model weights. "
                 "Useful for models with GQA or other architectural variants where checkpoint "
-                "shapes legitimately differ (e.g. GLM-OCR, GQA models)."
+                "shapes legitimately differ (e.g. GLM-OCR)."
             )
         },
     )

--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -159,6 +159,8 @@ def load_model(
         init_kwargs["config"] = config
         init_kwargs["pretrained_model_name_or_path"] = model_args.model_name_or_path
         init_kwargs["torch_dtype"] = "auto"
+        if model_args.ignore_mismatched_sizes:
+            init_kwargs["ignore_mismatched_sizes"] = True
 
         if model_args.mixture_of_depths == "load":
             model = load_mod_pretrained_model(**init_kwargs)


### PR DESCRIPTION
Fixes #10416

## Problem

When loading certain models (e.g. GLM-OCR / GLM4V variants with GQA), `from_pretrained` fails with a `RuntimeError: size mismatch` even though the checkpoint is valid. This happens because LLaMA-Factory does not pass `ignore_mismatched_sizes` to the model loader, causing transformers (>=5.0 with strict shape checking) to reject otherwise-loadable weights.

## Solution

Add an `ignore_mismatched_sizes` boolean argument to `BaseModelArguments` (defaults to `False` to preserve existing behaviour). When set to `True`, the flag is forwarded to `AutoModel*.from_pretrained`, allowing transformers to skip shape-mismatch errors.

Users opt in via their YAML config or CLI flag:
```yaml
ignore_mismatched_sizes: true
```

This mirrors the existing pattern already used in `quantization.py` for MXFP4/FP8 quantized models.

## Testing

- Verified that the new field is picked up by the dataclass argument parser.
- Existing load path is unchanged when `ignore_mismatched_sizes` is `False` (default).