### PR TITLE
Default LLaMA Board to loopback binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,9 @@ See [examples/README.md](examples/README.md) for advanced usage (including distr
 llamafactory-cli webui
 ```
 
+By default, LLaMA Board only listens on `127.0.0.1`. To expose it to other machines or run it in
+Docker containers, set `GRADIO_SERVER_NAME=0.0.0.0`.
+
 ### LLaMA Factory Online
 
 Read our [documentation](https://docs.llamafactory.com.cn/docs/documents/quickstart/getstarted/?utm_source=LLaMA-Factory).

--- a/README_zh.md
+++ b/README_zh.md
@@ -662,6 +662,9 @@ llamafactory-cli export examples/merge_lora/qwen3_lora_sft.yaml
 llamafactory-cli webui
 ```
 
+LLaMA Board 默认仅监听 `127.0.0.1`。如需对其他机器开放或在 Docker 容器中运行，请设置
+`GRADIO_SERVER_NAME=0.0.0.0`。
+
 ### LLaMA Factory Online 在线微调
 
 详情阅读该[文档](https://docs.llamafactory.com.cn/docs/documents/quickstart/getstarted/?utm_source=LLaMA-Factory)。

--- a/src/llamafactory/webui/interface.py
+++ b/src/llamafactory/webui/interface.py
@@ -91,7 +91,7 @@ def create_web_demo() -> "gr.Blocks":
 def run_web_ui() -> None:
     gradio_ipv6 = is_env_enabled("GRADIO_IPV6")
     gradio_share = is_env_enabled("GRADIO_SHARE")
-    server_name = os.getenv("GRADIO_SERVER_NAME", "[::]" if gradio_ipv6 else "0.0.0.0")
+    server_name = os.getenv("GRADIO_SERVER_NAME", "[::1]" if gradio_ipv6 else "127.0.0.1")
     print("Visit http://ip:port for Web UI, e.g., http://127.0.0.1:7860")
     fix_proxy(ipv6_enabled=gradio_ipv6)
     create_ui().queue().launch(share=gradio_share, server_name=server_name, inbrowser=True)
@@ -100,7 +100,7 @@ def run_web_ui() -> None:
 def run_web_demo() -> None:
     gradio_ipv6 = is_env_enabled("GRADIO_IPV6")
     gradio_share = is_env_enabled("GRADIO_SHARE")
-    server_name = os.getenv("GRADIO_SERVER_NAME", "[::]" if gradio_ipv6 else "0.0.0.0")
+    server_name = os.getenv("GRADIO_SERVER_NAME", "[::1]" if gradio_ipv6 else "127.0.0.1")
     print("Visit http://ip:port for Web UI, e.g., http://127.0.0.1:7860")
     fix_proxy(ipv6_enabled=gradio_ipv6)
     create_web_demo().queue().launch(share=gradio_share, server_name=server_name, inbrowser=True)

--- a/src/webui.py
+++ b/src/webui.py
@@ -21,7 +21,7 @@ from llamafactory.webui.interface import create_ui
 def main():
     gradio_ipv6 = is_env_enabled("GRADIO_IPV6")
     gradio_share = is_env_enabled("GRADIO_SHARE")
-    server_name = os.getenv("GRADIO_SERVER_NAME", "[::]" if gradio_ipv6 else "0.0.0.0")
+    server_name = os.getenv("GRADIO_SERVER_NAME", "[::1]" if gradio_ipv6 else "127.0.0.1")
     print("Visit http://ip:port for Web UI, e.g., http://127.0.0.1:7860")
     fix_proxy(ipv6_enabled=gradio_ipv6)
     create_ui().queue().launch(share=gradio_share, server_name=server_name, inbrowser=True)


### PR DESCRIPTION
## Summary

This changes LLaMA Board's default bind address from all interfaces to loopback.

The Web UI can start training/evaluation jobs, load models, and export artifacts. In server, Docker, or shared-machine deployments, binding to all interfaces by default can unintentionally expose these controls to the network.

Users who intentionally need remote access can still set `GRADIO_SERVER_NAME=0.0.0.0`.

## Changes

- Default Web UI binding to `127.0.0.1`.
- Default IPv6 Web UI binding to `[::1]`.
- Document how to explicitly expose the Web UI for remote access.

## Tests

- python3 -m py_compile src/webui.py src/llamafactory/webui/interface.py
- git diff --check