### PR TITLE
fix: handle NotImplementedError in export_model for transformers>=5.0 (fixes #10410)

### DIFF
--- a/src/llamafactory/train/tuner.py
+++ b/src/llamafactory/train/tuner.py
@@ -78,9 +78,7 @@ def _training_function(config: dict[str, Any]) -> None:
 
     if finetuning_args.stage == "sft" and finetuning_args.use_hyper_parallel:
         if not is_hyper_parallel_available():
-            raise ImportError(
-                "hyper_parallel is not installed. Please install it with `pip install hyper_parallel`."
-            )
+            raise ImportError("hyper_parallel is not installed. Please install it with `pip install hyper_parallel`.")
         from .hyper_parallel import run_sft as run_sft_hp
 
         run_sft_hp(model_args, data_args, training_args, finetuning_args, generating_args, callbacks)
@@ -182,7 +180,15 @@ def export_model(args: Optional[dict[str, Any]] = None) -> None:
     if not is_transformers_version_greater_than("5.0.0"):
         save_kwargs["safe_serialization"] = not model_args.export_legacy_format
 
-    model.save_pretrained(**save_kwargs)
+    try:
+        model.save_pretrained(**save_kwargs)
+    except NotImplementedError as err:
+        raise RuntimeError(
+            "Failed to export model: weight conversion reversal is not supported for this model architecture "
+            "(NotImplementedError in transformers.core_model_loading.reverse_op). "
+            "This is a known issue with transformers>=5.0 for certain model types (e.g. Mistral/Ministral). "
+            "Workarounds: (1) use transformers<5.0, or (2) report the issue to the transformers repository."
+        ) from err
 
     if model_args.export_hub_model_id is not None:
         # Prepare push arguments (safe_serialization removed in transformers v5.0.0)

--- a/src/llamafactory/train/tuner.py
+++ b/src/llamafactory/train/tuner.py
@@ -78,7 +78,9 @@ def _training_function(config: dict[str, Any]) -> None:
 
     if finetuning_args.stage == "sft" and finetuning_args.use_hyper_parallel:
         if not is_hyper_parallel_available():
-            raise ImportError("hyper_parallel is not installed. Please install it with `pip install hyper_parallel`.")
+            raise ImportError(
+                "hyper_parallel is not installed. Please install it with `pip install hyper_parallel`."
+            )
         from .hyper_parallel import run_sft as run_sft_hp
 
         run_sft_hp(model_args, data_args, training_args, finetuning_args, generating_args, callbacks)


### PR DESCRIPTION
Fixes #10410

## Problem

When exporting a LoRA-merged model with `llamafactory-cli export`, `model.save_pretrained()` raises `NotImplementedError` on transformers>=5.0 for certain model architectures (e.g. Ministral-3-8B). The root cause is inside transformers' `revert_weight_conversion()` → `reverse_transform()` → `reverse_op`, where some `ConversionOps` subclasses do not implement the `reverse_op` property.

The original traceback is:
```
File ".../transformers/modeling_utils.py", line 3311, in save_pretrained
    state_dict = revert_weight_conversion(model_to_save, state_dict)
  ...
  File ".../transformers/core_model_loading.py", line 100, in reverse_op
    raise NotImplementedError
NotImplementedError
```

This is a known upstream transformers issue (see also hiyouga/LlamaFactory#10230).

## Solution

Wrap `model.save_pretrained(**save_kwargs)` in a `try/except NotImplementedError` block and re-raise as `RuntimeError` with a clear, actionable message explaining:
- The root cause (transformers>=5.0 weight conversion reversal)
- Affected architectures (Mistral/Ministral family)
- Workarounds (downgrade transformers or wait for upstream fix)

This converts an opaque traceback into a helpful diagnostic.

## Testing

The fix is a defensive error-handling change. It only activates when `save_pretrained` raises `NotImplementedError`, which does not occur on unaffected models/versions.