### PR TITLE
feat: support per-message loss control via inline loss field

### DIFF
--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -167,6 +167,7 @@ class SharegptDatasetConverter(DatasetConverter):
                 {
                     "role": tag_mapping[message[self.dataset_attr.role_tag]],
                     "content": message[self.dataset_attr.content_tag],
+                    "loss": message.get("loss", True),
                 }
             )
 

--- a/src/llamafactory/data/processor/supervised.py
+++ b/src/llamafactory/data/processor/supervised.py
@@ -69,7 +69,7 @@ class SupervisedDatasetProcessor(DatasetProcessor):
         if self.data_args.mask_history:
             encoded_pairs = encoded_pairs[::-1]  # high priority for last turns
 
-        for turn_idx, (source_ids, target_ids) in enumerate(encoded_pairs):
+        for turn_idx, (source_ids, target_ids, should_compute_loss) in enumerate(encoded_pairs):
             if total_length >= self.data_args.cutoff_len:
                 break
 
@@ -88,6 +88,8 @@ class SupervisedDatasetProcessor(DatasetProcessor):
                 source_label = [IGNORE_INDEX] * source_len
 
             if self.data_args.mask_history and turn_idx != 0:  # train on the last turn only
+                target_label = [IGNORE_INDEX] * target_len
+            elif not should_compute_loss:  # per-message loss control
                 target_label = [IGNORE_INDEX] * target_len
             else:
                 target_label = target_ids

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -80,10 +80,18 @@ class Template:
         system: Optional[str] = None,
         tools: Optional[str] = None,
         discarding_history_cot: bool = False,  # only effect reasoning template
-    ) -> list[tuple[list[int], list[int]]]:
-        r"""Return multiple pairs of token ids representing prompts and responses respectively."""
+    ) -> list[tuple[list[int], list[int], bool]]:
+        r"""Return multiple pairs of token ids representing prompts and responses respectively.
+
+        Returns:
+            list of (source_ids, target_ids, should_compute_loss)
+        """
         encoded_messages = self._encode(tokenizer, messages, system, tools)
-        return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(0, len(encoded_messages), 2)]
+        return [
+            (encoded_messages[i], encoded_messages[i + 1], messages[i + 1].get("loss", True))
+            for i in range(0, len(encoded_messages), 2)
+        ]
+
 
     def extract_tool(self, content: str) -> Union[str, list["FunctionCall"]]:
         r"""Extract tool message."""

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -451,7 +451,7 @@ class ReasoningTemplate(Template):
         system: Optional[str] = None,
         tools: Optional[str] = None,
         discarding_history_cot: bool = False,
-    ) -> list[tuple[list[int], list[int]]]:
+    ) -> list[tuple[list[int], list[int], bool]]:
         messages = deepcopy(messages)
         if self.enable_thinking is False:  # remove all cot
             for i in range(1, len(messages), 2):

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -477,7 +477,7 @@ class ReasoningTemplate(Template):
                 else:  # do compute loss
                     encoded_messages[i + 1] = self.get_thought_word_ids(tokenizer) + encoded_messages[i + 1]
 
-        return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(0, len(encoded_messages), 2)]
+        return [(encoded_messages[i], encoded_messages[i + 1], messages[i + 1].get("loss", True)) for i in range(0, len(encoded_messages), 2)]
 
 
 @dataclass


### PR DESCRIPTION
## Motivation

In mixed-scenario SFT training (pure dialogue + agentic tool-calling), we need fine-grained control over which assistant messages contribute to loss calculation. The existing `mask_history` option is all-or-nothing and cannot handle per-message granularity.

This addresses the same need as #9630, but with a **simpler and more robust design** that avoids the length-mismatch issues reported in that PR.

## Design Comparison with #9630

| Aspect | #9630 (`loss_mask` array) | This PR (inline `loss` field) |
|--------|--------------------------|-------------------------------|
| Format | Separate array at dataset root | Boolean field inside each message |
| Readability | Need to count indices | See loss flag right next to message |
| Maintainability | Must update array when adding/removing messages | Automatically follows the message |
| Tool-call robustness | ❌ Length mismatch when converter merges parallel tool responses | ✅ No length coupling, immune to merging |
| Backward compatibility | ✅ | ✅ (defaults to `true`) |

## Usage

```json
{
  "conversations": [
    {"from": "human", "value": "Hello"},
    {"from": "gpt", "value": "Hi!", "loss": false},
    {"from": "human", "value": "What's the weather in Beijing?"},
    {"from": "gpt", "value": "<tool_call>{...}</tool_call>", "loss": true},
    {"from": "observation", "value": "{\"weather\": \"sunny\"}"},
    {"from": "gpt", "value": "It's sunny in Beijing today.", "loss": true}
  ]
}
