### PR TITLE
Fix: add missing return statement in MiniCPMVPlugin.get_mm_inputs

### DIFF
--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -1438,6 +1438,8 @@ class MiniCPMVPlugin(BasePlugin):
             mm_inputs.update(audio_inputs)
             mm_inputs.update({"audio_bounds": audio_bounds_ls, "spk_bounds": spk_bounds_ls})
 
+        return mm_inputs
+
 
 @dataclass
 class MiniCPMV4_6Plugin(BasePlugin):


### PR DESCRIPTION
# What does this PR do?

Append a missing `return mm_inputs` statement at the end of `MiniCPMVPlugin.get_mm_inputs` in [`src/llamafactory/data/mm_plugin.py`](https://github.com/hiyouga/LLaMA-Factory/blob/main/src/llamafactory/data/mm_plugin.py).

## The bug

`MiniCPMVPlugin.get_mm_inputs` is declared with the return type `dict[str, Union[list[int], torch.Tensor]]` and builds an `mm_inputs` dict end-to-end, but the final `return mm_inputs` is **missing**, so the function **implicitly returns `None`**.

This breaks every MiniCPM-V / MiniCPM-o multimodal SFT run, because the SFT collator immediately consumes the returned value at [`src/llamafactory/data/collator.py:398`](https://github.com/hiyouga/LLaMA-Factory/blob/main/src/llamafactory/data/collator.py):

```python
mm_inputs = self.template.mm_plugin.get_mm_inputs(...)
if "token_type_ids" in mm_inputs:   # <-- crashes here
    ...
```

raising:

```
TypeError: argument of type 'NoneType' is not iterable
```

## The fix

One-line change — add the missing `return` at the end of the method:

```python
def get_mm_inputs(self, ...) -> dict[str, Union[list[int], "torch.Tensor"]]:
    ...
    if len(audios) > 0:
        ...
        mm_inputs.update(audio_inputs)
        mm_inputs.update({"audio_bounds": audio_bounds_ls, "spk_bounds": spk_bounds_ls})

+   return mm_inputs
```

## Reproduction & verification

Reproduced on LoRA SFT for `openbmb/MiniCPM-o-4_5` across all four multimodal demo datasets shipped in `data/`:

- `mllm_demo` (image)
- `mllm_audio_demo` (audio)
- `mllm_video_demo` (video)
- `mllm_video_audio_demo` (omni: video + audio)

Before the fix: training crashes at the first batch with the `TypeError` above.

After the fix: training completes end-to-end with no other change.

```
trainable params: 21,823,488 / 9,045,914,864  (0.24%)
train_loss = 2.71  (1 epoch, 2 steps)
adapter saved successfully
```

Inference smoke test with the resulting LoRA adapter: 4/4 modalities (image / audio / video / video+audio) generate sensible responses via `llamafactory-cli chat`.

Tested environment: PyTorch 2.12.0+cu130, transformers 4.57.6, peft 0.18.1, accelerate 1.11.0, GPU NVIDIA RTX 6000D (85GB).

Fixes # (issue)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?

> Note: this is a one-line correctness fix for a code path that was previously unreachable in any successful run (the function silently returned `None`, then the collator crashed). No new tests were added because the existing multimodal demo datasets (`mllm_demo`, `mllm_audio_demo`, `mllm_video_demo`, `mllm_video_audio_demo`) now exercise this code path end-to-end as a de-facto integration test.
