### PR TITLE
[packing] add qwen35 patch for neat_packing

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -471,8 +471,8 @@ class SFTDataCollatorWith4DAttentionMask(MultiModalDataCollatorForSeq2Seq):
     def __post_init__(self):
         super().__post_init__()
         if self.neat_packing and self.attn_implementation == "flash_attention_2":
-            if self.model is not None and getattr(self.model.config, "model_type", None) in ["qwen3_5", "qwen3_5_moe", "gpt_oss"]:
-                raise ValueError("Neat packing is not supported for qwen3_5, qwen3_5_moe, gpt_oss models for now.")
+            if self.model is not None and getattr(self.model.config, "model_type", None) in ["gemma4", "gpt_oss"]:
+                raise ValueError("Neat packing is not supported for gemma4, gpt_oss models for now.")
 
     @staticmethod
     def _unpad_packed_features(features: dict[str, Any]) -> None:

--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -60,6 +60,192 @@ def patch_qwen3_omni_moe_thinker_text_sparse_moe_block():
         modeling_qwen3_omni_moe.Qwen3OmniMoeThinkerTextSparseMoeBlock = Qwen3OmniMoeThinkerTextSparseMoeBlock
 
 
+def _check_fla_dependencies() -> None:
+    """Check that the FLA dependencies required for varlen GDN forwarding are available.
+
+    Requires ``flash-linear-attention >= 0.4.1`` (which exposes the varlen
+    ``causal_conv1d`` under ``fla.modules.convolution`` and the
+    ``chunk_gated_delta_rule`` / ``fused_recurrent_gated_delta_rule`` kernels
+    under ``fla.ops.gated_delta_rule``). Raises ``ImportError`` with an
+    actionable message otherwise.
+    """
+    try:
+        from fla.modules.convolution import causal_conv1d  # noqa: F401
+        from fla.ops.gated_delta_rule import (  # noqa: F401
+            chunk_gated_delta_rule,
+            fused_recurrent_gated_delta_rule,
+        )
+    except ImportError as exc:
+        raise ImportError(
+            "Qwen3.5 packing-seq forwarding requires `flash-linear-attention>=0.4.1` "
+            "(provides `fla.modules.convolution.causal_conv1d` and "
+            "`fla.ops.gated_delta_rule.{chunk,fused_recurrent}_gated_delta_rule`). "
+            "Please install/upgrade it."
+        ) from exc
+
+
+def patch_qwen3_5_forward(model: "PreTrainedModel") -> None:
+    """Patch the forward method of Qwen3_5ForConditionalGeneration to support cu_seqlens input only patch when do training.
+
+    Refer to: https://github.com/axolotl-ai-cloud/axolotl/blob/main/src/axolotl/monkeypatch/models/qwen3_5/modeling.py.
+    """
+    if is_transformers_version_greater_than("5.2.0"):
+        from transformers.models.qwen3_5.modeling_qwen3_5 import apply_mask_to_padding_states
+
+    from torch.nn import functional as F
+    from transformers.modeling_flash_attention_utils import prepare_fa_kwargs_from_position_ids
+
+    _check_fla_dependencies()
+    from fla.modules.convolution import causal_conv1d as fla_causal_conv1d
+    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+
+    def _patched_decoder_forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values=None,
+        cache_position: torch.LongTensor | None = None,
+        **kwargs,
+    ) -> torch.FloatTensor:
+        """Decoder layer forward that passes position_ids through to linear attention."""
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        if self.layer_type == "linear_attention":
+            hidden_states = self.linear_attn(
+                hidden_states=hidden_states,
+                cache_params=past_key_values,
+                cache_position=cache_position,
+                attention_mask=attention_mask,
+                position_ids=position_ids, # passing position_ids to linear attention
+            )
+        elif self.layer_type == "full_attention":
+            hidden_states, _ = self.self_attn(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                cache_position=cache_position,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        if isinstance(hidden_states, tuple):  # MoE returns (hidden_states, router_logits)
+            hidden_states, _ = hidden_states
+
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+    # gdn forward (training only, cache_params is always None)
+    def _patch_gdn_forward(
+        self,
+        hidden_states: torch.Tensor,
+        cache_params=None,
+        cache_position: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+    ):
+        # @kuangdd fix: here attention_mask is None
+        hidden_states = apply_mask_to_padding_states(hidden_states, attention_mask)
+
+        batch_size, seq_len, _ = hidden_states.shape
+
+        # Qwen3.5 VL passes 3-D MRoPE position_ids ([axes, B, T]); collapse to [B, T].
+        if position_ids is not None and position_ids.ndim == 3:
+            position_ids = position_ids[0]
+
+        # `prepare_fa_kwargs_from_position_ids` would crash on None; guard for safety.
+        cu_seqlens = (
+            prepare_fa_kwargs_from_position_ids(position_ids)[0][0]
+            if position_ids is not None
+            else None
+        )
+        # print(f"【debug】cu_seqlens: {cu_seqlens} on device {cu_seqlens.device}")  # for debugging, can be removed later
+
+        # FLA varlen kernels expect [B, T, D] layout, not [B, D, T] like the
+        # standard causal-conv1d path that the upstream forward uses.
+        mixed_qkv = self.in_proj_qkv(hidden_states)
+
+        z = self.in_proj_z(hidden_states)
+        z = z.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+        b = self.in_proj_b(hidden_states)
+        a = self.in_proj_a(hidden_states)
+
+        # FLA's causal_conv1d returns (out, final_state); we don't use the state here.
+        mixed_qkv, _ = fla_causal_conv1d(
+            x=mixed_qkv,
+            weight=self.conv1d.weight.squeeze(1),
+            bias=self.conv1d.bias,
+            activation=self.activation,
+            cu_seqlens=cu_seqlens,
+        )
+
+        query, key, value = torch.split(
+            mixed_qkv,
+            [
+                self.key_dim,
+                self.key_dim,
+                self.value_dim,
+            ],
+            dim=-1,
+        )
+
+        query = query.reshape(batch_size, seq_len, -1, self.head_k_dim)
+        key = key.reshape(batch_size, seq_len, -1, self.head_k_dim)
+        value = value.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+        beta = b.sigmoid()
+        # If the model is loaded in fp16, without the .float() here, A might be -inf
+        g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+        if self.num_v_heads // self.num_k_heads > 1:
+            query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+            key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+
+        core_attn_out, _ = chunk_gated_delta_rule(
+            query,
+            key,
+            value,
+            g=g,
+            beta=beta,
+            initial_state=None,
+            output_final_state=False,
+            use_qk_l2norm_in_kernel=True,
+            **({"cu_seqlens": cu_seqlens} if cu_seqlens is not None else {}),
+        )
+
+        core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)
+        z = z.reshape(-1, self.head_v_dim)
+        core_attn_out = self.norm(core_attn_out, z)
+        core_attn_out = core_attn_out.reshape(batch_size, seq_len, -1)
+
+        output = self.out_proj(core_attn_out)
+
+        return output
+
+    if model.config.architectures[0] == "Qwen3_5ForConditionalGeneration":
+        from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5DecoderLayer, Qwen3_5GatedDeltaNet
+        Qwen3_5DecoderLayer.forward = _patched_decoder_forward
+        Qwen3_5GatedDeltaNet.forward = _patch_gdn_forward
+    elif model.config.architectures[0] == "Qwen3_5MoeForConditionalGeneration":
+        from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
+            Qwen3_5MoeDecoderLayer,
+            Qwen3_5MoeGatedDeltaNet,
+        )
+        Qwen3_5MoeDecoderLayer.forward = _patched_decoder_forward
+        Qwen3_5MoeGatedDeltaNet.forward = _patch_gdn_forward
+
+    logger.info_rank0("Patched Qwen3.5 decoder forward to support cu_seqlens input only patch when do training.")
+
+
 def patch_youtu_vl_model(model: "PreTrainedModel") -> None:
     original_forward = model.forward
 
