### PR TITLE
[chat] add thinking token injection for reasoning models in all engines

### DIFF
--- a/src/llamafactory/chat/hf_engine.py
+++ b/src/llamafactory/chat/hf_engine.py
@@ -23,7 +23,6 @@ from transformers import GenerationConfig, TextIteratorStreamer
 from typing_extensions import override
 
 from ..data import get_template_and_fix_tokenizer
-from ..data.template import ReasoningTemplate
 from ..extras import logging
 from ..extras.constants import AUDIO_PLACEHOLDER, IMAGE_PLACEHOLDER, VIDEO_PLACEHOLDER, EngineName
 from ..model import load_model, load_tokenizer
@@ -106,18 +105,7 @@ class HuggingfaceEngine(BaseEngine):
         )
         paired_messages = messages + [{"role": "assistant", "content": ""}]
         prompt_ids, _ = template.encode_oneturn(tokenizer, paired_messages, system, tools)
-        if (
-            template.enable_thinking is False
-            and not isinstance(template, ReasoningTemplate)
-            and template.thought_words is not None
-        ):
-            prompt_ids += tokenizer.encode(
-                template.thought_words[0] + template.thought_words[1], add_special_tokens=False
-            )
-        elif template.enable_thinking is True and isinstance(template, ReasoningTemplate):
-            prompt_ids += tokenizer.encode(
-                template.thought_words[0], add_special_tokens=False
-            )
+        prompt_ids = template.inject_thinking_tokens(prompt_ids, tokenizer)
         prompt_ids, _ = template.mm_plugin.process_token_ids(
             prompt_ids,
             None,

--- a/src/llamafactory/chat/hf_engine.py
+++ b/src/llamafactory/chat/hf_engine.py
@@ -23,6 +23,7 @@ from transformers import GenerationConfig, TextIteratorStreamer
 from typing_extensions import override
 
 from ..data import get_template_and_fix_tokenizer
+from ..data.template import ReasoningTemplate
 from ..extras import logging
 from ..extras.constants import AUDIO_PLACEHOLDER, IMAGE_PLACEHOLDER, VIDEO_PLACEHOLDER, EngineName
 from ..model import load_model, load_tokenizer
@@ -105,6 +106,18 @@ class HuggingfaceEngine(BaseEngine):
         )
         paired_messages = messages + [{"role": "assistant", "content": ""}]
         prompt_ids, _ = template.encode_oneturn(tokenizer, paired_messages, system, tools)
+        if (
+            template.enable_thinking is False
+            and not isinstance(template, ReasoningTemplate)
+            and template.thought_words is not None
+        ):
+            prompt_ids += tokenizer.encode(
+                template.thought_words[0] + template.thought_words[1], add_special_tokens=False
+            )
+        elif template.enable_thinking is True and isinstance(template, ReasoningTemplate):
+            prompt_ids += tokenizer.encode(
+                template.thought_words[0], add_special_tokens=False
+            )
         prompt_ids, _ = template.mm_plugin.process_token_ids(
             prompt_ids,
             None,

--- a/src/llamafactory/chat/kt_engine.py
+++ b/src/llamafactory/chat/kt_engine.py
@@ -23,6 +23,7 @@ import torch
 from typing_extensions import override
 
 from ..data import get_template_and_fix_tokenizer
+from ..data.template import ReasoningTemplate
 from ..extras import logging
 from ..extras.constants import EngineName
 from ..model import load_model, load_tokenizer
@@ -114,6 +115,18 @@ class KTransformersEngine(BaseEngine):
     ) -> AsyncGenerator[str, None]:
         paired = messages + [{"role": "assistant", "content": ""}]
         prompt_ids, _ = self.template.encode_oneturn(self.tokenizer, paired, system, tools)
+        if (
+            self.template.enable_thinking is False
+            and not isinstance(self.template, ReasoningTemplate)
+            and self.template.thought_words is not None
+        ):
+            prompt_ids += self.tokenizer.encode(
+                self.template.thought_words[0] + self.template.thought_words[1], add_special_tokens=False
+            )
+        elif self.template.enable_thinking is True and isinstance(self.template, ReasoningTemplate):
+            prompt_ids += self.tokenizer.encode(
+                self.template.thought_words[0], add_special_tokens=False
+            )
         prompt_len = len(prompt_ids)
 
         max_length: Optional[int] = input_kwargs.pop("max_length", None)

--- a/src/llamafactory/chat/kt_engine.py
+++ b/src/llamafactory/chat/kt_engine.py
@@ -23,7 +23,6 @@ import torch
 from typing_extensions import override
 
 from ..data import get_template_and_fix_tokenizer
-from ..data.template import ReasoningTemplate
 from ..extras import logging
 from ..extras.constants import EngineName
 from ..model import load_model, load_tokenizer
@@ -115,18 +114,8 @@ class KTransformersEngine(BaseEngine):
     ) -> AsyncGenerator[str, None]:
         paired = messages + [{"role": "assistant", "content": ""}]
         prompt_ids, _ = self.template.encode_oneturn(self.tokenizer, paired, system, tools)
