### PR TITLE
support early_stopping_threshold in trainer args

### DIFF
--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -567,6 +567,10 @@ class FinetuningArguments(
         default=None,
         metadata={"help": "Number of steps to stop training if the `metric_for_best_model` does not improve."},
     )
+    early_stopping_threshold: float = field(
+        default=0.0,
+        metadata={"help": "How much the `metric_for_best_model` must improve to not trigger early stopping."},
+    )
     plot_loss: bool = field(
         default=False,
         metadata={"help": "Whether or not to save the training loss curves."},

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -548,6 +548,10 @@ class FinetuningArguments(
         default=None,
         metadata={"help": "Number of steps to stop training if the `metric_for_best_model` does not improve."},
     )
+    early_stopping_threshold: float = field(
+        default=0.0,
+        metadata={"help": "How much the `metric_for_best_model` must improve to not trigger early stopping."},
+    )
     plot_loss: bool = field(
         default=False,
         metadata={"help": "Whether or not to save the training loss curves."},

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -569,7 +569,12 @@ class FinetuningArguments(
     )
     early_stopping_threshold: float = field(
         default=0.0,
-        metadata={"help": "How much the `metric_for_best_model` must improve to not trigger early stopping."},
+        metadata={
+            "help": (
+                "How much the `metric_for_best_model` must improve to not trigger early stopping. "
+                "Requires `early_stopping_steps`."
+            )
+        },
     )
     plot_loss: bool = field(
         default=False,

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -563,16 +563,26 @@ class FinetuningArguments(
         default=False,
         metadata={"help": "Whether or not to disable the shuffling of the training set."},
     )
+    early_stopping_patience: int | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Number of evaluations with no improvement in `metric_for_best_model` after which training stops. "
+                "Counted in evaluation calls, not training steps. Requires `metric_for_best_model` and an "
+                "`eval_strategy` other than `no`."
+            )
+        },
+    )
     early_stopping_steps: int | None = field(
         default=None,
-        metadata={"help": "Number of steps to stop training if the `metric_for_best_model` does not improve."},
+        metadata={"help": "Deprecated alias of `early_stopping_patience`."},
     )
     early_stopping_threshold: float = field(
         default=0.0,
         metadata={
             "help": (
-                "How much the `metric_for_best_model` must improve to not trigger early stopping. "
-                "Requires `early_stopping_steps`."
+                "How much the `metric_for_best_model` must improve to count as an improvement. "
+                "Requires `early_stopping_patience`."
             )
         },
     )
