### PR TITLE
[model] support Hy3-Preview

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -824,8 +824,8 @@ register_template(
 
 register_template(
     name="hy3",
-    format_user=StringFormatter(slots=["<｜hy_User｜>{{content}}"]),
-    format_assistant=StringFormatter(slots=["<｜hy_Assistant｜><think></think>{{content}}<｜hy_eos｜>"]),
+    format_user=StringFormatter(slots=["<｜hy_User｜>{{content}}<｜hy_Assistant｜>"]),
+    format_assistant=StringFormatter(slots=["{{content}}<｜hy_eos｜>"]),
     format_system=StringFormatter(slots=["{{content}}"]),
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
     stop_words=["<｜hy_eos｜>"],
@@ -2375,4 +2375,3 @@ register_template(
     efficient_eos=True,
     template_class=Glm47ReasoningTemplate,
 )
-

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -823,6 +823,19 @@ register_template(
 
 
 register_template(
+    name="hy3",
+    format_user=StringFormatter(slots=["<｜hy_User｜>{{content}}"]),
+    format_assistant=StringFormatter(slots=["<｜hy_Assistant｜><think></think>{{content}}<｜hy_eos｜>"]),
+    format_system=StringFormatter(slots=["{{content}}"]),
+    format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
+    stop_words=["<｜hy_eos｜>"],
+    replace_eos=True,
+    thought_words=("<think>", "</think>"),
+    template_class=ReasoningTemplate,
+)
+
+
+register_template(
     name="deepseekcoder",
     format_user=StringFormatter(slots=["### Instruction:\n{{content}}\n### Response:"]),
     format_assistant=StringFormatter(slots=["\n{{content}}\n<|EOT|>\n"]),

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -58,7 +58,6 @@ LLAMABOARD_CONFIG = "llamaboard_config.yaml"
 MCA_SUPPORTED_MODELS = {
     "deepseek_v3",
     "glm4_moe",
-    "hy_v3",
     "llama",
     "mistral",
     "mixtral",

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -58,6 +58,7 @@ LLAMABOARD_CONFIG = "llamaboard_config.yaml"
 MCA_SUPPORTED_MODELS = {
     "deepseek_v3",
     "glm4_moe",
+    "hy_v3",
     "llama",
     "mistral",
     "mixtral",
@@ -1254,6 +1255,17 @@ register_model_group(
         },
     },
     template="hunyuan_small",
+)
+
+
+register_model_group(
+    models={
+        "Hy3-Preview": {
+            DownloadSource.DEFAULT: "tencent/Hy3-preview",
+            DownloadSource.MODELSCOPE: "tencent/Hy3-preview",
+        },
+    },
+    template="hy3",
 )
 
 

--- a/src/llamafactory/model/model_utils/moe.py
+++ b/src/llamafactory/model/model_utils/moe.py
@@ -209,9 +209,6 @@ def configure_moe(config: "PretrainedConfig", model_args: "ModelArguments", is_t
     elif model_type == "jetmoe":
         setattr(config, "aux_loss_coef", model_args.moe_aux_loss_coef)
 
-    elif model_type == "hy_v3":
-        setattr(config, "router_aux_loss_coef", model_args.moe_aux_loss_coef)
-
 
 class Qwen3OmniMoeThinkerTextSparseMoeBlock(nn.Module):
     def __init__(self, config):

--- a/src/llamafactory/model/model_utils/moe.py
+++ b/src/llamafactory/model/model_utils/moe.py
@@ -62,6 +62,10 @@ def add_z3_leaf_module(model: "PreTrainedModel") -> None:
         # deepseek v3 and kimi vl use custom code
         _set_z3_leaf_modules(model, ["DeepseekV3MoE"])
 
+    if model_type == "hy_v3":
+        # hy3 uses custom code
+        _set_z3_leaf_modules(model, ["HYV3MoE"])
+
     if model_type == "ernie4_5_moe":
         from transformers.models.ernie4_5_moe.modeling_ernie4_5_moe import Ernie4_5_MoeSparseMoeBlock
 
@@ -164,6 +168,7 @@ def configure_moe(config: "PretrainedConfig", model_args: "ModelArguments", is_t
         "dbrx",
         "ernie4_5_moe",
         "granitemoe",
+        "hy_v3",
         "jamba",
         "jetmoe",
         "llama4",
@@ -184,6 +189,7 @@ def configure_moe(config: "PretrainedConfig", model_args: "ModelArguments", is_t
     if model_type in [
         "ernie4_5_moe",
         "granitemoe",
+        "hy_v3",
         "jamba",
         "llama4",
         "mixtral",
@@ -202,6 +208,9 @@ def configure_moe(config: "PretrainedConfig", model_args: "ModelArguments", is_t
 
     elif model_type == "jetmoe":
         setattr(config, "aux_loss_coef", model_args.moe_aux_loss_coef)
+
+    elif model_type == "hy_v3":
+        setattr(config, "router_aux_loss_coef", model_args.moe_aux_loss_coef)
 
 
 class Qwen3OmniMoeThinkerTextSparseMoeBlock(nn.Module):

--- a/src/llamafactory/model/model_utils/moe.py
+++ b/src/llamafactory/model/model_utils/moe.py
@@ -168,7 +168,6 @@ def configure_moe(config: "PretrainedConfig", model_args: "ModelArguments", is_t
         "dbrx",
         "ernie4_5_moe",
         "granitemoe",
-        "hy_v3",
         "jamba",
         "jetmoe",
         "llama4",
@@ -189,7 +188,6 @@ def configure_moe(config: "PretrainedConfig", model_args: "ModelArguments", is_t
     if model_type in [
         "ernie4_5_moe",
         "granitemoe",
-        "hy_v3",
         "jamba",
         "llama4",
         "mixtral",

--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -178,11 +178,6 @@ def patch_config(
     if getattr(config, "model_type", None) == "qwen3_omni_moe":
         patch_qwen3_omni_moe_thinker_text_sparse_moe_block()
 
-    if getattr(config, "model_type", None) == "hy_v3" and is_trainable:
-        # Hy3 uses sigmoid routing with expert bias, ensure output_router_logits is set
-        if hasattr(config, "output_router_logits"):
-            setattr(config, "output_router_logits", True)
-
     # deepspeed zero3 is not compatible with low_cpu_mem_usage
     init_kwargs["low_cpu_mem_usage"] = model_args.low_cpu_mem_usage and (not is_deepspeed_zero3_enabled())
 

--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -178,6 +178,11 @@ def patch_config(
     if getattr(config, "model_type", None) == "qwen3_omni_moe":
         patch_qwen3_omni_moe_thinker_text_sparse_moe_block()
 
+    if getattr(config, "model_type", None) == "hy_v3" and is_trainable:
+        # Hy3 uses sigmoid routing with expert bias, ensure output_router_logits is set
+        if hasattr(config, "output_router_logits"):
+            setattr(config, "output_router_logits", True)
+
     # deepspeed zero3 is not compatible with low_cpu_mem_usage
     init_kwargs["low_cpu_mem_usage"] = model_args.low_cpu_mem_usage and (not is_deepspeed_zero3_enabled())
 


### PR DESCRIPTION
## 🎯 Overview

Hy3-preview is Tencent's **Hybrid-Hierarchical Hybrid MoE** large language model, featuring an innovative gating routing mechanism and efficient expert parallelism. This PR adds complete training support for Hy3-preview model in LlamaFactory.

| Property                               | Value                              |
| -------------------------------------- | ---------------------------------- |
| Architecture                           | Mixture-of-Experts (MoE)           |
| Total Parameters                       | 295B                               |
| Activated Parameters                   | 21B                                |
| MTP Layer Parameters                   | 3.8B                               |
| Number of Layers (excluding MTP layer) | 80                                 |
| Number of MTP Layers                   | 1                                  |
| Attention Heads                        | 64 (GQA, 8 KV heads, head dim 128) |
| Hidden Size                            | 4096                               |
| Intermediate Size                      | 13312                              |
| Context Length                         | 256K                               |
| Vocabulary Size                        | 120832                             |
| Number of Experts                      | 192 experts, top-8 activated       |
| Supported Precisions                   | BF16                               |

## Highlights
 
- **STEM & Reasoning** — Complex reasoning underpins everything else. Hy3 preview performs well on challenging STEM benchmarks like FrontierScience-Olympiad and IMOAnswerBench, and achieved excellent results in the Tsinghua Qiuzhen College Math PhD qualifying exam (Spring '26) and the China High School Biology Olympiad (CHSBO 2025), demonstrating generalizable reasoning capacity.
 
- **Context Learning & Instruction Following** — Real-world tasks require the ability to parse messy, lengthy contexts and follow complex rules. We built CL-bench and CL-bench-Life from our own business scenarios to innovatively measure context learning ability. Hy3 preview exhibits solid gains in both context learning and instruction following capabilities.
 
- **Code & Agent** — Coding and agents saw the biggest gains. With a rebuilt RL infrastructure and larger-scale training tasks, we posted competitive scores across mainstream coding agent benchmarks (SWE-bench Verified, Terminal-Bench 2.0) and search agent benchmarks (BrowseComp, WideSearch).
 

<br class="Apple-interchange-newline">

## 📦 Available Models

- [Tencent/Hy3-preview](https://huggingface.co/tencent/Hy3-preview) - Official preview release

## 🔧 Training Usage

### LoRA Training

```bash
llamafactory-cli train examples/train_lora/hy3_lora_sft.yaml
```

```yaml
# Hy3-Preview Model LoRA Training Configuration Example
### Model Configuration
model_name_or_path: tencent/Hy3-preview
template: hy3
trust_remote_code: true

### Data Configuration
dataset: your_dataset_name  # Replace with your actual dataset
cutoff_len: 32768  # Adjust based on VRAM; Hy3 supports ultra-long context
max_samples: 100000
overwrite_cache: true
preprocessing_num_workers: 16

### Training Method
stage: sft
do_train: true
finetuning_type: lora
lora_target: all  # Or specify particular modules
lora_rank: 8
lora_alpha: 16
lora_dropout: 0.05
use_rslora: false

### MoE Configuration
# Hy3 adopts MoE architecture; auxiliary loss coefficient can be configured
moe_aux_loss_coef: 0.01  # MoE load-balancing loss coefficient

### Output Configuration
output_dir: saves/hy3-preview/lora/sft
logging_steps: 10
save_steps: 500
plot_loss: true
overwrite_output_dir: true

### Training Parameters
per_device_train_batch_size: 1
gradient_accumulation_steps: 8
learning_rate: 1.0e-4
num_train_epochs: 3.0
lr_scheduler_type: cosine
warmup_ratio: 0.1
bf16: true
ddp_timeout: 180000000

### Optimization Configuration
flash_attn: fa2  # Use FlashAttention-2 to accelerate training
# enable_liger_kernel: false  # Liger kernel is currently unsupported for Hy3

### Other Configuration
seed: 42
report_to: none  # Or use wandb/tensorboard
```


### Full Parameter Training

```bash
llamafactory-cli train examples/train_full/hy3_full_sft.yaml
```

```yaml
# Hy3-Preview Full-Parameter Training Configuration Example
# Note: Full-parameter training requires substantial VRAM/system memory (~600GB+ for model weights)
# Recommended: at least 8x H100 or equivalent setup

### Model Configuration
model_name_or_path: tencent/Hy3-preview
template: hy3
trust_remote_code: true

### Data Configuration
dataset: your_dataset_name  # Replace with your actual dataset
cutoff_len: 32768
max_samples: 100000
overwrite_cache: true
preprocessing_num_workers: 16

### Training Method
stage: sft
do_train: true
finetuning_type: full  # Full-parameter training

moe_aux_loss_coef: 0.01  # MoE load-balancing loss coefficient

output_dir: saves/hy3-preview/full/sft
logging_steps: 10
save_steps: 500
plot_loss: true
overwrite_output_dir: true

per_device_train_batch_size: 1
gradient_accumulation_steps: 16
learning_rate: 5.0e-5
num_train_epochs: 3.0
lr_scheduler_type: cosine
warmup_ratio: 0.1
bf16: true
ddp_timeout: 180000000

# deepspeed: examples/deepspeed/ds_z3_config.json

flash_attn: fa2

seed: 42
report_to: none
```

### Inference

```bash
llamafactory-cli chat --model_name_or_path tencent/Hy3-preview --template hy3 --trust_remote_code
```

## 📝 Changed Files

| File                                        | Description                                                  |
| ------------------------------------------- | ------------------------------------------------------------ |
| `src/llamafactory/extras/constants.py`      | Added `hy_v3` to MCA support list, registered Hy3-Preview model group |
| `src/llamafactory/data/template.py`         | Added `hy3` chat template with custom special tokens and chain-of-thought support |
| `src/llamafactory/model/model_utils/moe.py` | Added `HYV3MoE` ZeRO-3 leaf module and MoE configuration support |
| `src/llamafactory/model/patcher.py`         | Auto-enable `output_router_logits` during training           |

## ✅ Verification Results

All adaptation tests passed:
- ✅ Model registration
- ✅ Chat template
- ✅ MoE configuration
- ✅ Tokenizer compatibility
- ✅ Model loading
- ✅ LoRA compatibility (backward propagation verified)
- ✅ Forward propagation

## ⚠️ Notes

1. **Transformers Version**: Hy3 requires transformers 5.6.0+ or install the development version
2. **Model Size**: Full model is ~600GB, multi-GPU or quantization recommended
3. **MoE Load Balancing**: Recommended to set `moe_aux_loss_coef: 0.01`

---

## Related Links

- Hy3-preview Model: https://huggingface.co/tencent/Hy3-preview
- https://github.com/Tencent-Hunyuan/Hy3-preview