-        if (
-            self.template.enable_thinking is False
-            and not isinstance(self.template, ReasoningTemplate)
-            and self.template.thought_words is not None
-        ):
-            prompt_ids += self.tokenizer.encode(
-                self.template.thought_words[0] + self.template.thought_words[1], add_special_tokens=False
-            )
-        elif self.template.enable_thinking is True and isinstance(self.template, ReasoningTemplate):
-            prompt_ids += self.tokenizer.encode(
-                self.template.thought_words[0], add_special_tokens=False
-            )
+        if not self.force_think:
+            prompt_ids = self.template.inject_thinking_tokens(prompt_ids, self.tokenizer)
         prompt_len = len(prompt_ids)
 
         max_length: Optional[int] = input_kwargs.pop("max_length", None)

--- a/src/llamafactory/chat/sglang_engine.py
+++ b/src/llamafactory/chat/sglang_engine.py
@@ -22,6 +22,7 @@ import requests
 from typing_extensions import override
 
 from ..data import get_template_and_fix_tokenizer
+from ..data.template import ReasoningTemplate
 from ..extras import logging
 from ..extras.constants import AUDIO_PLACEHOLDER, IMAGE_PLACEHOLDER, VIDEO_PLACEHOLDER, EngineName
 from ..extras.misc import get_device_count, torch_gc
@@ -161,6 +162,18 @@ class SGLangEngine(BaseEngine):
         )
         paired_messages = messages + [{"role": "assistant", "content": ""}]
         prompt_ids, _ = self.template.encode_oneturn(self.tokenizer, paired_messages, system, tools)
+        if (
+            self.template.enable_thinking is False
+            and not isinstance(self.template, ReasoningTemplate)
+            and self.template.thought_words is not None
+        ):
+            prompt_ids += self.tokenizer.encode(
+                self.template.thought_words[0] + self.template.thought_words[1], add_special_tokens=False
+            )
+        elif self.template.enable_thinking is True and isinstance(self.template, ReasoningTemplate):
+            prompt_ids += self.tokenizer.encode(
+                self.template.thought_words[0], add_special_tokens=False
+            )
         prompt_length = len(prompt_ids)
 
         temperature: Optional[float] = input_kwargs.pop("temperature", None)

--- a/src/llamafactory/chat/sglang_engine.py
+++ b/src/llamafactory/chat/sglang_engine.py
@@ -22,7 +22,6 @@ import requests
 from typing_extensions import override
 
 from ..data import get_template_and_fix_tokenizer
-from ..data.template import ReasoningTemplate
 from ..extras import logging
 from ..extras.constants import AUDIO_PLACEHOLDER, IMAGE_PLACEHOLDER, VIDEO_PLACEHOLDER, EngineName
 from ..extras.misc import get_device_count, torch_gc
@@ -162,18 +161,7 @@ class SGLangEngine(BaseEngine):
         )
         paired_messages = messages + [{"role": "assistant", "content": ""}]
         prompt_ids, _ = self.template.encode_oneturn(self.tokenizer, paired_messages, system, tools)
-        if (
-            self.template.enable_thinking is False
-            and not isinstance(self.template, ReasoningTemplate)
-            and self.template.thought_words is not None
-        ):
-            prompt_ids += self.tokenizer.encode(
-                self.template.thought_words[0] + self.template.thought_words[1], add_special_tokens=False
-            )
-        elif self.template.enable_thinking is True and isinstance(self.template, ReasoningTemplate):
-            prompt_ids += self.tokenizer.encode(
-                self.template.thought_words[0], add_special_tokens=False
-            )
+        prompt_ids = self.template.inject_thinking_tokens(prompt_ids, self.tokenizer)
         prompt_length = len(prompt_ids)
 
         temperature: Optional[float] = input_kwargs.pop("temperature", None)

--- a/src/llamafactory/chat/vllm_engine.py
+++ b/src/llamafactory/chat/vllm_engine.py
@@ -20,6 +20,7 @@ from packaging import version
 from typing_extensions import override
 
 from ..data import get_template_and_fix_tokenizer
+from ..data.template import ReasoningTemplate
 from ..extras import logging
 from ..extras.constants import AUDIO_PLACEHOLDER, IMAGE_PLACEHOLDER, VIDEO_PLACEHOLDER, EngineName
 from ..extras.misc import get_device_count
@@ -133,6 +134,18 @@ class VllmEngine(BaseEngine):
         )
         paired_messages = messages + [{"role": "assistant", "content": ""}]
         prompt_ids, _ = self.template.encode_oneturn(self.tokenizer, paired_messages, system, tools)