@@ -600,6 +610,9 @@ class FinetuningArguments(
         self.galore_target: list[str] = split_arg(self.galore_target)
         self.apollo_target: list[str] = split_arg(self.apollo_target)
         self.use_ref_model = self.stage == "dpo" and self.pref_loss not in ["orpo", "simpo"]
+
+        if self.early_stopping_steps is not None and self.early_stopping_patience is None:
+            self.early_stopping_patience = self.early_stopping_steps
 
         assert self.finetuning_type in ["lora", "oft", "freeze", "full"], "Invalid fine-tuning method."
         assert self.ref_model_quantization_bit in [None, 8, 4], "We only accept 4-bit or 8-bit quantization."

--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -581,8 +581,14 @@ def get_train_args(args: dict[str, Any] | list[str] | None = None) -> _TRAIN_CLS
     if (not training_args.do_train) and finetuning_args.stage == "dpo" and finetuning_args.ref_model is None:
         logger.warning_rank0("Specify `ref_model` for computing rewards at evaluation.")
 
-    if finetuning_args.early_stopping_threshold > 0.0 and finetuning_args.early_stopping_steps is None:
-        logger.warning_rank0("`early_stopping_threshold` requires `early_stopping_steps` to take effect.")
+    if finetuning_args.early_stopping_steps is not None:
+        logger.warning_rank0(
+            "`early_stopping_steps` is deprecated, use `early_stopping_patience` instead. "
+            "It counts evaluations, not training steps."
+        )
+
+    if finetuning_args.early_stopping_threshold > 0.0 and finetuning_args.early_stopping_patience is None:
+        logger.warning_rank0("`early_stopping_threshold` requires `early_stopping_patience` to take effect.")
 
     # Post-process training arguments
     training_args.generation_max_length = training_args.generation_max_length or data_args.cutoff_len

--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -581,6 +581,9 @@ def get_train_args(args: dict[str, Any] | list[str] | None = None) -> _TRAIN_CLS
     if (not training_args.do_train) and finetuning_args.stage == "dpo" and finetuning_args.ref_model is None:
         logger.warning_rank0("Specify `ref_model` for computing rewards at evaluation.")
 
+    if finetuning_args.early_stopping_threshold > 0.0 and finetuning_args.early_stopping_steps is None:
+        logger.warning_rank0("`early_stopping_threshold` requires `early_stopping_steps` to take effect.")
+
     # Post-process training arguments
     training_args.generation_max_length = training_args.generation_max_length or data_args.cutoff_len
     training_args.generation_num_beams = data_args.eval_num_beams or training_args.generation_num_beams

--- a/src/llamafactory/train/tuner.py
+++ b/src/llamafactory/train/tuner.py
@@ -78,7 +78,12 @@ def _training_function(config: dict[str, Any]) -> None:
         callbacks.append(get_swanlab_callback(finetuning_args))
 
     if finetuning_args.early_stopping_steps is not None:
-        callbacks.append(EarlyStoppingCallback(early_stopping_patience=finetuning_args.early_stopping_steps))
+        callbacks.append(
+            EarlyStoppingCallback(
+                early_stopping_patience=finetuning_args.early_stopping_steps,
+                early_stopping_threshold=finetuning_args.early_stopping_threshold,
+            )
+        )
 
     if getattr(training_args, "enable_torch_profiler", False):
         callbacks.append(TorchProfilerCallback(training_args))

--- a/src/llamafactory/train/tuner.py
+++ b/src/llamafactory/train/tuner.py
@@ -79,7 +79,12 @@ def _training_function(config: dict[str, Any]) -> None:
         callbacks.append(get_swanlab_callback(finetuning_args))
 
     if finetuning_args.early_stopping_steps is not None:
-        callbacks.append(EarlyStoppingCallback(early_stopping_patience=finetuning_args.early_stopping_steps))
+        callbacks.append(
+            EarlyStoppingCallback(
+                early_stopping_patience=finetuning_args.early_stopping_steps,
+                early_stopping_threshold=finetuning_args.early_stopping_threshold,
+            )
+        )
 
     if getattr(training_args, "enable_torch_profiler", False):
         callbacks.append(TorchProfilerCallback(training_args))

--- a/src/llamafactory/train/tuner.py
+++ b/src/llamafactory/train/tuner.py
@@ -78,10 +78,10 @@ def _training_function(config: dict[str, Any]) -> None:
     if finetuning_args.use_swanlab:
         callbacks.append(get_swanlab_callback(finetuning_args))
 
-    if finetuning_args.early_stopping_steps is not None:
+    if finetuning_args.early_stopping_patience is not None:
         callbacks.append(
             EarlyStoppingCallback(
-                early_stopping_patience=finetuning_args.early_stopping_steps,
+                early_stopping_patience=finetuning_args.early_stopping_patience,
                 early_stopping_threshold=finetuning_args.early_stopping_threshold,
             )
         )


### PR DESCRIPTION
## What does this PR do?

Fixes #9123

Adds an `early_stopping_threshold` finetuning argument that is forwarded to HuggingFace's `EarlyStoppingCallback`. Default `0.0` preserves current behavior.

## Before submitting

- [x] Did you read the contributor guideline?
- [ ] Did you write any new necessary tests?