@@ -231,6 +417,10 @@ def patch_model(
         prepare_model_for_training(model, model_args)
         autocast_projector_dtype(model, model_args)
         add_z3_leaf_module(model)
+
+        if getattr(model.config, "model_type", None) in ["qwen3_5", "qwen3_5_moe"] and model_args.flash_attn == "fa2":
+            # patch_qwen3_5_forward(model)
+            pass
 
     if not model_args.use_unsloth:
         print_attn_implementation(model.config)

--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -168,7 +168,6 @@ def patch_qwen3_5_forward(model: "PreTrainedModel") -> None:
             if position_ids is not None
             else None
         )
-        # print(f"【debug】cu_seqlens: {cu_seqlens} on device {cu_seqlens.device}")  # for debugging, can be removed later
 
         # FLA varlen kernels expect [B, T, D] layout, not [B, D, T] like the
         # standard causal-conv1d path that the upstream forward uses.

--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -419,8 +419,7 @@ def patch_model(
         add_z3_leaf_module(model)
 
         if getattr(model.config, "model_type", None) in ["qwen3_5", "qwen3_5_moe"] and model_args.flash_attn == "fa2":
-            # patch_qwen3_5_forward(model)
-            pass
+            patch_qwen3_5_forward(model)
 
     if not model_args.use_unsloth:
         print_attn_implementation(model.config)


### PR DESCRIPTION
# Env info
- `llamafactory` version: 0.9.5.dev0
- Platform: Linux-5.15.0-113-generic-x86_64-with-glibc2.35
- Python version: 3.12.0
- PyTorch version: 2.11.0+cu130 (GPU)
- Transformers version: 5.6.0
- Datasets version: 4.0.0
- Accelerate version: 1.11.0
- PEFT version: 0.18.1
- GPU type: NVIDIA GeForce RTX 4090
- GPU number: 2
- GPU memory: 23.52GB
- TRL version: 0.24.0
- Git commit: af8e537d4f0995613a5a993103b30ac5e64da33d
- Default data directory: detected
- **flash: fa2 + fla**

# What does this PR do?

patch the original model.forward()
- for full attn layer, reuse fa2
- support linear_attention with varlen sequence packing
- pass into position_ids in decoder.forward

## who may help review
cc @hiyouga @frozenleaves @jiaqiw09 

## test code
```python
import os
import sys
import traceback
from dataclasses import dataclass
from typing import Any

import torch


REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
SRC_PATH = os.path.join(REPO_ROOT, "src")
if SRC_PATH not in sys.path:
    sys.path.insert(0, SRC_PATH)


# ---------------------------------------------------------------------------
# Config
# ---------------------------------------------------------------------------

MODEL_NAME = os.environ.get("MODEL_NAME", "Qwen/Qwen3.5-0.8B")
DEVICE = os.environ.get("DEVICE", "cuda:0" if torch.cuda.is_available() else "cpu")
DTYPE_STR = os.environ.get("DTYPE", "bf16").lower()
ATTN_IMPL = os.environ.get("ATTN_IMPL", "flash_attention_2")
SEED = int(os.environ.get("SEED", "0"))
PRINT_FULL_TENSORS = os.environ.get("PRINT_FULL_TENSORS", "1") == "1"

DTYPE_MAP = {
    "fp32": torch.float32,
    "fp16": torch.float16,
    "bf16": torch.bfloat16,
}
if DTYPE_STR not in DTYPE_MAP:
    raise ValueError(f"Unsupported DTYPE={DTYPE_STR!r}, choose from {list(DTYPE_MAP)}")
DTYPE = DTYPE_MAP[DTYPE_STR]


# Two short prompts of *different* lengths — different lengths matter,
# otherwise the concat boundary doesn't expose state-leakage between
# sequences inside the linear-attention layer.
PROMPTS = [
    "The capital of France is",
    "Large language models trained with packed sequences should produce",
    "When you stack tokens from multiple",
]


# ---------------------------------------------------------------------------
# Helpers
# ---------------------------------------------------------------------------


def _pretty_diff(name: str, ref: torch.Tensor, got: torch.Tensor) -> dict[str, float]:
    """Return a dict of common float-precision metrics between two tensors.

    ``ref`` and ``got`` must have the same shape (already aligned on
    *valid* positions). Computation is done in fp32 to avoid lossy
    accumulation in fp16/bf16.
    """
    assert ref.shape == got.shape, f"{name}: shape mismatch {ref.shape} vs {got.shape}"
    ref32 = ref.detach().float()
    got32 = got.detach().float()
    diff = (ref32 - got32).abs()

    cos = torch.nn.functional.cosine_similarity(
        ref32.reshape(-1, ref32.shape[-1]),
        got32.reshape(-1, got32.shape[-1]),
        dim=-1,
    )

    return {
        "max_abs_diff": diff.max().item(),
        "mean_abs_diff": diff.mean().item(),
        "rel_l2": (diff.pow(2).sum().sqrt() / ref32.pow(2).sum().sqrt().clamp_min(1e-8)).item(),
        "cosine_min": cos.min().item(),
        "cosine_mean": cos.mean().item(),
    }


def _print_diff(label: str, metrics: dict[str, float]) -> None:
    print(
        f"  [{label:<24}] "
        f"max={metrics['max_abs_diff']:.4e}  "
        f"mean={metrics['mean_abs_diff']:.4e}  "
        f"rel_l2={metrics['rel_l2']:.4e}  "
        f"cos_min={metrics['cosine_min']:.6f}  "
        f"cos_mean={metrics['cosine_mean']:.6f}"
    )


def _format_tensor_1d(t: torch.Tensor, max_items: int = 64) -> str:
    """Pretty-format a 1-D tensor as a python list, optionally truncated."""
    flat = t.detach().cpu().tolist()
    if len(flat) <= max_items:
        return str(flat)
    head = flat[: max_items // 2]
    tail = flat[-max_items // 2 :]
    return f"{head[:-1]}, ... ({len(flat) - max_items} more) ..., {tail}"


def _print_test_batches(tokenizer, prompts: list[str], unpacked: dict, packed: dict) -> None:
    """Print the unpacked-padded and packed batches in human-readable form.

    For each batch we print:
      * tensor shapes / dtype / device
      * input_ids / attention_mask / position_ids contents
      * decoded token strings (per row for unpacked, with sub-seq boundaries for packed)
    """
    sep = "=" * 88
    print("\n" + sep)
    print("[INPUT BATCHES]")
    print(sep)

    print(f"\nPrompts ({len(prompts)}):")
    for i, p in enumerate(prompts):
        print(f"  [{i}] {p!r}")

    # ---- Unpacked padded batch ------------------------------------------------------
    print("\n" + "-" * 88)
    print("Unpacked (padded) batch  —  reference, B = N")
    print("-" * 88)
    u_ids = unpacked["input_ids"]
    u_mask = unpacked["attention_mask"]
    u_pos = unpacked["position_ids"]
    print(f"  input_ids       : shape={tuple(u_ids.shape)}  dtype={u_ids.dtype}  device={u_ids.device}")
    print(f"  attention_mask  : shape={tuple(u_mask.shape)} dtype={u_mask.dtype} device={u_mask.device}")
    print(f"  position_ids    : shape={tuple(u_pos.shape)}  dtype={u_pos.dtype}  device={u_pos.device}")

    if PRINT_FULL_TENSORS:
        for i in range(u_ids.shape[0]):
            valid_len = int(u_mask[i].sum().item())
            print(f"\n  row[{i}]  (valid_len = {valid_len} / pad_len = {u_ids.shape[1]})")
            print(f"    input_ids      : {_format_tensor_1d(u_ids[i])}")
            print(f"    attention_mask : {_format_tensor_1d(u_mask[i])}")
            print(f"    position_ids   : {_format_tensor_1d(u_pos[i])}")
            valid_ids = u_ids[i, :valid_len].detach().cpu().tolist()
            decoded = tokenizer.decode(valid_ids, skip_special_tokens=False)
            tokens = tokenizer.convert_ids_to_tokens(valid_ids)
            print(f"    tokens (valid) : {tokens}")
            print(f"    decoded        : {decoded!r}")

    # ---- Packed batch ---------------------------------------------------------------
    print("\n" + "-" * 88)
    print("Packed batch  —  B = 1, position_ids reset at each boundary")
    print("-" * 88)
    p_ids = packed["input_ids"]
    p_mask = packed["attention_mask"]
    p_pos = packed["position_ids"]
    seq_lens = packed["seq_lens"]
    offsets = packed["offsets"]

    print(f"  input_ids       : shape={tuple(p_ids.shape)}  dtype={p_ids.dtype}  device={p_ids.device}")
    print(f"  attention_mask  : shape={tuple(p_mask.shape)} dtype={p_mask.dtype} device={p_mask.device}")
    print(f"  position_ids    : shape={tuple(p_pos.shape)}  dtype={p_pos.dtype}  device={p_pos.device}")
    print(f"  seq_lens        : {seq_lens}  (sum = {sum(seq_lens)})")
    print(f"  offsets         : {offsets}")

    if PRINT_FULL_TENSORS:
        print(f"\n  full input_ids      : {_format_tensor_1d(p_ids[0])}")
        print(f"  full attention_mask : {_format_tensor_1d(p_mask[0])}")
        print(f"  full position_ids   : {_format_tensor_1d(p_pos[0])}")

        print("\n  per sub-sequence breakdown:")
        for i, (off, L) in enumerate(zip(offsets, seq_lens)):
            sub_ids = p_ids[0, off : off + L]
            sub_pos = p_pos[0, off : off + L]
            sub_mask = p_mask[0, off : off + L]
            ids_list = sub_ids.detach().cpu().tolist()
            tokens = tokenizer.convert_ids_to_tokens(ids_list)
            decoded = tokenizer.decode(ids_list, skip_special_tokens=False)
            print(f"\n    sub-seq[{i}]  offset={off}  len={L}")
            print(f"      input_ids     : {_format_tensor_1d(sub_ids)}")
            print(f"      position_ids  : {_format_tensor_1d(sub_pos)}")
            print(f"      attention_mask: {_format_tensor_1d(sub_mask)}")
            print(f"      tokens        : {tokens}")
            print(f"      decoded       : {decoded!r}")

    # ---- Sanity check: same valid tokens in both batches ----------------------------
    print("\n" + "-" * 88)
    print("Sanity check: unpacked-valid tokens  vs  packed sub-seq tokens")
    print("-" * 88)
    all_match = True
    for i, (off, L) in enumerate(zip(offsets, seq_lens)):
        u_row_valid = u_ids[i, :L].detach().cpu()
        p_sub = p_ids[0, off : off + L].detach().cpu()
        same = bool(torch.equal(u_row_valid, p_sub))
        all_match = all_match and same
        print(f"  sub-seq[{i}]  L={L}  match={same}")
    print(f"  ALL MATCH = {all_match}")
    print(sep + "\n")


@dataclass
class _SavedForwards:
    """Snapshot of the original .forward methods so we can restore them."""

    decoder: Any | None = None
    gdn: Any | None = None
    decoder_cls: Any | None = None
    gdn_cls: Any | None = None


def _snapshot_forwards(arch: str) -> _SavedForwards:
    if arch == "Qwen3_5ForConditionalGeneration":
        from transformers.models.qwen3_5.modeling_qwen3_5 import (
            Qwen3_5DecoderLayer as DecoderLayer,
        )
        from transformers.models.qwen3_5.modeling_qwen3_5 import (
            Qwen3_5GatedDeltaNet as GatedDeltaNet,
        )
    elif arch == "Qwen3_5MoeForConditionalGeneration":
        from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
            Qwen3_5MoeDecoderLayer as DecoderLayer,
        )
        from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
            Qwen3_5MoeGatedDeltaNet as GatedDeltaNet,
        )
    else:
        raise RuntimeError(f"Unsupported architecture for snapshot: {arch}")

    return _SavedForwards(
        decoder=DecoderLayer.forward,
        gdn=GatedDeltaNet.forward,
        decoder_cls=DecoderLayer,
        gdn_cls=GatedDeltaNet,
    )


def _restore_forwards(snap: _SavedForwards) -> None:
    if snap.decoder_cls is not None and snap.decoder is not None:
        snap.decoder_cls.forward = snap.decoder
    if snap.gdn_cls is not None and snap.gdn is not None:
        snap.gdn_cls.forward = snap.gdn


# ---------------------------------------------------------------------------
# Core logic
# ---------------------------------------------------------------------------


def _build_inputs(tokenizer, prompts: list[str], device: str):
    """Build matched 'unpacked padded' and 'packed' batches.

    Returns
    -------
    unpacked : dict
        ``input_ids[B, T_pad]``, ``attention_mask[B, T_pad]``, ``position_ids[B, T_pad]``
    packed : dict
        ``input_ids[1, sum(T_i)]``, ``attention_mask[1, sum(T_i)]`` (all-ones),
        ``position_ids[1, sum(T_i)]`` (resets to 0 at each boundary),
        ``seq_lens`` (list[int]),
        ``offsets``  (list[int]) — start position of each sub-seq in the packed batch.
    """
    enc = [tokenizer(p, return_tensors="pt", add_special_tokens=False) for p in prompts]
    seq_lens = [int(e["input_ids"].shape[1]) for e in enc]
    pad_len = max(seq_lens)

    pad_id = tokenizer.pad_token_id
    if pad_id is None:
        pad_id = tokenizer.eos_token_id

    # Unpacked padded batch (right-padded so we can slice [:, :L_i] for valid positions).
    input_ids = torch.full((len(prompts), pad_len), pad_id, dtype=torch.long)
    attn_mask = torch.zeros((len(prompts), pad_len), dtype=torch.long)
    position_ids = torch.zeros((len(prompts), pad_len), dtype=torch.long)
    for i, e in enumerate(enc):
        L = seq_lens[i]
        input_ids[i, :L] = e["input_ids"][0]
        attn_mask[i, :L] = 1
        position_ids[i, :L] = torch.arange(L, dtype=torch.long)

    unpacked = {
        "input_ids": input_ids.to(device),
        "attention_mask": attn_mask.to(device),
        "position_ids": position_ids.to(device),
    }

    # Packed batch.
    flat = torch.cat([e["input_ids"][0] for e in enc], dim=0).unsqueeze(0)
    pos = torch.cat([torch.arange(L, dtype=torch.long) for L in seq_lens], dim=0).unsqueeze(0)
    full_attn = torch.ones_like(flat)
    offsets, cur = [], 0
    for L in seq_lens:
        offsets.append(cur)
        cur += L

    packed = {
        "input_ids": flat.to(device),
        "attention_mask": full_attn.to(device),
        "position_ids": pos.to(device),
        "seq_lens": seq_lens,
        "offsets": offsets,
    }

    return unpacked, packed


@torch.inference_mode()
def _forward(model, batch: dict, want_hidden: bool = True):
    """Single forward pass returning (logits, last_hidden_state) on cpu/fp32."""
    out = model(
        input_ids=batch["input_ids"],
        attention_mask=batch["attention_mask"],
        position_ids=batch["position_ids"],
        output_hidden_states=want_hidden,
        use_cache=False,
        return_dict=True,
    )
    logits = out.logits.detach().float().cpu()
    hidden = (
        out.hidden_states[-1].detach().float().cpu() if want_hidden and out.hidden_states is not None else None
    )
    return logits, hidden


def _gather_unpacked_valid(t: torch.Tensor, seq_lens: list[int]) -> list[torch.Tensor]:
    """t: [B, T_pad, D]  ->  [t_i[:L_i, D] for i]."""
    return [t[i, :L].contiguous() for i, L in enumerate(seq_lens)]


def _gather_packed_valid(t: torch.Tensor, offsets: list[int], seq_lens: list[int]) -> list[torch.Tensor]:
    """t: [1, sum(L_i), D]  ->  [t[0, off:off+L, D] for each subseq]."""
    out = []
    for off, L in zip(offsets, seq_lens):
        out.append(t[0, off : off + L].contiguous())
    return out


def _compare(label: str, ref_chunks: list[torch.Tensor], got_chunks: list[torch.Tensor]) -> None:
    """Print metrics per-subseq + global."""
    assert len(ref_chunks) == len(got_chunks)
    refs = torch.cat(ref_chunks, dim=0)
    gots = torch.cat(got_chunks, dim=0)
    print(f"\n  ---- {label} (global, all sub-seqs concatenated) ----")
    _print_diff("global", _pretty_diff(label, refs, gots))
    for i, (r, g) in enumerate(zip(ref_chunks, got_chunks)):
        _print_diff(f"sub-seq[{i}] L={r.shape[0]}", _pretty_diff(label, r, g))


def _build_per_item_inputs(tokenizer, prompts: list[str], device: str) -> list[dict]:
    """Build one un-padded mini-batch per prompt: B=1, T=L_i, no pad tokens.

    Returns a list of dicts with input_ids/attention_mask/position_ids, one
    per prompt, all of shape ``[1, L_i]``. This is the cleanest possible
    ground-truth — no padding, no concat boundaries, no cross-seq state at
    all — so it's what the unpacked-padded and packed runs *should* both
    converge to in the limit of correct masking.
    """
    batches = []
    for p in prompts:
        enc = tokenizer(p, return_tensors="pt", add_special_tokens=False)
        ids = enc["input_ids"].to(device)
        L = ids.shape[1]
        batches.append(
            {
                "input_ids": ids,
                "attention_mask": torch.ones((1, L), dtype=torch.long, device=device),
                "position_ids": torch.arange(L, dtype=torch.long, device=device).unsqueeze(0),
            }
        )
    return batches


@torch.inference_mode()
def _forward_per_item(model, batches: list[dict], want_hidden: bool = True):
    """Run forward once per item (for-loop), no padding involved.

    Returns
    -------
    logits_chunks : list[Tensor]   each shape [L_i, V]   on cpu/fp32
    hidden_chunks : list[Tensor]   each shape [L_i, D]   on cpu/fp32
    """
    logits_chunks: list[torch.Tensor] = []
    hidden_chunks: list[torch.Tensor] = []
    for i, b in enumerate(batches):
        out = model(
            input_ids=b["input_ids"],
            attention_mask=b["attention_mask"],
            position_ids=b["position_ids"],
            output_hidden_states=want_hidden,
            use_cache=False,
            return_dict=True,
        )
        # squeeze batch dim -> [L_i, ...]
        logits_chunks.append(out.logits[0].detach().float().cpu())
        if want_hidden and out.hidden_states is not None:
            hidden_chunks.append(out.hidden_states[-1][0].detach().float().cpu())
        else:
            hidden_chunks.append(None)  # type: ignore[arg-type]
    return logits_chunks, hidden_chunks

def _try_load_model(attn_impl: str):
    """Load Qwen3.5 model + tokenizer, with attn fallback (flash -> eager)."""
    from transformers import AutoTokenizer, AutoModelForImageTextToText

    tok = AutoTokenizer.from_pretrained(MODEL_NAME, trust_remote_code=True)

    last_err = None
    for impl in (attn_impl, "sdpa", "eager"):
        try:
            print(f"[load] trying attn_implementation={impl!r} dtype={DTYPE} device={DEVICE}")
            model = AutoModelForImageTextToText.from_pretrained(
                MODEL_NAME,
                dtype=DTYPE,
                attn_implementation=impl,
                trust_remote_code=True,
            ).to(DEVICE)
            model.eval()
            print(f"[load] OK with attn_implementation={impl!r}")
            return tok, model, impl
        except Exception as exc:  # pragma: no cover — environment-dependent
            last_err = exc
            print(f"[load] FAILED with {impl!r}: {exc!r}")

    raise RuntimeError(f"Could not load {MODEL_NAME!r} with any attn impl") from last_err


# ---------------------------------------------------------------------------
# Main
# ---------------------------------------------------------------------------


def main() -> int:
    torch.manual_seed(SEED)

    print("=" * 88)
    print(f"Qwen3.5 packing-seq precision test")
    print(f"  model       = {MODEL_NAME}")
    print(f"  device      = {DEVICE}")
    print(f"  dtype       = {DTYPE_STR}")
    print(f"  attn_impl   = {ATTN_IMPL}  (will fall back to sdpa/eager if unavailable)")
    print(f"  prompts     = {len(PROMPTS)} sequences")
    for i, p in enumerate(PROMPTS):
        print(f"    [{i}] {p!r}")
    print("=" * 88)

    tokenizer, model, used_impl = _try_load_model(ATTN_IMPL)
    arch = model.config.architectures[0]
    print(f"[info] architecture = {arch}")
    if arch not in ("Qwen3_5ForConditionalGeneration", "Qwen3_5MoeForConditionalGeneration"):
        print(
            f"[warn] this script targets Qwen3.5 (Moe) only — got {arch}. "
            "Linear-attention layers may be absent and the test becomes trivial."
        )

    unpacked, packed = _build_inputs(tokenizer, PROMPTS, DEVICE)
    seq_lens = packed["seq_lens"]
    offsets = packed["offsets"]
    print(f"[info] seq_lens={seq_lens}  total_packed_len={sum(seq_lens)}")

    _print_test_batches(tokenizer, PROMPTS, unpacked, packed)

    print("\n[run] reference per-item no-pad  (for-loop, B=1 per prompt)")
    per_item_batches = _build_per_item_inputs(tokenizer, PROMPTS, DEVICE)
    pi_logits_chunks, pi_hidden_chunks = _forward_per_item(model, per_item_batches)

    ref_logits_chunks = pi_logits_chunks
    ref_hidden_chunks = pi_hidden_chunks

    # ---- Reference B: unpacked padded ------------------------------------------------
    print("\n[run] reference unpacked  (padded, B=N)")
    up_logits, up_hidden = _forward(model, unpacked)
    up_logits_chunks = _gather_unpacked_valid(up_logits, seq_lens)
    up_hidden_chunks = _gather_unpacked_valid(up_hidden, seq_lens)

    print("\n[diff] unpacked_padded  vs  per_item_no_pad   (padding-only effect)")
    _compare("logits/padded_vs_pi", ref_logits_chunks, up_logits_chunks)
    _compare("hidden/padded_vs_pi", ref_hidden_chunks, up_hidden_chunks)

    # ---- Packed without patch ---------------------------------------------------------
    print("\n[run] packed WITHOUT patch  (vanilla GDN forward)")
    np_logits, np_hidden = _forward(model, packed)
    np_logits_chunks = _gather_packed_valid(np_logits, offsets, seq_lens)
    np_hidden_chunks = _gather_packed_valid(np_hidden, offsets, seq_lens)

    print("\n[diff] packed_no_patch  vs  per_item_no_pad")
    _compare("logits/no_patch", ref_logits_chunks, np_logits_chunks)
    _compare("hidden/no_patch", ref_hidden_chunks, np_hidden_chunks)

    # ---- Packed with each available patch backend -------------------------------------
    backend_results: list[dict] = []  # {name, ok, max_logits_diff, err}

    backends: list[tuple[str, callable]] = []

    # Backend 1: LLaMA-Factory's patch (model-level, takes the model instance)
    def _apply_llamafactory(model_):
        from llamafactory.model.patcher import patch_qwen3_5_forward

        patch_qwen3_5_forward(model_)

    backends.append(("llamafactory", _apply_llamafactory))


    for backend_name, apply_fn in backends:
        print(f"\n[run] packed WITH patch  ({backend_name})")
        snap = _snapshot_forwards(arch)
        ok = False
        err: BaseException | None = None
        max_diff: float | None = None
        try:
            apply_fn(model)
            wp_logits, wp_hidden = _forward(model, packed)
            wp_logits_chunks = _gather_packed_valid(wp_logits, offsets, seq_lens)
            wp_hidden_chunks = _gather_packed_valid(wp_hidden, offsets, seq_lens)

            print(f"\n[diff] packed_with_patch[{backend_name}]  vs  per_item_no_pad")
            _compare(f"logits/{backend_name}", ref_logits_chunks, wp_logits_chunks)
            _compare(f"hidden/{backend_name}", ref_hidden_chunks, wp_hidden_chunks)

            ref_flat = torch.cat(ref_logits_chunks, dim=0)
            wp_flat = torch.cat(wp_logits_chunks, dim=0)
            max_diff = (ref_flat - wp_flat).abs().max().item()
            ok = True
        except Exception as exc:
            err = exc
            print(f"[patch:{backend_name}] failed: {type(exc).__name__}: {exc}")
            traceback.print_exc()
        finally:
            _restore_forwards(snap)

        backend_results.append(
            {"name": backend_name, "ok": ok, "max_logits_diff": max_diff, "err": err}
        )

    # ---- Final summary -----------------------------------------------------------------
    ref_logits_flat = torch.cat(ref_logits_chunks, dim=0)
    up_logits_flat = torch.cat(up_logits_chunks, dim=0)
    no_logits_flat = torch.cat(np_logits_chunks, dim=0)

    print("\n" + "=" * 88)
    print("[SUMMARY] max-abs logits diff vs per-item no-pad reference")
    print(f"  unpacked_padded  : {(ref_logits_flat - up_logits_flat).abs().max().item():.4e}")
    print(f"  packed_no_patch  : {(ref_logits_flat - no_logits_flat).abs().max().item():.4e}")
    for r in backend_results:
        if r["ok"]:
            print(f"  packed_{r['name']:<10}: {r['max_logits_diff']:.4e}")
        else:
            print(f"  packed_{r['name']:<10}: FAILED ({type(r['err']).__name__})")
    print("=" * 88)

    all_ok = all(r["ok"] for r in backend_results)
    return 0 if all_ok else 1


if __name__ == "__main__":
    raise SystemExit(main())
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
