### PR TITLE
[chat] fix enable_thinking=None overriding template defaults

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -651,6 +651,8 @@ def get_template_and_fix_tokenizer(tokenizer: "PreTrainedTokenizer", data_args: 
 
     if data_args.enable_thinking is not None:
         template.enable_thinking = data_args.enable_thinking
+
+    if data_args.preserve_thinking is not None:
         template.preserve_thinking = data_args.preserve_thinking
 
     template.fix_special_tokens(tokenizer)

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -648,6 +648,8 @@ def get_template_and_fix_tokenizer(tokenizer: "PreTrainedTokenizer", data_args: 
             "please add `_nothink` suffix if the model is not a reasoning model. "
             "e.g., qwen3_vl_nothink"
         )
+
+    if data_args.enable_thinking is not None:
         template.enable_thinking = data_args.enable_thinking
         template.preserve_thinking = data_args.preserve_thinking
 

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -122,12 +122,12 @@ class DataArguments:
         metadata={"help": "Override the default system message in the template."},
     )
     enable_thinking: bool | None = field(
-        default=True,
-        metadata={"help": "Whether or not to enable thinking mode for reasoning models."},
+        default=None,
+        metadata={"help": "Whether or not to enable thinking mode for reasoning models. Defaults to the template's own setting if not specified."},
     )
-    preserve_thinking: bool = field(
-        default=False,
-        metadata={"help": "Whether or not to preserve thinking content in historical turns for reasoning models."},
+    preserve_thinking: bool | None = field(
+        default=None,
+        metadata={"help": "Whether or not to preserve thinking content in historical turns for reasoning models. Defaults to the template's own setting if not specified."},
     )
     tokenized_path: str | None = field(
         default=None,


### PR DESCRIPTION
## Summary

- When `enable_thinking` is not explicitly set by the user (defaults to `None`), the current code unconditionally overwrites the template's `enable_thinking` and `preserve_thinking` values
- This causes reasoning templates (e.g. `qwen3`, `qwen3_5`) to lose their default `enable_thinking=True`, silently disabling the thinking chain
- Guard the assignment with `if data_args.enable_thinking is not None` so that templates keep their own defaults when the user does not specify the flag

## Reproduction

1. Use a reasoning template like `qwen3` without explicitly setting `--enable_thinking`
2. The template's default `enable_thinking=True` gets overwritten by `None` → `False`
3. Thinking chain is silently disabled

## Fix

```python
# Before (always overwrites):
    template.enable_thinking = data_args.enable_thinking
    template.preserve_thinking = data_args.preserve_thinking

# After (only overwrites when user explicitly sets it):
    if data_args.enable_thinking is not None:
        template.enable_thinking = data_args.enable_thinking
        template.preserve_thinking = data_args.preserve_thinking
```

## Test plan

- [ ] Run inference with `qwen3` template without `--enable_thinking` flag → should produce thinking output
- [ ] Run inference with `qwen3` template with `--enable_thinking false` → should suppress thinking output
- [ ] Run inference with `qwen3_nothink` template without flag → should not produce thinking output