### PR TITLE
[Device-Metrics]: Add support to dump device metrics in log

### DIFF
--- a/src/llamafactory/train/callbacks.py
+++ b/src/llamafactory/train/callbacks.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import csv
+import io
 import json
 import os
 import signal
+import subprocess
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -48,6 +51,118 @@ if TYPE_CHECKING:
 
 
 logger = logging.get_logger(__name__)
+
+_XPU_TELEMETRY_FIELDS: tuple[tuple[tuple[str, ...], str], ...] = (
+    # Compute utilization: metric 0 ("GPU Utilization (%)") is preferred but is often
+    # reported as N/A on Arc/BMG and some PVC firmwares. Fall back to compute-engine
+    # group util (metric 31) and EU array active (metric 9) when available.
+    (
+        (
+            "GPU Utilization (%)",
+            "Compute engine group utilization (%)",
+            "GPU EU Array Active (%)",
+        ),
+        "xpu_compute_util_pct",
+    ),
+    (("GPU Memory Utilization (%)",), "xpu_mem_bandwidth_pct"),
+    (("GPU Memory Used (MiB)",), "xpu_mem_in_use_mib"),
+)
+
+
+def _sample_xpu_device_metrics(device_id: int = 0) -> dict[str, float]:
+    r"""Sample per-device XPU telemetry via the ``xpu-smi dump`` interface.
+
+    ``xpu-smi dump`` emits CSV (the ``-j`` flag is only honored by ``stats``/``discovery``),
+    so we parse the header row to map column names onto our metric keys. Returns an
+    empty dict if ``xpu-smi`` is missing, times out, or returns malformed output.
+    A single warning is logged per failure mode.
+
+    Metric IDs requested: 0=GPU Util, 5=Mem Util, 9=EU Active, 18=Mem Used (MiB),
+    31=Compute Engine Group Util. Metric 0 is preferred for compute utilization but
+    falls back to 31 then 9 when N/A on the device.
+    """
+    metrics: dict[str, float] = {}
+    cmd = ["xpu-smi", "dump", "-d", str(device_id), "-m", "0,5,9,18,31", "-n", "1"]
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+    except FileNotFoundError:
+        logger.warning_rank0_once(
+            "xpu-smi binary not found on PATH; XPU telemetry will be skipped. "
+            "Install Intel XPU Manager or unset RECORD_XPU to silence this warning."
+        )
+        return metrics
+    except subprocess.TimeoutExpired:
+        logger.warning_rank0_once("xpu-smi query timed out; XPU telemetry will be skipped for this step.")
+        return metrics
+    except Exception as err:
+        logger.warning_rank0_once(f"xpu-smi query failed ({err!r}); XPU telemetry will be skipped.")
+        return metrics
+
+    if proc.returncode != 0:
+        logger.warning_rank0_once(
+            f"xpu-smi exited with code {proc.returncode}; XPU telemetry will be skipped. "
+            f"stderr: {proc.stderr.strip()[:200]}"
+        )
+        return metrics
+
+    rows = list(csv.reader(io.StringIO(proc.stdout)))
+    # Expect a header line plus at least one data row.
+    data_rows = [r for r in rows if r and r[0].strip()]
+    if len(data_rows) < 2:
+        logger.warning_rank0_once("xpu-smi returned no data rows; XPU telemetry will be skipped.")
+        return metrics
+
+    header = [col.strip() for col in data_rows[0]]
+    values = [col.strip() for col in data_rows[1]]
+    row = dict(zip(header, values))
+
+    for src_keys, dst_key in _XPU_TELEMETRY_FIELDS:
+        for src_key in src_keys:
+            raw = row.get(src_key)
+            if raw is None or raw == "" or raw.lower() == "n/a":
+                continue
+            try:
+                metrics[dst_key] = round(float(raw), 2)
+                break
+            except (ValueError, TypeError):
+                continue
+
+    return metrics
+
+
+def _sample_host_resource_usage() -> dict[str, float]:
+    r"""Sample host-side CPU and RAM utilization via ``psutil``.
+
+    Returns an empty dict when ``psutil`` is not installed (warned once). The first
+    call to ``psutil.cpu_percent(interval=None)`` always returns 0.0; this helper
+    primes the counter on its first invocation so later samples reflect real activity.
+    """
+    try:
+        import psutil  # type: ignore[import-not-found]
+    except ImportError:
+        logger.warning_rank0_once(
+            "psutil is not installed; host CPU/RAM telemetry will be skipped. "
+            "Run `pip install psutil` or unset RECORD_CPU to silence this warning."
+        )
+        return {}
+
+    # Prime the non-blocking CPU counter exactly once at the start.
+    if not getattr(_sample_host_resource_usage, "_primed", False):
+        psutil.cpu_percent(interval=None)
+        _sample_host_resource_usage._primed = True
+        return {}
+
+    try:
+        vmem = psutil.virtual_memory()
+        return {
+            "host_cpu_busy_pct": round(psutil.cpu_percent(interval=None), 2),
+            "host_ram_in_use_gib": round(vmem.used / (1024**3), 2),
+            "host_ram_full_pct": round(vmem.percent, 2),
+        }
+    except Exception as err:
+        logger.warning_rank0_once(f"psutil host query failed ({err!r}); CPU telemetry will be skipped.")
+        return {}
 
 
 def fix_valuehead_checkpoint(
@@ -294,6 +409,20 @@ class LogCallback(TrainerCallback):
             vram_allocated, vram_reserved = get_peak_memory()
             logs["vram_allocated"] = round(vram_allocated / (1024**3), 2)
             logs["vram_reserved"] = round(vram_reserved / (1024**3), 2)
+
+        # XPU telemetry via xpu-smi (opt-in via RECORD_XPU=1)
+        if is_env_enabled("RECORD_XPU"):
+            device_id = 0
+            if hasattr(torch, "xpu") and torch.xpu.is_available():
+                try:
+                    device_id = torch.xpu.current_device()
+                except Exception:
+                    device_id = 0
+            logs.update(_sample_xpu_device_metrics(device_id))
+
+        # Host CPU / RAM telemetry via psutil (opt-in via RECORD_CPU=1)
+        if is_env_enabled("RECORD_CPU"):
+            logs.update(_sample_host_resource_usage())
 
         logs = {k: v for k, v in logs.items() if v is not None}
         if self.webui_mode and all(key in logs for key in ("loss", "lr", "epoch")):

--- a/src/llamafactory/train/callbacks.py
+++ b/src/llamafactory/train/callbacks.py
@@ -53,17 +53,9 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 _XPU_TELEMETRY_FIELDS: tuple[tuple[tuple[str, ...], str], ...] = (
-    # Compute utilization: metric 0 ("GPU Utilization (%)") is preferred but is often
-    # reported as N/A on Arc/BMG and some PVC firmwares. Fall back to compute-engine
-    # group util (metric 31) and EU array active (metric 9) when available.
-    (
-        (
-            "GPU Utilization (%)",
-            "Compute engine group utilization (%)",
-            "GPU EU Array Active (%)",
-        ),
-        "xpu_compute_util_pct",
-    ),
+    # Compute utilization: use metric 31 (Compute engine group utilization) which
+    # measures compute engines only, providing the most accurate view of AI/ML workload.
+    (("Compute engine group utilization (%)",), "xpu_compute_util_pct"),
     (("GPU Memory Utilization (%)",), "xpu_mem_bandwidth_pct"),
     (("GPU Memory Used (MiB)",), "xpu_mem_in_use_mib"),
 )
@@ -77,15 +69,14 @@ def _sample_xpu_device_metrics(device_id: int = 0) -> dict[str, float]:
     empty dict if ``xpu-smi`` is missing, times out, or returns malformed output.
     A single warning is logged per failure mode.
 
-    Metric IDs requested: 0=GPU Util, 5=Mem Util, 9=EU Active, 18=Mem Used (MiB),
-    31=Compute Engine Group Util. Metric 0 is preferred for compute utilization but
-    falls back to 31 then 9 when N/A on the device.
+    Metric IDs requested: 5=Mem Util, 18=Mem Used (MiB), 31=Compute Engine Group Util.
+    Metric 31 provides the most accurate compute utilization for AI/ML workloads.
     """
     metrics: dict[str, float] = {}
-    cmd = ["xpu-smi", "dump", "-d", str(device_id), "-m", "0,5,9,18,31", "-n", "1"]
+    cmd = ["sudo", "xpu-smi", "dump", "-d", str(device_id), "-m", "5,18,31", "-n", "1"]
 
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=3)
     except FileNotFoundError:
         logger.warning_rank0_once(
             "xpu-smi binary not found on PATH; XPU telemetry will be skipped. "
@@ -134,12 +125,14 @@ def _sample_xpu_device_metrics(device_id: int = 0) -> dict[str, float]:
 def _sample_host_resource_usage() -> dict[str, float]:
     r"""Sample host-side CPU and RAM utilization via ``psutil``.
 
-    Returns an empty dict when ``psutil`` is not installed (warned once). The first
-    call to ``psutil.cpu_percent(interval=None)`` always returns 0.0; this helper
-    primes the counter on its first invocation so later samples reflect real activity.
+    Returns an empty dict when ``psutil`` is not installed (warned once). RAM metrics
+    are always included when available. The first call to ``psutil.cpu_percent(interval=None)``
+    has no prior sample to diff against and would report 0.0, so ``host_cpu_busy_pct``
+    is omitted on the first invocation; the counter is primed and reported from the
+    second invocation onward.
     """
     try:
-        import psutil  # type: ignore[import-not-found]
+        import psutil
     except ImportError:
         logger.warning_rank0_once(
             "psutil is not installed; host CPU/RAM telemetry will be skipped. "
@@ -147,21 +140,22 @@ def _sample_host_resource_usage() -> dict[str, float]:
         )
         return {}
 
-    # Prime the non-blocking CPU counter exactly once at the start.
-    if not getattr(_sample_host_resource_usage, "_primed", False):
-        psutil.cpu_percent(interval=None)
-        _sample_host_resource_usage._primed = True
-        return {}
-
     try:
+        first_call = not getattr(_sample_host_resource_usage, "_primed", False)
+        cpu_pct = psutil.cpu_percent(interval=None)
+        _sample_host_resource_usage._primed = True
+
         vmem = psutil.virtual_memory()
-        return {
-            "host_cpu_busy_pct": round(psutil.cpu_percent(interval=None), 2),
+        result: dict[str, float] = {
             "host_ram_in_use_gib": round(vmem.used / (1024**3), 2),
             "host_ram_full_pct": round(vmem.percent, 2),
         }
+
+        if not first_call:
+            result["host_cpu_busy_pct"] = round(cpu_pct, 2)
+        return result
     except Exception as err:
-        logger.warning_rank0_once(f"psutil host query failed ({err!r}); CPU telemetry will be skipped.")
+        logger.warning_rank0_once(f"psutil host query failed ({err!r}); host telemetry will be skipped.")
         return {}
 
 
@@ -329,6 +323,22 @@ class LogCallback(TrainerCallback):
         with open(os.path.join(output_dir, TRAINER_LOG), "a", encoding="utf-8") as f:
             f.write(json.dumps(logs) + "\n")
 
+    def _sample_and_write_log(self, output_dir: str, logs: dict[str, Any], device_id: int) -> None:
+        r"""Sample device/host metrics on the worker thread and append to the log file.
+
+        ``_sample_xpu_device_metrics`` shells out to ``xpu-smi`` (subprocess + IO) and
+        ``_sample_host_resource_usage`` calls ``psutil``; both are blocking. Running them
+        here keeps the main training thread free, which matters when ``logging_steps`` is
+        small. Metrics are not used by the Web UI's inline log line, so deferring them
+        only affects the persisted ``trainer_log.jsonl`` content.
+        """
+        if is_env_enabled("RECORD_XPU"):
+            logs.update(_sample_xpu_device_metrics(device_id))
+        if is_env_enabled("RECORD_CPU"):
+            logs.update(_sample_host_resource_usage())
+        logs = {k: v for k, v in logs.items() if v is not None}
+        self._write_log(output_dir, logs)
+
     def _create_thread_pool(self, output_dir: str) -> None:
         os.makedirs(output_dir, exist_ok=True)
         self.thread_pool = ThreadPoolExecutor(max_workers=1)
@@ -410,21 +420,16 @@ class LogCallback(TrainerCallback):
             logs["vram_allocated"] = round(vram_allocated / (1024**3), 2)
             logs["vram_reserved"] = round(vram_reserved / (1024**3), 2)
 
-        # XPU telemetry via xpu-smi (opt-in via RECORD_XPU=1)
-        if is_env_enabled("RECORD_XPU"):
-            device_id = 0
-            if hasattr(torch, "xpu") and torch.xpu.is_available():
-                try:
-                    device_id = torch.xpu.current_device()
-                except Exception:
-                    device_id = 0
-            logs.update(_sample_xpu_device_metrics(device_id))
+        # Resolve the active XPU device on the main thread (cheap torch query) so the
+        # worker can sample without touching torch state. Actual xpu-smi / psutil
+        # sampling is offloaded below to avoid blocking training on logging steps.
+        xpu_device_id = 0
+        if is_env_enabled("RECORD_XPU") and hasattr(torch, "xpu") and torch.xpu.is_available():
+            try:
+                xpu_device_id = torch.xpu.current_device()
+            except Exception:
+                xpu_device_id = 0
 
-        # Host CPU / RAM telemetry via psutil (opt-in via RECORD_CPU=1)
-        if is_env_enabled("RECORD_CPU"):
-            logs.update(_sample_host_resource_usage())
-
-        logs = {k: v for k, v in logs.items() if v is not None}
         if self.webui_mode and all(key in logs for key in ("loss", "lr", "epoch")):
             log_str = f"'loss': {logs['loss']:.4f}, 'learning_rate': {logs['lr']:2.4e}, 'epoch': {logs['epoch']:.2f}"
             for extra_key in ("reward", "accuracy", "throughput"):
@@ -434,7 +439,9 @@ class LogCallback(TrainerCallback):
             logger.info_rank0("{" + log_str + "}")
 
         if self.thread_pool is not None:
-            self.thread_pool.submit(self._write_log, args.output_dir, logs)
+            # Offload XPU/host sampling (xpu-smi subprocess + psutil) plus the file write
+            # onto the single-worker pool so they cannot stall the training step.
+            self.thread_pool.submit(self._sample_and_write_log, args.output_dir, logs, xpu_device_id)
 
     @override
     def on_prediction_step(


### PR DESCRIPTION
### **Summary**
Add feature for per-step dump of device & host telemetry to LogCallback, writing extra fields into trainer_log.jsonl:

| Field | Source | Gate |
|---|---|---|
| `xpu_compute_util_pct`, `xpu_mem_bandwidth_pct`, `xpu_mem_in_use_mib` | `xpu-smi dump`  | `RECORD_XPU=1` |
| `host_cpu_busy_pct`, `host_ram_in_use_gib`, `host_ram_full_pct` | `psutil` | `RECORD_CPU=1` |

Both these groups are off by default — zero behavior change unless the corresponding env var is set. Each tool is probed at runtime; missing tools emit a single rank-0 warning and the metric is silently skipped.

### **Metric Description**
1. xpu_compute_util_pct: percentage of time the XPU compute engines were actively executing work.
2. xpu_compute_util_pct: percentage of time the XPU memory subsystem (VRAM bus) was busy transferring data.
3. xpu_mem_in_use_mib: percentage of total host RAM currently in use.
4. host_cpu_busy_pct: percentage of time host CPU cores were actively executing work.
5. host_ram_in_use_gib: absolute amount of system RAM currently in use(GiB).
6. host_ram_full_pct: percentage of total system RAM currently in use.

### **Motivation**
Trainer logs currently only carry loss/throughput/learning-rate. When debugging long fine-tunes on Intel XPU and on heterogeneous host configurations, it's helpful to correlate loss curves with GPU compute utilization, GPU memory pressure, and host-side CPU/RAM usage — without bolting on a separate observability stack. Today this requires running xpu-smi / intel_gpu_top / htop in parallel and aligning timestamps by eye.

### **Implementation**

1. XPU sampling (_sample_xpu_device_metrics): runs xpu-smi dump -m 0,5,9,18,31 , parses the CSV header, maps column candidates onto our metric keys. N/A and empty cells are filtered.
2. Host sampling (_sample_host_resource_usage): psutil primed once on first call so subsequent non-blocking cpu_percent reads are accurate.
3. All warnings use logger.warning_rank0_once so misconfigured hosts don't spam the log every step.


### **Testing**
Verified on  a BMG setup:

**Default**
> {"current_steps": 1, "total_steps": 36, "loss": 6.140847206115723, "lr": 0.0, "epoch": 0.08695652173913043, "percentage": 2.78, "elapsed_time": "0:00:36", "remaining_time": "0:21:33"}
{"current_steps": 2, "total_steps": 36, "loss": 7.800095081329346, "lr": 5e-05, "epoch": 0.17391304347826086, "percentage": 5.56, "elapsed_time": "0:01:17", "remaining_time": "0:21:49"}


**With RECORD_CPU=1 & RECORD_XPU=1**
> {"current_steps": 5, "total_steps": 36, "loss": 3.7397549152374268, "lr": 0.0002, "epoch": 0.43478260869565216, "percentage": 13.89, "elapsed_time": "0:00:04", "remaining_time": "0:00:29", "xpu_compute_util_pct": 95.9, "xpu_mem_bandwidth_pct": 50.75, "xpu_mem_in_use_mib": 16573.91, "host_ram_in_use_gib": 4.72, "host_ram_full_pct": 15.6, "host_cpu_busy_pct": 5.9}
{"current_steps": 6, "total_steps": 36, "loss": 2.5100693702697754, "lr": 0.0001995184726672197, "epoch": 0.5217391304347826, "percentage": 16.67, "elapsed_time": "0:00:05", "remaining_time": "0:00:27", "xpu_compute_util_pct": 99.99, "xpu_mem_bandwidth_pct": 50.75, "xpu_mem_in_use_mib": 16573.92, "host_ram_in_use_gib": 4.79, "host_ram_full_pct": 15.8, "host_cpu_busy_pct": 5.7}

