### PR TITLE
fix(data/converter): handle None tool_calls in OpenAI-style messages

### DIFF
--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -257,7 +257,7 @@ class OpenAIDatasetConverter(DatasetConverter):
             content = message[self.dataset_attr.content_tag]
 
             if role in [self.dataset_attr.assistant_tag, self.dataset_attr.function_tag]:
-                if "tool_calls" in message and len(message["tool_calls"]) > 0:
+                if message.get("tool_calls") and len(message["tool_calls"]) > 0:
                     tool_calls_list = [tool["function"] for tool in message["tool_calls"]]
                     content = json.dumps(tool_calls_list, ensure_ascii=False)
                     role = self.dataset_attr.function_tag

--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -257,8 +257,8 @@ class OpenAIDatasetConverter(DatasetConverter):
             content = message[self.dataset_attr.content_tag]
 
             if role in [self.dataset_attr.assistant_tag, self.dataset_attr.function_tag]:
-                if message.get("tool_calls") and len(message["tool_calls"]) > 0:
-                    tool_calls_list = [tool["function"] for tool in message["tool_calls"]]
+                if tool_calls := message.get("tool_calls"):
+                    tool_calls_list = [tool["function"] for tool in tool_calls]
                     content = json.dumps(tool_calls_list, ensure_ascii=False)
                     role = self.dataset_attr.function_tag
 


### PR DESCRIPTION
## Problem

Fixes #10451.

In `llamafactory/data/converter.py:260`:

```python
if "tool_calls" in message and len(message["tool_calls"]) > 0:
```

When a dataset message contains an explicit `\"tool_calls\": null` field (which OpenAI's API spec allows for assistant messages without tool calls), this branch crashes:

- `\"tool_calls\" in message` → `True` (the key exists)
- `len(message[\"tool_calls\"])` → `TypeError: object of type 'NoneType' has no len()`

This is a real-world hazard because many tool-calling datasets exported from OpenAI / GLM / DeepSeek formats keep the `tool_calls` field present and set to `null` for non-tool turns, instead of omitting the key.

## Fix

Use `.get()` so a `None` value short-circuits to falsy:

```diff
-                if \"tool_calls\" in message and len(message[\"tool_calls\"]) > 0:
+                if message.get(\"tool_calls\") and len(message[\"tool_calls\"]) > 0:
```

Behavior preserved across all existing cases:

| `message[\"tool_calls\"]` | Before | After |
|---|---|---|
| key absent | False (skip) | False (skip) |
| `[]` | False (skip) | False (skip) |
| `[{...}]` | True (process) | True (process) |
| `None` | **TypeError** | False (skip) ✓ |

## Notes

The second `len(...) > 0` check is now redundant for non-`None` cases (a non-empty list is already truthy), but kept for symmetry with the original code and to make the intent obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)