### PR TITLE
Harden API media validation

### DIFF
--- a/src/llamafactory/api/chat.py
+++ b/src/llamafactory/api/chat.py
@@ -70,18 +70,21 @@ ROLE_MAPPING = {
 }
 
 
-def _fetch_remote_media(url: str):
+def _fetch_remote_media(url: str) -> io.BytesIO:
     check_ssrf_url(url)
+    response = None
     try:
-        response = requests.get(url, stream=True, timeout=10, allow_redirects=False)
+        response = requests.get(url, timeout=10, allow_redirects=False)
+        if response.is_redirect:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Media URL redirects are not allowed.")
+
         response.raise_for_status()
+        return io.BytesIO(response.content)
     except requests.RequestException as err:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Failed to fetch media URL: {err}")
-
-    if response.is_redirect:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Media URL redirects are not allowed.")
-
-    return response.raw
+    finally:
+        if response is not None:
+            response.close()
 
 
 def _process_request(

--- a/src/llamafactory/api/chat.py
+++ b/src/llamafactory/api/chat.py
@@ -70,6 +70,20 @@ ROLE_MAPPING = {
 }
 
 
+def _fetch_remote_media(url: str):
+    check_ssrf_url(url)
+    try:
+        response = requests.get(url, stream=True, timeout=10, allow_redirects=False)
+        response.raise_for_status()
+    except requests.RequestException as err:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Failed to fetch media URL: {err}")
+
+    if response.is_redirect:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Media URL redirects are not allowed.")
+
+    return response.raw
+
+
 def _process_request(
     request: "ChatCompletionRequest",
 ) -> tuple[
@@ -127,8 +141,7 @@ def _process_request(
                         check_lfi_path(image_url)
                         image_stream = open(image_url, "rb")
                     else:  # web uri
-                        check_ssrf_url(image_url)
-                        image_stream = requests.get(image_url, stream=True).raw
+                        image_stream = _fetch_remote_media(image_url)
 
                     images.append(Image.open(image_stream).convert("RGB"))
                 elif input_item.type == "video_url":
@@ -140,8 +153,7 @@ def _process_request(
                         check_lfi_path(video_url)
                         video_stream = video_url
                     else:  # web uri
-                        check_ssrf_url(video_url)
-                        video_stream = requests.get(video_url, stream=True).raw
+                        video_stream = _fetch_remote_media(video_url)
 
                     videos.append(video_stream)
                 elif input_item.type == "audio_url":
@@ -153,8 +165,7 @@ def _process_request(
                         check_lfi_path(audio_url)
                         audio_stream = audio_url
                     else:  # web uri
-                        check_ssrf_url(audio_url)
-                        audio_stream = requests.get(audio_url, stream=True).raw
+                        audio_stream = _fetch_remote_media(audio_url)
 
                     audios.append(audio_stream)
                 else:

--- a/src/llamafactory/api/chat.py
+++ b/src/llamafactory/api/chat.py
@@ -68,18 +68,45 @@ ROLE_MAPPING = {
     Role.FUNCTION: DataRole.FUNCTION.value,
     Role.TOOL: DataRole.OBSERVATION.value,
 }
+MAX_REMOTE_MEDIA_SIZE = int(os.getenv("MAX_REMOTE_MEDIA_SIZE", str(100 * 1024 * 1024)))
+REMOTE_MEDIA_CHUNK_SIZE = 64 * 1024
 
 
 def _fetch_remote_media(url: str) -> io.BytesIO:
     check_ssrf_url(url)
     response = None
     try:
-        response = requests.get(url, timeout=10, allow_redirects=False)
+        response = requests.get(url, stream=True, timeout=10, allow_redirects=False)
         if response.is_redirect:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Media URL redirects are not allowed.")
 
         response.raise_for_status()
-        return io.BytesIO(response.content)
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None:
+            try:
+                if int(content_length) > MAX_REMOTE_MEDIA_SIZE:
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail="Remote media exceeds the maximum allowed size.",
+                    )
+            except ValueError:
+                pass
+
+        media = io.BytesIO()
+        total_size = 0
+        for chunk in response.iter_content(chunk_size=REMOTE_MEDIA_CHUNK_SIZE):
+            if chunk:
+                total_size += len(chunk)
+                if total_size > MAX_REMOTE_MEDIA_SIZE:
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail="Remote media exceeds the maximum allowed size.",
+                    )
+
+                media.write(chunk)
+
+        media.seek(0)
+        return media
     except requests.RequestException as err:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Failed to fetch media URL: {err}")
     finally:

--- a/src/llamafactory/api/common.py
+++ b/src/llamafactory/api/common.py
@@ -58,13 +58,18 @@ def check_lfi_path(path: str) -> None:
         os.makedirs(SAFE_MEDIA_PATH, exist_ok=True)
         real_path = os.path.realpath(path)
         safe_path = os.path.realpath(SAFE_MEDIA_PATH)
-
-        if not real_path.startswith(safe_path):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="File access is restricted to the safe media directory."
-            )
-    except Exception:
+    except OSError:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or inaccessible file path.")
+
+    try:
+        is_safe_path = os.path.commonpath([real_path, safe_path]) == safe_path
+    except ValueError:
+        is_safe_path = False
+
+    if not is_safe_path:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="File access is restricted to the safe media directory."
+        )
 
 
 def check_ssrf_url(url: str) -> None:
@@ -78,19 +83,17 @@ def check_ssrf_url(url: str) -> None:
         if not hostname:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid URL hostname.")
 
-        ip_info = socket.getaddrinfo(hostname, parsed_url.port)
-        ip_address_str = ip_info[0][4][0]
-        ip = ipaddress.ip_address(ip_address_str)
-
-        if not ip.is_global:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Access to private or reserved IP addresses is not allowed.",
-            )
+        for ip_info in socket.getaddrinfo(hostname, parsed_url.port, type=socket.SOCK_STREAM):
+            ip = ipaddress.ip_address(ip_info[4][0])
+            if not ip.is_global:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Access to private or reserved IP addresses is not allowed.",
+                )
 
     except socket.gaierror:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=f"Could not resolve hostname: {parsed_url.hostname}"
         )
