### PR TITLE
fix(api_example): guard against IndexError on empty choices list

### DIFF
--- a/scripts/api_example/test_image.py
+++ b/scripts/api_example/test_image.py
@@ -40,6 +40,9 @@ def main():
         }
     )
     result = client.chat.completions.create(messages=messages, model="test")
+    if not result.choices:
+        print("Round 1: no response received")
+        return
     messages.append(result.choices[0].message)
     print("Round 1:", result.choices[0].message.content)
     # The image shows a pyramid of colored blocks with numbers on them. Here are the colors and numbers of ...
@@ -56,6 +59,9 @@ def main():
         }
     )
     result = client.chat.completions.create(messages=messages, model="test")
+    if not result.choices:
+        print("Round 2: no response received")
+        return
     messages.append(result.choices[0].message)
     print("Round 2:", result.choices[0].message.content)
     # The image shows a cluster of forget-me-not flowers. Forget-me-nots are small ...

--- a/scripts/api_example/test_image.py
+++ b/scripts/api_example/test_image.py
@@ -41,8 +41,7 @@ def main():
     )
     result = client.chat.completions.create(messages=messages, model="test")
     if not result.choices:
-        print("Round 1: no response received")
-        return
+        raise SystemExit("Round 1: no response received")
     messages.append(result.choices[0].message)
     print("Round 1:", result.choices[0].message.content)
     # The image shows a pyramid of colored blocks with numbers on them. Here are the colors and numbers of ...
@@ -60,8 +59,7 @@ def main():
     )
     result = client.chat.completions.create(messages=messages, model="test")
     if not result.choices:
-        print("Round 2: no response received")
-        return
+        raise SystemExit("Round 2: no response received")
     messages.append(result.choices[0].message)
     print("Round 2:", result.choices[0].message.content)
     # The image shows a cluster of forget-me-not flowers. Forget-me-nots are small ...

--- a/scripts/api_example/test_image.py
+++ b/scripts/api_example/test_image.py
@@ -40,7 +40,7 @@ def main():
         }
     )
     result = client.chat.completions.create(messages=messages, model="test")
-    if not result.choices:
+    if not result.choices or result.choices[0].message is None:
         raise SystemExit("Round 1: no response received")
     messages.append(result.choices[0].message)
     print("Round 1:", result.choices[0].message.content)
@@ -58,7 +58,7 @@ def main():
         }
     )
     result = client.chat.completions.create(messages=messages, model="test")
-    if not result.choices:
+    if not result.choices or result.choices[0].message is None:
         raise SystemExit("Round 2: no response received")
     messages.append(result.choices[0].message)
     print("Round 2:", result.choices[0].message.content)


### PR DESCRIPTION
## Problem

`scripts/api_example/test_image.py` calls `result.choices[0]` twice per round without first checking whether the API returned any choices. When the model refuses the request (content-policy filter, token limit, etc.) the API returns `choices=[]`, raising a bare `IndexError`.

## Changes

Added `if not result.choices` guards after each `client.chat.completions.create()` call — both for Round 1 and Round 2. When the API returns no choices the script prints a clear message and returns early rather than crashing.

```python
# Before
result = client.chat.completions.create(messages=messages, model="test")
messages.append(result.choices[0].message)

# After
result = client.chat.completions.create(messages=messages, model="test")
if not result.choices:
    print("Round 1: no response received")
    return
messages.append(result.choices[0].message)
```

Minimal diff, no behaviour change on successful API responses.

---
*Found by [pact](https://github.com/qizwiz/pact) static analysis — `llm_response_unguarded` mode.*