### PR TITLE
fix: allow OFT adapter to be loaded for inference (#9563)

### DIFF
--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -182,8 +182,8 @@ def _verify_model_args(
     data_args: "DataArguments",
     finetuning_args: "FinetuningArguments",
 ) -> None:
-    if model_args.adapter_name_or_path is not None and finetuning_args.finetuning_type != "lora":
-        raise ValueError("Adapter is only valid for the LoRA method.")
+    if model_args.adapter_name_or_path is not None and finetuning_args.finetuning_type not in ["lora", "oft"]:
+        raise ValueError("Adapter is only valid for the LoRA or OFT method.")
 
     if model_args.quantization_bit is not None:
         if finetuning_args.finetuning_type not in ["lora", "oft"]:


### PR DESCRIPTION
**Closes #9563**
    
### Problem

`_verify_model_args` raises an error when loading an OFT adapter for inference or export: “ValueError: Adapter is only valid for the LoRA method.” Both `llamafactory-cli export` and `llamafactory-cli chat` are affected.

### Root Cause

In `src/llamafactory/hparams/parser.py` line 185, the guard condition only allows `finetuning_type == "lora"` to load an adapter via `adapter_name_or_path`. OFT adapters are rejected before the actual loading logic in `adapter.py` even runs.

### Fix

Changed `!= "lora"` to `not in ["lora", "oft"]` to also accept OFT adapters. This is consistent with the quantization check right below (line 189)  which already accepts both LoRA and OFT.

### Verification

End-to-end test with Qwen2.5-0.5B + OFT SFT:
1. `llamafactory-cli train` — OFT training completes successfully
2. `llamafactory-cli export` — OFT adapter merged and exported
3. `llamafactory-cli chat` — inference produces output without error
