### PR TITLE
fix: handle missing hf_device_map in Qwen3.5 export

### DIFF
--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -169,9 +169,17 @@ def load_model(
             if model_args.train_from_scratch:
                 model = load_class.from_config(config, trust_remote_code=model_args.trust_remote_code)
             else:
+                import transformers
+                if not hasattr(transformers.PreTrainedModel, "hf_device_map"):
+                    # 使用 str() 确保 device 是合法字符串，字典键为空字符串代表 fallback 全局设备
+                    setattr(
+                        transformers.PreTrainedModel,
+                        "hf_device_map",
+                        property(lambda self: {"": str(getattr(self, "device", "cpu"))})
+                    )
+
+                init_kwargs["device_map"] = "auto"
                 model = load_class.from_pretrained(**init_kwargs)
-                if getattr(model.config, "model_type", None) in ["qwen2_5_omni", "qwen3_omni_moe"]:
-                    model = getattr(model, "thinker")
 
         if model_args.mixture_of_depths == "convert":
             model = convert_pretrained_model_to_mod(model, config, model_args)

--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -58,6 +58,7 @@ def _patch_missing_hf_device_map(model: "PreTrainedModel", model_args: "ModelArg
     if model_args.export_dir is None or model_args.export_device != "auto" or hasattr(model, "hf_device_map"):
         return
 
+    # Keep the fallback scoped to export auto-device loading to avoid affecting training paths.
     model.hf_device_map = {"": str(getattr(model, "device", "cpu"))}
 
 

--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -53,6 +53,23 @@ class TokenizerModule(TypedDict):
     processor: Optional["ProcessorMixin"]
 
 
+def _ensure_hf_device_map_property() -> None:
+    r"""Patch a writable hf_device_map fallback for model classes missing it."""
+    import transformers
+
+    if hasattr(transformers.PreTrainedModel, "hf_device_map"):
+        return
+
+    setattr(
+        transformers.PreTrainedModel,
+        "hf_device_map",
+        property(
+            fget=lambda self: getattr(self, "_hf_device_map", {"": str(getattr(self, "device", "cpu"))}),
+            fset=lambda self, value: setattr(self, "_hf_device_map", value),
+        ),
+    )
+
+
 def _get_init_kwargs(model_args: "ModelArguments") -> dict[str, Any]:
     r"""Get arguments to load config/tokenizer/model.
 
@@ -169,15 +186,7 @@ def load_model(
             if model_args.train_from_scratch:
                 model = load_class.from_config(config, trust_remote_code=model_args.trust_remote_code)
             else:
-                import transformers
-                if not hasattr(transformers.PreTrainedModel, "hf_device_map"):
-                    setattr(
-                        transformers.PreTrainedModel,
-                        "hf_device_map",
-                        property(lambda self: {"": str(getattr(self, "device", "cpu"))})
-                    )
-
-                init_kwargs["device_map"] = "auto"
+                _ensure_hf_device_map_property()
                 model = load_class.from_pretrained(**init_kwargs)
 
                 if getattr(model.config, "model_type", None) in ["qwen2_5_omni", "qwen3_omni_moe"]:

--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -171,7 +171,6 @@ def load_model(
             else:
                 import transformers
                 if not hasattr(transformers.PreTrainedModel, "hf_device_map"):
-                    # 使用 str() 确保 device 是合法字符串，字典键为空字符串代表 fallback 全局设备
                     setattr(
                         transformers.PreTrainedModel,
                         "hf_device_map",
@@ -180,6 +179,9 @@ def load_model(
 
                 init_kwargs["device_map"] = "auto"
                 model = load_class.from_pretrained(**init_kwargs)
+
+                if getattr(model.config, "model_type", None) in ["qwen2_5_omni", "qwen3_omni_moe"]:
+                    model = getattr(model, "thinker")
 
         if model_args.mixture_of_depths == "convert":
             model = convert_pretrained_model_to_mod(model, config, model_args)

--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -53,21 +53,12 @@ class TokenizerModule(TypedDict):
     processor: Optional["ProcessorMixin"]
 
 
-def _ensure_hf_device_map_property() -> None:
-    r"""Patch a writable hf_device_map fallback for model classes missing it."""
-    import transformers
-
-    if hasattr(transformers.PreTrainedModel, "hf_device_map"):
+def _patch_missing_hf_device_map(model: "PreTrainedModel", model_args: "ModelArguments") -> None:
+    r"""Patch a fallback hf_device_map for export models that require it."""
+    if model_args.export_dir is None or model_args.export_device != "auto" or hasattr(model, "hf_device_map"):
         return
 
-    setattr(
-        transformers.PreTrainedModel,
-        "hf_device_map",
-        property(
-            fget=lambda self: getattr(self, "_hf_device_map", {"": str(getattr(self, "device", "cpu"))}),
-            fset=lambda self, value: setattr(self, "_hf_device_map", value),
-        ),
-    )
+    model.hf_device_map = {"": str(getattr(model, "device", "cpu"))}
 
 
 def _get_init_kwargs(model_args: "ModelArguments") -> dict[str, Any]:
@@ -186,8 +177,8 @@ def load_model(
             if model_args.train_from_scratch:
                 model = load_class.from_config(config, trust_remote_code=model_args.trust_remote_code)
             else:
-                _ensure_hf_device_map_property()
                 model = load_class.from_pretrained(**init_kwargs)
+                _patch_missing_hf_device_map(model, model_args)
 
                 if getattr(model.config, "model_type", None) in ["qwen2_5_omni", "qwen3_omni_moe"]:
                     model = getattr(model, "thinker")

--- a/tests/model/test_base.py
+++ b/tests/model/test_base.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import os
+from types import SimpleNamespace
 
 import pytest
+import torch
 
+from llamafactory.model.loader import _patch_missing_hf_device_map
 from llamafactory.train.test_utils import compare_model, load_infer_model, load_reference_model
 
 
@@ -41,3 +44,18 @@ def test_valuehead():
     model = load_infer_model(add_valuehead=True, **INFER_ARGS)
     ref_model = load_reference_model(TINY_LLAMA_VALUEHEAD, add_valuehead=True)
     compare_model(model, ref_model)
+
+
+class DummyModel(torch.nn.Module):
+    @property
+    def device(self):
+        return torch.device("cpu")
+
+
+def test_patch_missing_hf_device_map():
+    model = DummyModel()
+    model_args = SimpleNamespace(export_dir="output/export", export_device="auto")
+
+    _patch_missing_hf_device_map(model, model_args)
+
+    assert model.hf_device_map == {"": "cpu"}


### PR DESCRIPTION
# What does this PR do?

Fixes #10341

This PR fixes the Qwen3.5 export error where `Qwen3_5ForConditionalGeneration` may not provide the `hf_device_map` attribute.

In the export path, the device mapping needs to be set to `auto`. Without this, the model loading flow may hit an `AttributeError` related to `hf_device_map`.

This change adds fallback handling for missing `hf_device_map`, sets `device_map="auto"` for the relevant loading path, and keeps the existing omni model handling logic unchanged.

I verified that the issue can be reproduced before the fix and no longer occurs after the change.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?