+        if (
+            self.template.enable_thinking is False
+            and not isinstance(self.template, ReasoningTemplate)
+            and self.template.thought_words is not None
+        ):
+            prompt_ids += self.tokenizer.encode(
+                self.template.thought_words[0] + self.template.thought_words[1], add_special_tokens=False
+            )
+        elif self.template.enable_thinking is True and isinstance(self.template, ReasoningTemplate):
+            prompt_ids += self.tokenizer.encode(
+                self.template.thought_words[0], add_special_tokens=False
+            )
         prompt_length = len(prompt_ids)
 
         temperature: Optional[float] = input_kwargs.pop("temperature", None)

--- a/src/llamafactory/chat/vllm_engine.py
+++ b/src/llamafactory/chat/vllm_engine.py
@@ -20,7 +20,6 @@ from packaging import version
 from typing_extensions import override
 
 from ..data import get_template_and_fix_tokenizer
-from ..data.template import ReasoningTemplate
 from ..extras import logging
 from ..extras.constants import AUDIO_PLACEHOLDER, IMAGE_PLACEHOLDER, VIDEO_PLACEHOLDER, EngineName
 from ..extras.misc import get_device_count
@@ -134,18 +133,7 @@ class VllmEngine(BaseEngine):
         )
         paired_messages = messages + [{"role": "assistant", "content": ""}]
         prompt_ids, _ = self.template.encode_oneturn(self.tokenizer, paired_messages, system, tools)
-        if (
-            self.template.enable_thinking is False
-            and not isinstance(self.template, ReasoningTemplate)
-            and self.template.thought_words is not None
-        ):
-            prompt_ids += self.tokenizer.encode(
-                self.template.thought_words[0] + self.template.thought_words[1], add_special_tokens=False
-            )
-        elif self.template.enable_thinking is True and isinstance(self.template, ReasoningTemplate):
-            prompt_ids += self.tokenizer.encode(
-                self.template.thought_words[0], add_special_tokens=False
-            )
+        prompt_ids = self.template.inject_thinking_tokens(prompt_ids, self.tokenizer)
         prompt_length = len(prompt_ids)
 
         temperature: Optional[float] = input_kwargs.pop("temperature", None)

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -109,6 +109,28 @@ class Template:
         r"""Get the token ids of thought words."""
         return tokenizer.encode(self.add_thought(), add_special_tokens=False)
 
+    def inject_thinking_tokens(self, prompt_ids: list[int], tokenizer: "PreTrainedTokenizer") -> list[int]:
+        r"""Inject thinking tokens into prompt_ids after encode_oneturn for inference.
+
+        When enable_thinking is False and this is not a ReasoningTemplate, append both
+        thought start and end tokens to suppress thinking output.
+        When enable_thinking is True and this is a ReasoningTemplate, append the thought
+        start token to initiate the thinking chain.
+        """
+        if (
+            self.enable_thinking is False
+            and not isinstance(self, ReasoningTemplate)
+            and self.thought_words is not None
+        ):
+            prompt_ids = prompt_ids + tokenizer.encode(
+                self.thought_words[0] + self.thought_words[1], add_special_tokens=False
+            )
+        elif self.enable_thinking is True and isinstance(self, ReasoningTemplate):
+            prompt_ids = prompt_ids + tokenizer.encode(
+                self.thought_words[0], add_special_tokens=False
+            )
+        return prompt_ids
+
     def _convert_elements_to_ids(self, tokenizer: "PreTrainedTokenizer", elements: "SLOTS") -> list[int]:
         r"""Convert elements to token ids."""
         token_ids = []


### PR DESCRIPTION
## Summary

- After `encode_oneturn`, thinking-related tokens (`<think>`, `</think>`) are missing from the prompt because `ReasoningTemplate.encode_oneturn` puts the thinking start token into `response_ids`, which gets discarded by all engine callers
- Add post-encoding token injection in all four engines (`hf_engine`, `vllm_engine`, `sglang_engine`, `kt_engine`) with two branches:
  - `enable_thinking=False` + non-ReasoningTemplate: append `<think></think>` to suppress thinking output
  - `enable_thinking=True` + ReasoningTemplate: append `<think>` to start the thinking chain

## Why `isinstance` instead of `hasattr`

`thought_words` is defined on the base `Template` dataclass, so **all** templates have it. Using `hasattr(template, "thought_words")` would cause the `enable_thinking=False` branch to fire for `ReasoningTemplate`, double-adding tokens that `encode_oneturn` already handles internally.

The correct guard is `isinstance(template, ReasoningTemplate)` to distinguish templates that override `encode_oneturn` with thinking logic from those that don't.

## Affected files

- `src/llamafactory/chat/hf_engine.py`
- `src/llamafactory/chat/vllm_engine.py`
- `src/llamafactory/chat/sglang_engine.py`
- `src/llamafactory/chat/kt_engine.py`

## Test plan

- [ ] `enable_thinking=True` with `qwen3` template → output includes `<think>...</think>` reasoning
- [ ] `enable_thinking=False` with `qwen3_nothink` template → no thinking output
- [ ] `enable_thinking=True` with `qwen3` + vllm engine → thinking chain works
- [ ] `enable_thinking=True` with `qwen3` + hf engine → thinking chain works