-    except Exception as e:
+    except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid URL: {e}")

--- a/tests/api/test_chat.py
+++ b/tests/api/test_chat.py
@@ -1,0 +1,85 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from fastapi import HTTPException
+
+from llamafactory.api import chat
+
+
+class FakeResponse:
+    def __init__(self, content: bytes = b"media", is_redirect: bool = False, error: Exception | None = None):
+        self.closed = False
+        self.content = content
+        self.is_redirect = is_redirect
+        self.error = error
+
+    def raise_for_status(self):
+        if self.error is not None:
+            raise self.error
+
+    def close(self):
+        self.closed = True
+
+
+def test_fetch_remote_media_returns_buffer_and_closes_response(monkeypatch):
+    response = FakeResponse(content=b"image")
+
+    monkeypatch.setattr(chat, "check_ssrf_url", lambda url: None)
+    monkeypatch.setattr(chat.requests, "get", lambda *args, **kwargs: response)
+
+    media = chat._fetch_remote_media("https://example.com/image.png")
+
+    assert media.read() == b"image"
+    assert response.closed
+
+
+def test_fetch_remote_media_rejects_redirect_and_closes_response(monkeypatch):
+    response = FakeResponse(is_redirect=True)
+
+    monkeypatch.setattr(chat, "check_ssrf_url", lambda url: None)
+    monkeypatch.setattr(chat.requests, "get", lambda *args, **kwargs: response)
+
+    with pytest.raises(HTTPException) as exc_info:
+        chat._fetch_remote_media("https://example.com/image.png")
+
+    assert exc_info.value.status_code == 403
+    assert response.closed
+
+
+def test_fetch_remote_media_maps_request_errors(monkeypatch):
+    monkeypatch.setattr(chat, "check_ssrf_url", lambda url: None)
+
+    def fake_get(*args, **kwargs):
+        raise chat.requests.Timeout("timed out")
+
+    monkeypatch.setattr(chat.requests, "get", fake_get)
+
+    with pytest.raises(HTTPException) as exc_info:
+        chat._fetch_remote_media("https://example.com/image.png")
+
+    assert exc_info.value.status_code == 400
+
+
+def test_fetch_remote_media_maps_http_errors_and_closes_response(monkeypatch):
+    response = FakeResponse(error=chat.requests.HTTPError("not found"))
+
+    monkeypatch.setattr(chat, "check_ssrf_url", lambda url: None)
+    monkeypatch.setattr(chat.requests, "get", lambda *args, **kwargs: response)
+
+    with pytest.raises(HTTPException) as exc_info:
+        chat._fetch_remote_media("https://example.com/image.png")
+
+    assert exc_info.value.status_code == 400
+    assert response.closed

--- a/tests/api/test_chat.py
+++ b/tests/api/test_chat.py
@@ -19,11 +19,18 @@ from llamafactory.api import chat
 
 
 class FakeResponse:
-    def __init__(self, content: bytes = b"media", is_redirect: bool = False, error: Exception | None = None):
+    def __init__(
+        self,
+        content: bytes = b"media",
+        is_redirect: bool = False,
+        error: Exception | None = None,
+        headers: dict[str, str] | None = None,
+    ):
         self.closed = False
-        self.content = content
+        self.chunks = [content]
         self.is_redirect = is_redirect
         self.error = error
+        self.headers = headers or {}
 
     def raise_for_status(self):
         if self.error is not None:
@@ -32,16 +39,55 @@ class FakeResponse:
     def close(self):
         self.closed = True
 
