### PR TITLE
[fix] drop Qwen3-VL video metadata before model inputs

### DIFF
--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -2355,6 +2355,26 @@ class Qwen3VLPlugin(Qwen2VLPlugin):
         return mm_inputs
 
     @override
+    def get_mm_inputs(
+        self,
+        images: list["ImageInput"],
+        videos: list["VideoInput"],
+        audios: list["AudioInput"],
+        imglens: list[int],
+        vidlens: list[int],
+        audlens: list[int],
+        batch_ids: list[list[int]],
+        processor: Optional["MMProcessor"],
+    ) -> dict[str, Union[list[int], "torch.Tensor"]]:
+        self._validate_input(processor, images, videos, audios)
+        mm_inputs = self._get_mm_inputs(images, videos, audios, processor)
+
+        # Used by processor / prompt expansion, not by model.forward or model.generate.
+        mm_inputs.pop("video_metadata", None)
+
+        return mm_inputs
+
+    @override
     def process_messages(
         self,
         messages: list[dict[str, str]],

--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -87,6 +87,17 @@ if TYPE_CHECKING:
             pass
 
 
+# Processor-only metadata that must not be passed to model.forward or model.generate.
+_PROCESSOR_ONLY_MM_INPUT_KEYS = (
+    "num_soft_tokens_per_image",
+    "num_soft_tokens_per_video",
+    "video_metadata",
+    "_gemma4_fps_per_video",
+    "_gemma4_frames_indices",
+    "_gemma4_num_audio_soft_tokens",
+)
+
+
 def _get_paligemma_token_type_ids(imglens: list[int], seqlens: list[int], processor: "MMProcessor") -> list[list[int]]:
     r"""Get paligemma token type ids for computing loss.
 
@@ -1160,14 +1171,7 @@ class Gemma4Plugin(BasePlugin):
         self._validate_input(processor, images, videos, audios)
         mm_inputs = self._get_mm_inputs(images, videos, audios, processor)
         # Pop metadata keys that must not be passed to the model.
-        for key in (
-            "num_soft_tokens_per_image",
-            "num_soft_tokens_per_video",
-            "video_metadata",
-            "_gemma4_fps_per_video",
-            "_gemma4_frames_indices",
-            "_gemma4_num_audio_soft_tokens",
-        ):
+        for key in _PROCESSOR_ONLY_MM_INPUT_KEYS:
             mm_inputs.pop(key, None)
 
         mm_inputs["mm_token_type_ids"] = processor.create_mm_token_type_ids(batch_ids)
@@ -2699,6 +2703,26 @@ class Qwen3VLPlugin(Qwen2VLPlugin):
             temporal_patch_size: int = getattr(image_processor, "temporal_patch_size", 2)
             if "second_per_grid_ts" in processor.model_input_names:
                 mm_inputs["second_per_grid_ts"] = [temporal_patch_size / fps for fps in videos["fps_per_video"]]
+
+        return mm_inputs
+
+    @override
+    def get_mm_inputs(
+        self,
+        images: list["ImageInput"],
+        videos: list["VideoInput"],
+        audios: list["AudioInput"],
+        imglens: list[int],
+        vidlens: list[int],
+        audlens: list[int],
+        batch_ids: list[list[int]],
+        processor: Optional["MMProcessor"],
+    ) -> dict[str, Union[list[int], "torch.Tensor"]]:
+        self._validate_input(processor, images, videos, audios)
+        mm_inputs = self._get_mm_inputs(images, videos, audios, processor)
+        # Pop metadata keys that must not be passed to the model.
+        for key in _PROCESSOR_ONLY_MM_INPUT_KEYS:
+            mm_inputs.pop(key, None)
 
         return mm_inputs
 

--- a/tests/data/test_mm_plugin.py
+++ b/tests/data/test_mm_plugin.py
@@ -422,8 +422,11 @@ def test_qwen2_vl_plugin():
 def test_qwen3_vl_plugin():
     frame_seqlen = 1
     tokenizer_module = _load_tokenizer_module(model_name_or_path="Qwen/Qwen3-VL-30B-A3B-Instruct")
+    processor = tokenizer_module["processor"]
     qwen3_vl_plugin = get_mm_plugin(name="qwen3_vl", video_token="<|video_pad|>")
     check_inputs = {"plugin": qwen3_vl_plugin, **tokenizer_module}
+    mm_inputs = qwen3_vl_plugin._get_mm_inputs(NO_IMAGES, VIDEOS, NO_AUDIOS, processor)
+    mm_inputs.pop("video_metadata", None)
     check_inputs["expected_mm_messages"] = [
         {
             key: value.replace(
@@ -437,6 +440,12 @@ def test_qwen3_vl_plugin():
         for message in VIDEO_MESSAGES
     ]
     _check_plugin(**check_inputs)
+    _is_close(
+        qwen3_vl_plugin.get_mm_inputs(
+            NO_IMAGES, VIDEOS, NO_AUDIOS, NO_IMGLENS, [len(VIDEOS)], NO_AUDLENS, BATCH_IDS, processor
+        ),
+        mm_inputs,
+    )
 
 
 @pytest.mark.runs_on(["cpu", "mps"])

--- a/tests/data/test_mm_plugin.py
+++ b/tests/data/test_mm_plugin.py
@@ -441,8 +441,10 @@ def test_moss_vl_plugin():
 def test_qwen3_vl_plugin():
     frame_seqlen = 1
     tokenizer_module = _load_tokenizer_module(model_name_or_path="Qwen/Qwen3-VL-30B-A3B-Instruct")
+    processor = tokenizer_module["processor"]
     qwen3_vl_plugin = get_mm_plugin(name="qwen3_vl", video_token="<|video_pad|>")
     check_inputs = {"plugin": qwen3_vl_plugin, **tokenizer_module}
+
     video_token = "<|video_pad|>" * frame_seqlen
     first_video = (
         f"<0.2 seconds><|vision_start|>{video_token}<|vision_end|>"
@@ -461,6 +463,10 @@ def test_qwen3_vl_plugin():
         {key: value.replace("<video>", first_video) for key, value in message.items()} for message in VIDEO_MESSAGES
     ]
     _check_plugin(**check_inputs)
+    model_mm_inputs = qwen3_vl_plugin.get_mm_inputs(
+        NO_IMAGES, VIDEOS, NO_AUDIOS, NO_IMGLENS, [len(VIDEOS)], NO_AUDLENS, BATCH_IDS, processor
+    )
+    assert "video_metadata" not in model_mm_inputs
     assert qwen3_vl_plugin.process_messages(messages, NO_IMAGES, videos, NO_AUDIOS, tokenizer_module["processor"]) == [
         {
             "role": "user",


### PR DESCRIPTION
# What does this PR do?

This PR fixes a latent Qwen3-VL video generation issue where processor-side `video_metadata` can leak into model inputs and be passed to `model.generate()`.

For Qwen3-VL video inputs, `video_metadata` is needed during processor-side preprocessing / prompt expansion to build timestamp-aware video placeholders. However, `video_metadata` is not a valid model forward or generation argument. During generation-based evaluation or prediction, this field may be forwarded into `model.generate(...)`, causing an error like:

```text
ValueError: The following `model_kwargs` are not used by the model: ['video_metadata']
```

This PR adds a Qwen3-VL-specific `get_mm_inputs()` override to remove `video_metadata` before returning multimodal inputs to the model.

The change keeps the existing Qwen3-VL metadata flow intact for prompt-side processing, while preventing processor-only metadata from leaking into model inputs.

## Changes

- Adds `Qwen3VLPlugin.get_mm_inputs()`.
- Calls `_get_mm_inputs(...)` as before.
- Removes `video_metadata` from the returned multimodal inputs.
- Keeps real model inputs unchanged, including:
  - `pixel_values_videos`
  - `video_grid_thw`
  - `second_per_grid_ts`

## Why is this needed?

`video_metadata` is an intermediate processor-side field. It is useful for Qwen3-VL timestamp / video token expansion, but the model itself does not consume it.

Training may not always expose this issue, but generation-based evaluation or prediction can fail because `transformers.generate()` validates unused model kwargs more strictly.

This fix aligns Qwen3-VL behavior with other multimodal plugins that remove processor-only metadata before passing inputs to the model.

Reference patterns in `src/llamafactory/data/mm_plugin.py`:

- `Gemma3Plugin.get_mm_inputs()` removes `num_crops` before returning model inputs.
- `Gemma4Plugin.get_mm_inputs()` removes metadata-only fields such as `num_soft_tokens_per_image`, `num_soft_tokens_per_video`, and `video_metadata`.
- `VideoLlavaPlugin.get_mm_inputs()` removes `timestamps` before returning model inputs.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
