### PR TITLE
feat/add-qwen3.5-roleplay-example

### DIFF
--- a/examples/train_lora/qwen3.5_lora_roleplay.yaml
+++ b/examples/train_lora/qwen3.5_lora_roleplay.yaml
@@ -1,0 +1,42 @@
+### model
+model_name_or_path: Qwen/Qwen3.5-4B-Instruct
+
+### method
+stage: sft
+do_train: true
+finetuning_type: lora
+lora_rank: 16
+lora_alpha: 32
+lora_dropout: 0.1
+lora_target: all
+
+### dataset
+dataset: identity,alpaca_en
+template: qwen3_5
+cutoff_len: 2048
+max_samples: 1000
+overwrite_cache: true
+preprocessing_num_workers: 16
+
+### output
+output_dir: saves/qwen3.5-4b/lora/roleplay
+logging_steps: 10
+save_steps: 100
+plot_loss: true
+overwrite_output_dir: true
+
+### train
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 8
+learning_rate: 2.0e-4
+num_train_epochs: 3.0
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+bf16: true
+ddp_timeout: 180000000
+
+### eval
+val_size: 0.1
+per_device_eval_batch_size: 1
+eval_strategy: steps
+eval_steps: 100

--- a/examples/train_lora/qwen3.5_lora_roleplay.yaml
+++ b/examples/train_lora/qwen3.5_lora_roleplay.yaml
@@ -11,7 +11,7 @@ lora_dropout: 0.1
 lora_target: all
 
 ### dataset
-dataset: identity,alpaca_en
+dataset: identity,sharegpt_hyper
 template: qwen3_5
 cutoff_len: 2048
 max_samples: 1000


### PR DESCRIPTION
## Summary

Add a new LoRA fine-tuning example configuration for Qwen3.5-4B-Instruct, demonstrating how to fine-tune the model for role-playing scenarios.

## Changes

- Added `examples/train_lora/qwen3.5_lora_roleplay.yaml`

## Motivation

Qwen3.5 is one of the latest models supported by LLaMA Factory, but there was no example configuration for role-playing use cases. This example helps users get started with Qwen3.5 fine-tuning quickly.

## Checklist

- [x] Added example configuration file
- [x] Used correct template (qwen3_5)
- [x] Followed existing example format