+    def iter_content(self, chunk_size):
+        yield from self.chunks
+
 
 def test_fetch_remote_media_returns_buffer_and_closes_response(monkeypatch):
     response = FakeResponse(content=b"image")
+    request_kwargs = {}
 
     monkeypatch.setattr(chat, "check_ssrf_url", lambda url: None)
-    monkeypatch.setattr(chat.requests, "get", lambda *args, **kwargs: response)
+
+    def fake_get(*args, **kwargs):
+        request_kwargs.update(kwargs)
+        return response
+
+    monkeypatch.setattr(chat.requests, "get", fake_get)
 
     media = chat._fetch_remote_media("https://example.com/image.png")
 
     assert media.read() == b"image"
+    assert request_kwargs["stream"] is True
+    assert response.closed
+
+
+def test_fetch_remote_media_rejects_large_content_length(monkeypatch):
+    response = FakeResponse(headers={"Content-Length": "6"})
+
+    monkeypatch.setattr(chat, "MAX_REMOTE_MEDIA_SIZE", 5)
+    monkeypatch.setattr(chat, "check_ssrf_url", lambda url: None)
+    monkeypatch.setattr(chat.requests, "get", lambda *args, **kwargs: response)
+
+    with pytest.raises(HTTPException) as exc_info:
+        chat._fetch_remote_media("https://example.com/image.png")
+
+    assert exc_info.value.status_code == 413
+    assert response.closed
+
+
+def test_fetch_remote_media_rejects_large_stream(monkeypatch):
+    response = FakeResponse()
+    response.chunks = [b"abc", b"def"]
+
+    monkeypatch.setattr(chat, "MAX_REMOTE_MEDIA_SIZE", 5)
+    monkeypatch.setattr(chat, "check_ssrf_url", lambda url: None)
+    monkeypatch.setattr(chat.requests, "get", lambda *args, **kwargs: response)
+
+    with pytest.raises(HTTPException) as exc_info:
+        chat._fetch_remote_media("https://example.com/image.png")
+
+    assert exc_info.value.status_code == 413
     assert response.closed
 
 

--- a/tests/api/test_common.py
+++ b/tests/api/test_common.py
@@ -1,0 +1,72 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import socket
+
+import pytest
+from fastapi import HTTPException
+
+from llamafactory.api import common
+
+
+def test_check_lfi_path_allows_safe_child(tmp_path, monkeypatch):
+    safe_dir = tmp_path / "safe"
+    media_file = safe_dir / "image.png"
+    safe_dir.mkdir()
+    media_file.write_bytes(b"image")
+
+    monkeypatch.setattr(common, "ALLOW_LOCAL_FILES", True)
+    monkeypatch.setattr(common, "SAFE_MEDIA_PATH", str(safe_dir))
+
+    common.check_lfi_path(str(media_file))
+
+
+def test_check_lfi_path_rejects_prefix_sibling(tmp_path, monkeypatch):
+    safe_dir = tmp_path / "safe"
+    sibling_dir = tmp_path / "safe_evil"
+    sibling_file = sibling_dir / "image.png"
+    sibling_dir.mkdir()
+    sibling_file.write_bytes(b"image")
+
+    monkeypatch.setattr(common, "ALLOW_LOCAL_FILES", True)
+    monkeypatch.setattr(common, "SAFE_MEDIA_PATH", str(safe_dir))
+
+    with pytest.raises(HTTPException) as exc_info:
+        common.check_lfi_path(str(sibling_file))
+
+    assert exc_info.value.status_code == 403
+
+
+def test_check_ssrf_url_checks_all_resolved_addresses(monkeypatch):
+    def fake_getaddrinfo(hostname, port, type=0):
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port or 80)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", port or 80)),
+        ]
+
+    monkeypatch.setattr(common.socket, "getaddrinfo", fake_getaddrinfo)
+
+    with pytest.raises(HTTPException) as exc_info:
+        common.check_ssrf_url("https://example.com/image.png")
+
+    assert exc_info.value.status_code == 403
+
+
+def test_check_ssrf_url_allows_global_addresses(monkeypatch):
+    def fake_getaddrinfo(hostname, port, type=0):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port or 80))]
+
+    monkeypatch.setattr(common.socket, "getaddrinfo", fake_getaddrinfo)
+
+    common.check_ssrf_url("https://example.com/image.png")


### PR DESCRIPTION
# What does this PR do?

This PR hardens media input validation in the OpenAI-compatible API for `image_url`, `video_url`, and `audio_url` content parts.

The API already has SSRF/LFI checks, but this patch closes several edge cases in those checks:

- Use `os.path.commonpath()` instead of string prefix matching when validating local media paths under `SAFE_MEDIA_PATH`.
- Check every address returned by DNS resolution, rather than only the first resolved IP.
- Disable redirects and add a timeout when fetching remote media URLs.
- Add regression tests for local path containment and multi-address DNS validation.

No associated issue.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?