### PR TITLE
feat: add share_ref_base for dual-adapter shared base model in DPO/KTO

### DIFF
--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -232,6 +232,16 @@ class RLHFArguments:
         default=None,
         metadata={"help": "The number of bits to quantize the reference model."},
     )
+    share_ref_base: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to share the base model between policy and reference by loading "
+                "ref_model_adapters as a frozen adapter named 'ref'. Only valid for LoRA DPO/KTO. "
+                "Incompatible with `ref_model`."
+            )
+        },
+    )
     reward_model: str | None = field(
         default=None,
         metadata={"help": "Path to the reward model used for the PPO training."},
@@ -572,6 +582,25 @@ class FinetuningArguments(
         self.galore_target: list[str] = split_arg(self.galore_target)
         self.apollo_target: list[str] = split_arg(self.apollo_target)
         self.use_ref_model = self.stage == "dpo" and self.pref_loss not in ["orpo", "simpo"]
+
+        if self.share_ref_base:
+            if self.finetuning_type != "lora":
+                raise ValueError("`share_ref_base` requires LoRA finetuning.")
+
+            if self.stage not in ("dpo", "kto"):
+                raise ValueError("`share_ref_base` only supports DPO/KTO stages.")
+
+            if self.stage == "dpo" and not self.use_ref_model:
+                raise ValueError("`share_ref_base` does not apply to ORPO/SimPO (no ref model).")
+
+            if self.ref_model is not None:
+                raise ValueError("`share_ref_base` is incompatible with `ref_model` (separate base path).")
+
+            if self.ref_model_adapters is None:
+                raise ValueError("`share_ref_base` requires `ref_model_adapters`.")
+
+            if self.ref_model_quantization_bit is not None:
+                raise ValueError("`share_ref_base` cannot use `ref_model_quantization_bit`.")
 
         assert self.finetuning_type in ["lora", "oft", "freeze", "full"], "Invalid fine-tuning method."
         assert self.ref_model_quantization_bit in [None, 8, 4], "We only accept 4-bit or 8-bit quantization."

--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -453,6 +453,13 @@ def get_train_args(args: dict[str, Any] | list[str] | None = None) -> _TRAIN_CLS
     if (not training_args.do_train) and finetuning_args.stage == "dpo" and finetuning_args.ref_model is None:
         logger.warning_rank0("Specify `ref_model` for computing rewards at evaluation.")
 
+    if training_args.do_train and finetuning_args.share_ref_base:
+        logger.info_rank0(
+            "[share_ref_base] Using shared base model with dual adapters: "
+            "'default' (policy, trainable) and 'ref' (reference, frozen). "
+            f"Reference adapter: {finetuning_args.ref_model_adapters}"
+        )
+
     # Post-process training arguments
     training_args.generation_max_length = training_args.generation_max_length or data_args.cutoff_len
     training_args.generation_num_beams = data_args.eval_num_beams or training_args.generation_num_beams

--- a/src/llamafactory/train/dpo/trainer.py
+++ b/src/llamafactory/train/dpo/trainer.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import warnings
 from collections import defaultdict
 from contextlib import nullcontext
@@ -32,7 +33,13 @@ from typing_extensions import override
 from ...extras.constants import IGNORE_INDEX
 from ...extras.packages import is_transformers_version_greater_than
 from ..callbacks import SaveProcessorCallback
-from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_batch_logps, nested_detach
+from ..trainer_utils import (
+    create_custom_optimizer,
+    create_custom_scheduler,
+    get_batch_logps,
+    nested_detach,
+    switch_ref_adapter_context,
+)
 
 
 if TYPE_CHECKING:
@@ -261,7 +268,10 @@ class CustomDPOTrainer(DPOTrainer):
 
         if self.ref_model is None:
             ref_model = model
-            ref_context = self.accelerator.unwrap_model(model).disable_adapter()
+            if self.finetuning_args.share_ref_base:
+                ref_context = switch_ref_adapter_context(self.accelerator.unwrap_model(model))
+            else:
+                ref_context = self.accelerator.unwrap_model(model).disable_adapter()
         else:
             ref_model = self.ref_model
             ref_context = nullcontext()
@@ -272,6 +282,34 @@ class CustomDPOTrainer(DPOTrainer):
             reference_rejected_logps = ref_output["rejected_logps"]
 
         return reference_chosen_logps, reference_rejected_logps
+
+    @override
+    def _save(self, output_dir: Optional[str] = None, state_dict=None) -> None:
+        r"""Only save the 'default' (policy) adapter when share_ref_base is enabled."""
+        if self.finetuning_args.share_ref_base:
+            from peft import PeftModel
+
+            output_dir = output_dir if output_dir is not None else self.args.output_dir
+            os.makedirs(output_dir, exist_ok=True)
+            unwrapped = self.accelerator.unwrap_model(self.model)
+            if isinstance(unwrapped, PeftModel):
+                # Under FSDP, model.state_dict() is a collective op that hangs if called
+                # only on rank 0. Use the pre-gathered state_dict from the trainer if available,
+                # otherwise call state_dict() (safe when all ranks enter _save together under FSDP).
+                if state_dict is None:
+                    state_dict = self.model.state_dict()
+
+                unwrapped.save_pretrained(
+                    output_dir,
+                    selected_adapters=["default"],
+                    safe_serialization=getattr(self.args, "save_safetensors", True),
+                    state_dict=state_dict,
+                )
+                if self.processing_class is not None:
+                    self.processing_class.save_pretrained(output_dir)
+                return
+
+        super()._save(output_dir, state_dict)
 
     @override
     def get_batch_loss_metrics(

--- a/src/llamafactory/train/dpo/workflow.py
+++ b/src/llamafactory/train/dpo/workflow.py
@@ -23,7 +23,7 @@ from ...extras.misc import calculate_tps
 from ...extras.ploting import plot_loss
 from ...hparams import ModelArguments
 from ...model import load_model, load_tokenizer
-from ..trainer_utils import create_modelcard_and_push, create_ref_model
+from ..trainer_utils import create_modelcard_and_push, create_ref_model, load_ref_adapter
 
 
 if TYPE_CHECKING:
@@ -55,7 +55,13 @@ def run_dpo(
 
     # Create reference model
     if finetuning_args.use_ref_model:
-        if finetuning_args.ref_model is None and (not training_args.do_train):  # use the model itself
+        if finetuning_args.share_ref_base:
+            # Dual adapter mode: load ref adapter onto the same base model.
+            # Load it for both training and eval-only so that ref logp computation
+            # always has the 'ref' adapter available.
+            load_ref_adapter(model, finetuning_args)
+            ref_model = None
+        elif finetuning_args.ref_model is None and (not training_args.do_train):  # use the model itself
             ref_model = model
         else:
             ref_model = create_ref_model(model_args, finetuning_args)

--- a/src/llamafactory/train/kto/trainer.py
+++ b/src/llamafactory/train/kto/trainer.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import warnings
 from collections import defaultdict
 from contextlib import nullcontext
@@ -31,7 +32,13 @@ from typing_extensions import override
 from ...extras.constants import IGNORE_INDEX
 from ...extras.packages import is_transformers_version_greater_than
 from ..callbacks import SaveProcessorCallback
-from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_batch_logps, nested_detach
+from ..trainer_utils import (
+    create_custom_optimizer,
+    create_custom_scheduler,
+    get_batch_logps,
+    nested_detach,
+    switch_ref_adapter_context,
+)
 
 
 if TYPE_CHECKING:
@@ -205,7 +212,10 @@ class CustomKTOTrainer(KTOTrainer):
         r"""Compute log probabilities of the reference model."""
         if self.ref_model is None:
             ref_model = model
-            ref_context = self.accelerator.unwrap_model(model).disable_adapter()
+            if self.finetuning_args.share_ref_base:
+                ref_context = switch_ref_adapter_context(self.accelerator.unwrap_model(model))
+            else:
+                ref_context = self.accelerator.unwrap_model(model).disable_adapter()
         else:
             ref_model = self.ref_model
             ref_context = nullcontext()
@@ -216,6 +226,34 @@ class CustomKTOTrainer(KTOTrainer):
             )
 
         return reference_chosen_logps, reference_rejected_logps, reference_kl_logps
+
+    @override
+    def _save(self, output_dir: Optional[str] = None, state_dict=None) -> None:
+        r"""Only save the 'default' (policy) adapter when share_ref_base is enabled."""
+        if self.finetuning_args.share_ref_base:
+            from peft import PeftModel
+
+            output_dir = output_dir if output_dir is not None else self.args.output_dir
+            os.makedirs(output_dir, exist_ok=True)
+            unwrapped = self.accelerator.unwrap_model(self.model)
+            if isinstance(unwrapped, PeftModel):
+                # Under FSDP, model.state_dict() is a collective op that hangs if called
+                # only on rank 0. Use the pre-gathered state_dict from the trainer if available,
+                # otherwise call state_dict() (safe when all ranks enter _save together under FSDP).
+                if state_dict is None:
+                    state_dict = self.model.state_dict()
+
+                unwrapped.save_pretrained(
+                    output_dir,
+                    selected_adapters=["default"],
+                    safe_serialization=getattr(self.args, "save_safetensors", True),
+                    state_dict=state_dict,
+                )
+                if self.processing_class is not None:
+                    self.processing_class.save_pretrained(output_dir)
+                return
+
+        super()._save(output_dir, state_dict)
 
     @override
     def get_batch_loss_metrics(

--- a/src/llamafactory/train/kto/workflow.py
+++ b/src/llamafactory/train/kto/workflow.py
@@ -22,7 +22,7 @@ from ...extras.constants import IGNORE_INDEX
 from ...extras.ploting import plot_loss
 from ...hparams import ModelArguments
 from ...model import load_model, load_tokenizer
-from ..trainer_utils import create_modelcard_and_push, create_ref_model
+from ..trainer_utils import create_modelcard_and_push, create_ref_model, load_ref_adapter
 from .trainer import CustomKTOTrainer
 
 
@@ -54,7 +54,13 @@ def run_kto(
     )
 
     # Create reference model
-    if finetuning_args.ref_model is None and (not training_args.do_train):  # use the model itself
+    if finetuning_args.share_ref_base:
+        # Dual adapter mode: load ref adapter onto the same base model.
+        # Load it for both training and eval-only so that ref logp computation
+        # always has the 'ref' adapter available.
+        load_ref_adapter(model, finetuning_args)
+        ref_model = None
+    elif finetuning_args.ref_model is None and (not training_args.do_train):  # use the model itself
         ref_model = model
     else:
         ref_model = create_ref_model(model_args, finetuning_args)

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -180,6 +180,11 @@ def load_ref_adapter(
         (p.dtype for n, p in model.named_parameters() if "lora" not in n and "modules_to_save" not in n),
         None,
     )
+    if base_dtype is None or not base_dtype.is_floating_point:
+        base_dtype = next(
+            (p.dtype for n, p in model.named_parameters() if ".default." in n),
+            None,
+        )
     ref_cast_count = 0
     for name, param in model.named_parameters():
         if ".ref." in name:

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -215,11 +215,12 @@ def switch_ref_adapter_context(unwrapped_model: "PreTrainedModel"):
     if not isinstance(unwrapped_model, PeftModel):
         raise RuntimeError("switch_ref_adapter_context requires a PeftModel.")
 
+    old_adapter = unwrapped_model.active_adapter
     try:
         unwrapped_model.set_adapter("ref")
         yield
     finally:
-        unwrapped_model.set_adapter("default")
+        unwrapped_model.set_adapter(old_adapter)
 
 
 def create_reward_model(

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -20,6 +20,7 @@
 import json
 import os
 from collections.abc import Callable, Mapping
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
@@ -146,6 +147,74 @@ def create_ref_model(
             logger.info_rank0("Created reference model from the model itself.")
 
     return ref_model
+
+
+def load_ref_adapter(
+    model: "PreTrainedModel",
+    finetuning_args: "FinetuningArguments",
+) -> None:
+    r"""Load a frozen reference LoRA adapter onto the model as adapter named 'ref'.
+
+    After this call the model has two adapters:
+      - "default" (trainable, the policy)
+      - "ref" (frozen, the reference)
+    The active adapter is set back to "default".
+    """
+    from peft import PeftModel
+
+    if not isinstance(model, PeftModel):
+        raise RuntimeError(
+            "`share_ref_base` requires the policy model to be a PeftModel. "
+            "Ensure `finetuning_type=lora` and the adapter is properly configured."
+        )
+
+    ref_adapter_path = finetuning_args.ref_model_adapters
+    logger.info_rank0(f"[share_ref_base] Loading reference adapter from '{ref_adapter_path}' as adapter 'ref'...")
+    model.load_adapter(ref_adapter_path, adapter_name="ref", is_trainable=False)
+
+    # Defensively freeze all ref adapter parameters and cast to base model dtype.
+    # The dtype cast is critical for FSDP compatibility: FSDP requires uniform dtype
+    # within each sharding unit. Without this, ref adapter params remain fp32 while
+    # the base model is bf16/fp16, causing "Must flatten tensors with uniform dtype" errors.
+    base_dtype = next(
+        (p.dtype for n, p in model.named_parameters() if "lora" not in n and "modules_to_save" not in n),
+        None,
+    )
+    ref_cast_count = 0
+    for name, param in model.named_parameters():
+        if ".ref." in name:
+            param.requires_grad_(False)
+            if base_dtype is not None and param.dtype != base_dtype:
+                param.data = param.data.to(base_dtype)
+                ref_cast_count += 1
+
+    if ref_cast_count > 0:
+        logger.info_rank0(
+            f"[share_ref_base] Cast {ref_cast_count} ref adapter params to {base_dtype} for FSDP compatibility."
+        )
+
+    # Switch back to default (policy) adapter for training
+    model.set_adapter("default")
+    logger.info_rank0("[share_ref_base] Reference adapter 'ref' loaded and frozen. Active adapter: 'default'.")
+
+
+@contextmanager
+def switch_ref_adapter_context(unwrapped_model: "PreTrainedModel"):
+    r"""Context manager that switches the PeftModel to the 'ref' adapter, then restores 'default'.
+
+    Args:
+        unwrapped_model: The already-unwrapped PeftModel (call accelerator.unwrap_model first).
+    """
+    from peft import PeftModel
+
+    if not isinstance(unwrapped_model, PeftModel):
+        raise RuntimeError("switch_ref_adapter_context requires a PeftModel.")
+
+    try:
+        unwrapped_model.set_adapter("ref")
+        yield
+    finally:
+        unwrapped_model.set_adapter("default")
 
 
 def create_reward_model(


### PR DESCRIPTION
# What does this PR do?

Adds a new flag `share_ref_base` for **LoRA DPO/KTO** training that lets the policy and the reference share the **same** base model in memory. Instead of loading two full backbones (2x backbone weights), the reference is loaded as a frozen LoRA adapter named `ref` on top of the same base, while the trainable policy stays on the `default` adapter.

| Mode                    | Backbone | Adapter |
|-------------------------|----------|---------|
| Default (separate ref)  | **2x**   | 1x      |
| `share_ref_base=True`   | **1x**   | 2x      |

For large models (e.g. 27B+) where the LoRA adapter is small relative to the backbone, this approximately halves the GPU memory needed for the reference, making LoRA DPO/KTO feasible on smaller multi-GPU setups.

## Usage

```yaml
stage: dpo                                 # or kto
do_train: true
finetuning_type: lora
adapter_name_or_path: /path/to/sft_adapter
ref_model_adapters: /path/to/sft_adapter   # required
share_ref_base: true                       # <-- new
# Note: incompatible with `ref_model` and `ref_model_quantization_bit`
```

## Implementation summary

The dual-adapter swap mechanism follows the same idea as TRL's `null_ref_context` (via `model_adapter_name` / `ref_adapter_name` in `DPOConfig`), but exposes it as a single yaml-level flag and adds:

- **Hparam** (`finetuning_args.py`): new `share_ref_base: bool` on `RLHFArguments`. Strict validation in `__post_init__` — LoRA only, DPO/KTO only, mutually exclusive with `ref_model` / `ref_model_quantization_bit`, excludes ORPO/SimPO which have no ref.
- **Adapter loading** (`trainer_utils.py`):
  - `load_ref_adapter(model, finetuning_args)` — loads the ref LoRA as the `ref` adapter with `is_trainable=False`, defensively freezes its parameters, and **casts ref params to the base-model dtype** so that FSDP's per-unit uniform-dtype requirement is satisfied.
  - `switch_ref_adapter_context(unwrapped_model)` — a `contextmanager` that activates `ref` for the reference forward and **always** restores `default` via `try/finally`.
- **Workflows** (`train/dpo/workflow.py`, `train/kto/workflow.py`): when `share_ref_base=True`, call `load_ref_adapter` so downstream code can rely on the `ref` adapter being present (covers both training and eval-only paths).
- **Trainers** (`train/dpo/trainer.py`, `train/kto/trainer.py`):
  - In `concatenated_forward` (DPO) / `forward` (KTO), use `switch_ref_adapter_context(...)` instead of `disable_adapter()` when `share_ref_base=True`. This routes the reference logp computation through `base + ref` instead of through `base` only.
  - Override `_save()` to persist **only** the `default` (policy) adapter; the frozen `ref` adapter is identical to the input file on disk, so we avoid duplicating it in every checkpoint. Under FSDP, the trainer's pre-gathered `state_dict` is forwarded to `PeftModel.save_pretrained()` to avoid collective gather hangs.

## Backward compatibility

`share_ref_base` defaults to `False`, so this PR is a no-op for every existing config. All existing DPO/KTO recipes (full / freeze / LoRA, with or without `ref_model` / `ref_model_adapters`) take exactly the same code path as before.

---

## Test matrix

Environment: 8x NVIDIA H20 (97.9GB), PyTorch 2.6.0+cu124, PEFT 0.18.1, DeepSpeed 0.18.9, Accelerate 1.11.0. Models: Qwen2.5-0.5B-Instruct (small) and Qwen3.5-27B (production).

| # | Test | Status | Notes |
|---|---|---|---|
| T1 | DPO single-GPU (Qwen2.5-0.5B) | ✅ PASS | Loss converges from 0.693 |
| T2 | KTO single-GPU (Qwen2.5-0.5B) | ✅ PASS | Loss ~0.5, KL non-NaN and increasing |
| T3 | DPO multi-GPU DeepSpeed ZeRO-2 | ✅ PASS | 4xH20 |
| T4 | KTO multi-GPU DeepSpeed ZeRO-2 | ✅ PASS | 4xH20 |
| T5 | Save verification | ✅ PASS | Checkpoint only contains `default` adapter |
| T6 | Gradient isolation | ✅ PASS | All 336 ref-adapter params unchanged after backward |
| T7 | 27B production (8 GPU) | ✅ PASS | Loss 0.693 → 0.519, accuracy 0% → 100% |
| T8 | DPO ZeRO-3 (4 GPU) | ✅ PASS | `set_adapter()` works correctly under ZeRO-3 partitioning |
| T9 | `modules_to_save` (1 GPU) | ✅ PASS | SFT adapter with `lm_head`; gradient isolation verified (337 ref params unchanged) |
| T10 | FSDP1 + transformer-layer wrap (4 GPU) | ✅ PASS | Works after the dtype cast in `load_ref_adapter` |
| T11 | FSDP1 minimal (4 GPU) | ✅ PASS | `fsdp: "full_shard"` without explicit wrap config |
| T12 | FSDP2 (4 GPU) | ⚠️ BLOCKED | accelerate 1.11–1.13 + PyTorch 2.6 env issue; **not** specific to `share_ref_base` — vanilla LoRA + FSDP2 fails identically |

### Regression on existing configurations after the changes

| Config | train_loss |
|---|---|
| DeepSpeed ZeRO-3 | 0.6894 ✅ |
| Single GPU + `modules_to_save` | 0.6843 ✅ |
| FSDP1 minimal | 0.6854 ✅ |
| FSDP1 + transformer wrap | 0.7117 ✅ |

### Code quality

| Check | Command | Result |
|---|---|---|
| Style | `make style` | ✅ 278 files unchanged |
| Quality | `make quality` | ✅ 278 files already formatted |
| License | `make license` | ✅ No errors |
| Tests | `make test` | ✅ 39 passed, 120 skipped, 2 xfailed, 1 xpassed (260.75s) |

---

## Compatibility details

| Backend | Status | Notes |
|---|---|---|
| DeepSpeed ZeRO-2 | ✅ | Recommended for production multi-GPU use |
| DeepSpeed ZeRO-3 | ✅ | `set_adapter()` works under ZeRO-3 partitioning |
| FSDP1 (any wrap policy) | ✅ | The `load_ref_adapter()` dtype cast keeps the ref adapter aligned with the base; PEFT's `fsdp_auto_wrap_policy` (applied automatically by HuggingFace `Trainer` via `update_fsdp_plugin_peft()`) separates trainable LoRA into independent FSDP units |
| `modules_to_save` (e.g. `lm_head`) | ✅ | Gradient isolation verified — 337 ref params remain frozen after backward |
| Single GPU | ✅ | Both DPO and KTO |
| FSDP2 | ⚠️ | Currently blocked by an upstream accelerate ≤1.13 + PyTorch 2.6 incompatibility (`ignored_params` API removed / uniform-dtype assertion). Confirmed **not** specific to `share_ref_base` — any LoRA + FSDP2 combination fails identically. Should be resolved by future accelerate releases. |

### Why FSDP1 works

The dtype cast in `load_ref_adapter()` aligns ref-adapter params with the base-model dtype. Combined with PEFT's `fsdp_auto_wrap_policy`, each FSDP sharding unit ends up with uniform dtype:

- **Trainable LoRA units** (fp32): `lora_A.default`, `lora_B.default` — wrapped independently by PEFT's lambda policy (`weight.requires_grad=True`)
- **Frozen units** (bf16): base weights + ref-adapter LoRA — grouped into transformer-layer units

This separation is automatic and requires no user configuration.

---

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
