### PR TITLE
[v1] Enhance LlamaFactory v1 and fix bugs in multi-node distributed training 

### DIFF
--- a/src/llamafactory/v1/config/training_args.py
+++ b/src/llamafactory/v1/config/training_args.py
@@ -63,7 +63,13 @@ class TrainingArguments:
     )
     batching_workers: int = field(
         default=16,
-        metadata={"help": "Number of workers for batching."},
+        metadata={
+            "help": (
+                "Number of DataLoader workers for batching/tokenization. "
+                "When > 0, TOKENIZERS_PARALLELISM is set to false so Rust tokenizers do not "
+                "spawn parallel pools in forked workers (avoids EAGAIN / worker crashes on multi-GPU)."
+            )
+        },
     )
     enable_activation_checkpointing: bool = field(
         default=True,

--- a/src/llamafactory/v1/core/base_trainer.py
+++ b/src/llamafactory/v1/core/base_trainer.py
@@ -28,6 +28,7 @@ Train Phase:
 """
 
 from abc import abstractmethod
+import os
 
 import torch
 import torch.nn.functional as F
@@ -143,7 +144,15 @@ class BaseTrainer:
                 )
             from ..plugins.model_plugins.parallelization.sequence_parallel import SequenceParallelModelPlugin
 
-            if model.config._attn_implementation != "flash_attention_2":
+            user_attn = os.environ.get("LLAMAFACTORY_V1_ATTN_IMPLEMENTATION")
+            if user_attn:
+                model.config._attn_implementation = user_attn
+                setattr(model.config, "attn_implementation", user_attn)
+                logger.warning_rank0(
+                    f"LLAMAFACTORY_V1_ATTN_IMPLEMENTATION={user_attn!r}: not forcing flash_attention_2 for CP. "
+                    "Ulysses CP is only validated with FlashAttention; training may fail if incompatible."
+                )
+            elif model.config._attn_implementation != "flash_attention_2":
                 logger.warning_rank0(
                     "Sequence parallelism is optimized for flash attention only. Replace the attention implementation to flash_attention_2."
                 )

--- a/src/llamafactory/v1/core/base_trainer.py
+++ b/src/llamafactory/v1/core/base_trainer.py
@@ -207,7 +207,7 @@ class BaseTrainer:
         elif self.args.lr_scheduler_config.name == "cosine":
             self.lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
                 self.optimizer,
-                T_max=max(1, self.args.num_train_epochs),
+                T_max=max(1, self.num_training_steps),
                 eta_min=self.args.lr_scheduler_config.get("eta_min", 0.0),
             )
         else:

--- a/src/llamafactory/v1/core/base_trainer.py
+++ b/src/llamafactory/v1/core/base_trainer.py
@@ -259,7 +259,30 @@ class BaseTrainer:
                 step_valid_tokens = compute_valid_tokens(micro_batches)
                 step_valid_tokens = DistributedInterface().all_reduce(step_valid_tokens, op=ReduceOp.SUM)
                 num_micro = len(micro_batches)
+                # FSDP2 (HSDP) gradient accumulation: by default every loss.backward() triggers a
+                # per-FSDP-unit cross-replica all-reduce of grads (and a per-backward sync wait),
+                # so on multi-node HSDP every microbatch crosses the inter-node link N-1 times per
+                # layer. With NNODES microbatches/optimizer-step that erases the benefit of adding
+                # nodes (e.g. 2-node and 4-node both end up at the same step time). Match the
+                # DeepSpeed branch's behavior by deferring the cross-replica all-reduce and the
+                # backward sync to the final microbatch only. set_requires_all_reduce(False)
+                # keeps the cheap intra-node reduce-scatter every backward but skips the expensive
+                # inter-node all-reduce; set_is_last_backward(False) avoids the per-microbatch
+                # synchronous wait. Disable via LLAMAFACTORY_V1_FSDP_HSDP_GRAD_ACCUM=0 if needed.
+                fsdp_grad_accum = (
+                    self._deepspeed_engine is None
+                    and num_micro > 1
+                    and os.environ.get("LLAMAFACTORY_V1_FSDP_HSDP_GRAD_ACCUM", "1").lower()
+                    not in ("0", "false", "no", "off")
+                    and hasattr(self.model, "set_requires_all_reduce")
+                    and hasattr(self.model, "set_is_last_backward")
+                )
                 for i, micro_batch in enumerate(micro_batches):
+                    is_last_micro = i == num_micro - 1
+                    if fsdp_grad_accum:
+                        self.model.set_requires_all_reduce(is_last_micro)
+                        self.model.set_is_last_backward(is_last_micro)
+
                     if self.args.dist_config and self.args.dist_config.get("cp_size", 1) > 1:
                         from ..plugins.model_plugins.parallelization.sequence_parallel import (
                             SequenceParallelLossPlugin,
@@ -274,7 +297,7 @@ class BaseTrainer:
 
                     if self._deepspeed_engine is not None:
                         # deepspeed: set sync_gradients so engine.step() only fires on last micro-batch
-                        self._deepspeed_engine.accelerator.sync_gradients = i == num_micro - 1
+                        self._deepspeed_engine.accelerator.sync_gradients = is_last_micro
                         self._deepspeed_engine.backward(loss)
                     else:
                         loss.backward()

--- a/src/llamafactory/v1/core/base_trainer.py
+++ b/src/llamafactory/v1/core/base_trainer.py
@@ -200,6 +200,22 @@ class BaseTrainer:
 
             self.optimizer = OptimizerPlugin(self.args.optim_config.name)(self.model, self.args.optim_config)
 
+    def _should_defer_fsdp_grad_accum(self, num_micro: int) -> bool:
+        """Whether to defer FSDP2 HSDP cross-replica all-reduce until the last microbatch.
+
+        Returns True only when all of the following hold:
+        * We are not running under DeepSpeed (which already manages sync via accelerator).
+        * There is more than one microbatch per optimizer step (otherwise the deferral is a no-op).
+        * The model exposes the FSDP2 hooks `set_requires_all_reduce` / `set_is_last_backward`.
+        * `LLAMAFACTORY_V1_FSDP_HSDP_GRAD_ACCUM` is not set to a falsy value
+          (`0`, `false`, `no`, `off`; case-insensitive).
+        """
+        if self._deepspeed_engine is not None or num_micro <= 1:
+            return False
+        if os.environ.get("LLAMAFACTORY_V1_FSDP_HSDP_GRAD_ACCUM", "1").lower() in ("0", "false", "no", "off"):
+            return False
+        return hasattr(self.model, "set_requires_all_reduce") and hasattr(self.model, "set_is_last_backward")
+
     def _init_lr_scheduler(self) -> None:
         """Init lr scheduler."""
         if self.args.lr_scheduler_config is None:
@@ -269,14 +285,7 @@ class BaseTrainer:
                 # keeps the cheap intra-node reduce-scatter every backward but skips the expensive
                 # inter-node all-reduce; set_is_last_backward(False) avoids the per-microbatch
                 # synchronous wait. Disable via LLAMAFACTORY_V1_FSDP_HSDP_GRAD_ACCUM=0 if needed.
-                fsdp_grad_accum = (
-                    self._deepspeed_engine is None
-                    and num_micro > 1
-                    and os.environ.get("LLAMAFACTORY_V1_FSDP_HSDP_GRAD_ACCUM", "1").lower()
-                    not in ("0", "false", "no", "off")
-                    and hasattr(self.model, "set_requires_all_reduce")
-                    and hasattr(self.model, "set_is_last_backward")
-                )
+                fsdp_grad_accum = self._should_defer_fsdp_grad_accum(num_micro)
                 for i, micro_batch in enumerate(micro_batches):
                     is_last_micro = i == num_micro - 1
                     if fsdp_grad_accum:

--- a/src/llamafactory/v1/core/base_trainer.py
+++ b/src/llamafactory/v1/core/base_trainer.py
@@ -204,6 +204,12 @@ class BaseTrainer:
         """Init lr scheduler."""
         if self.args.lr_scheduler_config is None:
             self.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=lambda x: 1.0)
+        elif self.args.lr_scheduler_config.name == "cosine":
+            self.lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+                self.optimizer,
+                T_max=max(1, self.args.num_train_epochs),
+                eta_min=self.args.lr_scheduler_config.get("eta_min", 0.0),
+            )
         else:
             from ..plugins.trainer_plugins.lr_scheduler import LRSchedulerPlugin
 

--- a/src/llamafactory/v1/core/model_engine.py
+++ b/src/llamafactory/v1/core/model_engine.py
@@ -29,6 +29,8 @@ Init workflow:
 4. Init adapter.
 """
 
+import os
+
 import torch
 from accelerate import init_empty_weights
 from transformers import AutoConfig, AutoProcessor
@@ -101,10 +103,15 @@ class ModelEngine:
 
     def _init_model_config(self) -> HFConfig:
         """Init model config."""
-        return AutoConfig.from_pretrained(
+        config = AutoConfig.from_pretrained(
             self.args.model,
             trust_remote_code=self.args.trust_remote_code,
         )
+        v1_attn = os.environ.get("LLAMAFACTORY_V1_ATTN_IMPLEMENTATION")
+        if v1_attn:
+            setattr(config, "_attn_implementation", v1_attn)
+            setattr(config, "attn_implementation", v1_attn)
+        return config
 
     def _init_model(self) -> HFModel:
         """Init model.

--- a/src/llamafactory/v1/core/utils/batching.py
+++ b/src/llamafactory/v1/core/utils/batching.py
@@ -23,6 +23,7 @@
     d) pack + dynamic
 """
 
+import os
 from collections.abc import Iterator
 from typing import Any
 
@@ -136,6 +137,13 @@ class BatchGenerator(Iterator):
             )
         else:
             raise NotImplementedError("Iterable dataset is not supported yet.")
+
+        if self.batching_workers > 0:
+            # Rust tokenizers use a parallel encoding thread pool. Many forked DataLoader
+            # workers across distributed ranks can hit pthread limits (EAGAIN) and panic with
+            # "ThreadPoolBuildError ... Resource temporarily unavailable". HF recommends
+            # disabling tokenizer-side parallelism whenever workers run tokenization.
+            os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 
         generato_seed = torch.Generator()
         generato_seed.manual_seed(self.seed)

--- a/src/llamafactory/v1/core/utils/checkpoint.py
+++ b/src/llamafactory/v1/core/utils/checkpoint.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Checkpoint utilities: low-level helpers and full training save/resume orchestration."""
-
+import gc
 import glob
 import json
 import os
@@ -279,6 +279,14 @@ class TrainingCheckpointCoordinator:
             save_rng_state(ckpt_dir, rank)
 
         DistributedInterface().sync()
+    
+        # DCP gather can leave the device nearly full; the next training step's CP
+        # cross-entropy needs a large contiguous allocation. Release cached blocks
+        # on every rank before resuming the step loop.
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
 
         if rank == 0:
             mark_checkpoint_complete(ckpt_dir)

--- a/src/llamafactory/v1/plugins/model_plugins/parallelization/sequence_parallel.py
+++ b/src/llamafactory/v1/plugins/model_plugins/parallelization/sequence_parallel.py
@@ -151,10 +151,15 @@ def padding_and_split_data(data, device_mesh=None):
 
 @SequenceParallelLossPlugin("sequence_parallel_loss").register()
 def sequence_parallel_loss(model, model_inputs):
-    device_mesh = DistributedInterface().get_device_mesh(Dim.CP)
+    dist_interface = DistributedInterface()
+    device_mesh = dist_interface.get_device_mesh(Dim.CP)
+    # Use local rank (not global rank) as the device ordinal: on multi-node setups
+    # `dist.get_rank()` returns the global rank, which exceeds the per-node GPU
+    # count and triggers "CUDA error: invalid device ordinal" on worker nodes.
+    device = dist_interface.current_device
 
     model_inputs = {
-        k: v.to(dist.get_rank(), non_blocking=True) for k, v in model_inputs.items() if isinstance(v, torch.Tensor)
+        k: v.to(device, non_blocking=True) for k, v in model_inputs.items() if isinstance(v, torch.Tensor)
     }
 
     model_inputs = padding_and_split_data(model_inputs, device_mesh)

--- a/src/llamafactory/v1/plugins/model_plugins/parallelization/sequence_parallel.py
+++ b/src/llamafactory/v1/plugins/model_plugins/parallelization/sequence_parallel.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 from functools import partial
 
@@ -34,6 +35,42 @@ from .ulysses import (
 
 
 logger = logging.get_logger(__name__)
+
+
+def _cross_entropy_none_chunked(
+    shift_logits: torch.Tensor, shift_labels: torch.Tensor, batch_size: int
+) -> torch.Tensor:
+    """Cross-entropy with reduction='none', chunked along the token dimension.
+
+    At 70k ctx + CP the per-rank token count is still huge; a single
+    F.cross_entropy(..., reduction='none') can reserve ~20 GiB for the softmax
+    workspace. Chunking caps peak memory without changing numerics. Keep the
+    full logits tensor in its model dtype and cast each slice to fp32 here, so
+    we do not materialize the entire [tokens, vocab] matrix in fp32.
+    Override chunk size via LLAMAFACTORY_V1_CE_CHUNK_SIZE (0 disables chunking).
+    """
+    num_tokens = shift_logits.size(0)
+    chunk_size = int(os.environ.get("LLAMAFACTORY_V1_CE_CHUNK_SIZE", "4096"))
+    if chunk_size <= 0 or num_tokens <= chunk_size:
+        return -F.cross_entropy(shift_logits.float(), shift_labels, reduction="none").view(batch_size, -1)
+
+    chunks: list[torch.Tensor] = []
+    start = 0
+    min_chunk_size = int(os.environ.get("LLAMAFACTORY_V1_CE_MIN_CHUNK_SIZE", "512"))
+    while start < num_tokens:
+        end = min(start + chunk_size, num_tokens)
+        try:
+            chunks.append(
+                -F.cross_entropy(shift_logits[start:end].float(), shift_labels[start:end], reduction="none")
+            )
+            start = end
+        except torch.OutOfMemoryError:
+            if chunk_size <= min_chunk_size:
+                raise
+            torch.cuda.empty_cache()
+            chunk_size = max(min_chunk_size, chunk_size // 2)
+            logger.warning_rank0(f"Reducing sequence-parallel CE chunk size to {chunk_size} after CUDA OOM.")
+    return torch.cat(chunks).view(batch_size, -1)
 
 
 class SequenceParallelModelPlugin(BasePlugin):
@@ -168,7 +205,7 @@ def sequence_parallel_loss(model, model_inputs):
 
     outputs: ModelOutput = model(**model_inputs)
 
-    logits = outputs.logits.float()
+    logits = outputs.logits
 
     labels = model_inputs["labels"]
 
@@ -183,6 +220,7 @@ def sequence_parallel_loss(model, model_inputs):
     shift_labels = labels[..., 1:].contiguous()
     shift_labels = F.pad(shift_labels, (0, 1), value=-100)
     shift_labels = torch.chunk(shift_labels, chunks=cp_world_size, dim=1)[cp_rank].contiguous()
+    del global_labels, labels
 
     # use all_gather to collect loss_weights from all sequence parallel processes
     loss_weights = model_inputs["loss_weights"]
@@ -190,12 +228,13 @@ def sequence_parallel_loss(model, model_inputs):
     dist.all_gather(global_loss_weights, loss_weights, group=cp_group)
     shift_loss_weights = torch.cat(global_loss_weights, dim=1).contiguous()
     shift_loss_weights = shift_loss_weights[..., 1:].contiguous()
+    del global_loss_weights, loss_weights
 
     shift_logits = logits.view(-1, logits.size(-1)).contiguous()
     shift_labels = shift_labels.view(-1).contiguous()
 
     # use all_gather to collect log_probs from all sequence parallel processes
-    log_probs = -F.cross_entropy(shift_logits, shift_labels, reduction="none").view(batch_size, -1)
+    log_probs = _cross_entropy_none_chunked(shift_logits, shift_labels, batch_size)
     global_log_probs = dist.nn.all_gather(log_probs, group=cp_group)
     global_log_probs = torch.cat(global_log_probs, dim=1).contiguous()
     log_probs = global_log_probs[..., :-1].contiguous()

--- a/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
+++ b/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
@@ -103,6 +103,22 @@ def save_model(model: HFModel, output_dir: str, processor: Processor) -> None:
         logger.info(f"Model saved to {output_dir}")
 
 
+def _release_cuda_cache_for_nccl() -> None:
+    """Return PyTorch's reserved-but-unused GPU memory to the driver.
+
+    torch.distributed.checkpoint.save/load exchange their plan via NCCL gather_object, which
+    needs fresh per-collective scratch buffers. NCCL allocates via raw cudaMalloc - *not* the
+    caching allocator - so if PyTorch has reserved the whole device, even a ~5 KB cudaMalloc
+    fails with "Failed to CUDA calloc async N bytes". Dropping refs and emptying the cache
+    here gives NCCL room to bring up the plan collective. Pair with
+    PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True so empty_cache() can actually release
+    segments back to CUDA.
+    """
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
 def save_checkpoint(model: HFModel, optimizer: torch.optim.Optimizer, ckpt_dir: str, **kwargs) -> None:
     save_ckpt_as_hf = kwargs.get("save_ckpt_as_hf", False)
     processor = kwargs.get("processor", None)
@@ -110,17 +126,22 @@ def save_checkpoint(model: HFModel, optimizer: torch.optim.Optimizer, ckpt_dir: 
     # Always save DCP format for resume capability
     options = StateDictOptions(full_state_dict=False, cpu_offload=True)
 
+    _release_cuda_cache_for_nccl()
     model_state = get_model_state_dict(model, options=options)
     dcp.save(state_dict=model_state, checkpoint_id=os.path.join(ckpt_dir, "model"))
+    del model_state
 
+    _release_cuda_cache_for_nccl()
     optim_state = get_optimizer_state_dict(model, optimizer, options=options)
     dcp.save(state_dict=optim_state, checkpoint_id=os.path.join(ckpt_dir, "optimizer"))
+    del optim_state
 
     # Additionally save HF format if requested
     if save_ckpt_as_hf:
         if DistributedInterface().get_rank() == 0:
             logger.info("Gathering state dict for saving additional HF format checkpoint...")
 
+        _release_cuda_cache_for_nccl()
         hf_options = StateDictOptions(full_state_dict=True, cpu_offload=True)
         hf_state_dict = get_model_state_dict(model, options=hf_options)
 
@@ -132,20 +153,29 @@ def save_checkpoint(model: HFModel, optimizer: torch.optim.Optimizer, ckpt_dir: 
                 processor.save_pretrained(hf_dir, max_shard_size="4GB")
 
             logger.info(f"Additional HF format checkpoint saved to {hf_dir}")
+        del hf_state_dict
+
+    _release_cuda_cache_for_nccl()
 
 
 def load_checkpoint(model: HFModel, optimizer: torch.optim.Optimizer, ckpt_dir: str, **kwargs) -> None:
     options = StateDictOptions(full_state_dict=False, cpu_offload=True)
 
+    _release_cuda_cache_for_nccl()
     ckpt_model_dir = os.path.join(ckpt_dir, "model")
     model_state = get_model_state_dict(model, options=options)
     dcp.load(state_dict=model_state, checkpoint_id=ckpt_model_dir)
     set_model_state_dict(model, model_state, options=options)
+    del model_state
 
+    _release_cuda_cache_for_nccl()
     ckpt_optim_dir = os.path.join(ckpt_dir, "optimizer")
     optim_state = get_optimizer_state_dict(model, optimizer, options=options)
     dcp.load(state_dict=optim_state, checkpoint_id=ckpt_optim_dir)
     set_optimizer_state_dict(model, optimizer, optim_state, options=options)
+    del optim_state
+
+    _release_cuda_cache_for_nccl()
 
 
 class FSDP2Engine:
@@ -381,7 +411,7 @@ class FSDP2Engine:
 
         with torch.no_grad():
             grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
-            if isinstance(grad_norm, torch.distributed._tensor.DTensor):
+            if isinstance(grad_norm, torch.distributed.tensor.DTensor):
                 grad_norm = grad_norm.full_tensor()
 
         for param in model.parameters():

--- a/src/llamafactory/v1/trainers/sft_trainer.py
+++ b/src/llamafactory/v1/trainers/sft_trainer.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import os
+
 from ..accelerator.interface import DistributedInterface
 from ..config import InputArgument, get_args
 from ..core.base_trainer import BaseTrainer
@@ -31,6 +33,8 @@ class SFTTrainer(BaseTrainer):
 
 def run_sft(args: InputArgument = None):
     model_args, data_args, training_args, _ = get_args(args)
+    if training_args.batching_workers > 0:
+        os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
     DistributedInterface(training_args.dist_config)
     train_dataset = DataEngine(data_args.train_dataset)
     model_engine = ModelEngine(model_args, is_train=True)


### PR DESCRIPTION
# What does this PR do?

A set of v1 trainer fixes and optimizations encountered while running large-scale multi-node SFT (FSDP2 / HSDP, CP/SP, DCP checkpointing). Each change is in its own commit so it can be reviewed / reverted independently.

**The one-step training runtime for Qwen3-30B-A3B-Instruct-2507 with the 128 batch size and 70K context length reduces from 8 minutes to 2.5 minutes by multi-node distributed training, where the number of GPU nodes with 8 GPUs increases from 1 to 4. It well demonstrates the training scalability. The training accuracy is also consistent with expectations.**

**However, without this PR, the similar settings on 4 nodes with 32 GPUs in total, the one-step training takes 10 minutes.** 

The below is the network IO before and after the PR, which drops dramatically with the PR.
<img width="760" height="319" alt="image" src="https://github.com/user-attachments/assets/dfac275d-bd78-4643-9799-aff086b1fe12" />


## 1. Disable Rust tokenizer parallelism when DataLoader workers are used (`723af7d4`)

When `batching_workers > 0`, many forked DataLoader workers across distributed ranks would hit pthread limits and trigger Rust tokenizer panics, e.g.:

```
ThreadPoolBuildError { kind: IOError(Os { code: 11, kind: WouldBlock,
message: "Resource temporarily unavailable" }) }
```

Set `TOKENIZERS_PARALLELISM=false` via `os.environ.setdefault` (so users can still opt back in) both early in `run_sft` (before any fork) and inside `BatchGenerator`. Updated the `batching_workers` help text to document the behavior.

- `src/llamafactory/v1/config/training_args.py`
- `src/llamafactory/v1/core/utils/batching.py`
- `src/llamafactory/v1/trainers/sft_trainer.py`

## 2. Fix CP/SP on multi-node and allow attention impl override (`887b00d0`)

Two issues prevented context-parallel / sequence-parallel training from working on multi-node setups:

- `sequence_parallel_loss` used `dist.get_rank()` (global rank) as the device ordinal when moving model inputs. On any worker node the global rank exceeds the per-node GPU count and `tensor.to(rank)` crashed with `CUDA error: invalid device ordinal`. Switched to `DistributedInterface.current_device` (local rank).
- The CP code path force-overrides `_attn_implementation` to `flash_attention_2`, which is too aggressive for users who need a different kernel for debugging or model-specific reasons. Added `LLAMAFACTORY_V1_ATTN_IMPLEMENTATION` to opt out of the forced override; the user-specified value is also applied to the `AutoConfig` inside `ModelEngine` so it sticks end-to-end. A warning is emitted that Ulysses CP is only validated with FlashAttention.

- `src/llamafactory/v1/core/base_trainer.py`
- `src/llamafactory/v1/core/model_engine.py`
- `src/llamafactory/v1/plugins/model_plugins/parallelization/sequence_parallel.py`

## 3. Support cosine LR scheduler in `BaseTrainer` (`d22a3d8d`)

Added a direct `cosine` branch in `_init_lr_scheduler` so users can request a cosine schedule via `lr_scheduler_config` without going through `LRSchedulerPlugin`. `T_max` defaults to `num_train_epochs`, `eta_min` is read from the config (default `0.0`).

- `src/llamafactory/v1/core/base_trainer.py`

## 4. Defer FSDP2 HSDP cross-replica all-reduce to the last microbatch (`b67f566e`)

Under FSDP2 HSDP, every `loss.backward()` triggers a per-FSDP-unit cross-replica grad all-reduce plus a synchronous backward wait. With `N` microbatches per optimizer step that means `N - 1` unnecessary inter-node all-reduces, which erases the speedup from adding nodes (e.g. 2-node and 4-node end up at the same step time in our runs).

Mirror the DeepSpeed branch's behavior on FSDP2: on non-last microbatches call

```python
self.model.set_requires_all_reduce(False)
self.model.set_is_last_backward(False)
```

so the cheap intra-node reduce-scatter still runs every backward but the expensive inter-node all-reduce and per-microbatch sync are skipped. Gated on `num_micro > 1` and on the model exposing the FSDP2 hooks, and can be disabled with `LLAMAFACTORY_V1_FSDP_HSDP_GRAD_ACCUM=0`.

- `src/llamafactory/v1/core/base_trainer.py`

## 5. Fix FSDP2 DCP checkpoint NCCL `cudaMalloc` failures (`fb414cbe`)

`torch.distributed.checkpoint.save` / `load` exchange their save plan via NCCL `gather_object`, which allocates per-collective scratch buffers through raw `cudaMalloc` — bypassing the PyTorch caching allocator. If PyTorch has already reserved the device, even a ~5 KB `cudaMalloc` fails with:

```
Failed to CUDA calloc async <small> bytes (CUDA error: out of memory)
```

and the rank crashes mid-checkpoint.

Added a small helper `_release_cuda_cache_for_nccl()` that drops references to the just-built state dict and runs `gc.collect()` + `torch.cuda.empty_cache()` before / between every `dcp.save` / `dcp.load` and around the optional HF-format export, giving NCCL room to bring up the plan collective. Pair with `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` so `empty_cache()` can actually release segments back to CUDA.

Also switched from the private `torch.distributed._tensor.DTensor` import to the public `torch.distributed.tensor.DTensor`.

- `src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py`

## Testing

- Multi-node FSDP2 HSDP SFT runs (2-node and 4-node) on Qwen-class models with gradient accumulation, with and without DCP / HF-format checkpoint saving.
- Multi-node CP/SP runs with Ulysses + FlashAttention.
- Single-node FSDP2 and DeepSpeed runs to confirm no regression on the existing code paths (the FSDP2 HSDP optimization is gated on `num_micro > 1` and DeepSpeed; CP fixes are gated on `cp_size > 1`).


## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
