### PR TITLE
[data] qwen3_vl: relax default thought_words to handle single-newline </think>

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -2003,6 +2003,7 @@ register_template(
     ),
     format_tools=ToolFormatter(tool_format="qwen"),
     stop_words=["<|im_end|>"],
+    thought_words=("<think>", "</think>"),
     replace_eos=True,
     mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
     template_class=ReasoningTemplate,


### PR DESCRIPTION
### What does this PR do?

Sets `thought_words=("<think>", "</think>")` on the `qwen3_vl` template so that `<think>...</think>` blocks emitted before a JSON tool call in `function_call` messages are correctly stripped before `json.loads`.

### Why

The `qwen3_vl` template currently inherits the default `thought_words = ("<think>\n", "\n</think>\n\n")` from `register_template`:

https://github.com/hiyouga/LLaMA-Factory/blob/main/src/llamafactory/data/template.py#L528

The closing boundary requires **two** trailing newlines after `</think>`. ShareGPT-format SFT data that interleaves reasoning with tool calls commonly uses a single newline:

```
<think>
...
</think>
{"name": "...", "arguments": {...}}
```

When the regex in `FunctionFormatter.apply` does not match, the full string (including `<think>` tags) is fed to `json.loads` and the user gets:

> RuntimeError: Invalid JSON format in function message: ...

See:

https://github.com/hiyouga/LLaMA-Factory/blob/main/src/llamafactory/data/formatter.py#L122-L134

Loosening the boundary to `("<think>", "</think>")` lets the regex match either newline convention. The matched block is removed before JSON parsing and reattached to the formatted output:

https://github.com/hiyouga/LLaMA-Factory/blob/main/src/llamafactory/data/formatter.py#L133-L134

so no information is dropped — the thinking content still flows into the supervised loss as before.

### Reproduction (before this PR)

Train Qwen3-VL with `template: qwen3_vl` on a ShareGPT dataset whose `function_call` values look like:

```json
{"from": "function_call",
 "value": "<think>\nplan...\n</think>\n{\"name\":\"foo\",\"arguments\":{}}"}
```

Result: `RuntimeError: Invalid JSON format in function message`.

### After this PR

The same data trains without modification.

### Related

Reported in https://github.com/Schuture/Meissa/issues/4 — the Meissa-4B SFT data follows exactly this format.

### Test plan

- [x] Confirmed locally: `template: qwen3_vl` SFT run on the Meissa-SFT dataset (https://huggingface.co/datasets/CYX1998/Meissa-SFT) succeeds with this one-line change and otherwise vanilla LLaMA-Factory.
- [x] No effect on data without `<think>` blocks — the regex simply finds no match and falls through.
- [x] No effect on `qwen3_vl_nothink` (separate template, not modified).
