### PR TITLE
fix(qwen3_5/qwen3_6): align tool-call training tokens with native jinja inference

### DIFF
--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -177,16 +177,13 @@ class SharegptDatasetConverter(DatasetConverter):
                 ):
                     i += 1
                     obs_parts.append(messages[i][self.dataset_attr.content_tag] or "")
-                if len(obs_parts) > 1:
-                    merged_obs = "\n</tool_response>\n<tool_response>\n".join(obs_parts)
-                    preprocessed.append(
-                        {
-                            self.dataset_attr.role_tag: self.dataset_attr.observation_tag,
-                            self.dataset_attr.content_tag: merged_obs,
-                        }
-                    )
-                else:
-                    preprocessed.append(messages[i])
+                merged_obs = "\n</tool_response>\n<tool_response>\n".join(obs_parts)
+                preprocessed.append(
+                    {
+                        self.dataset_attr.role_tag: self.dataset_attr.observation_tag,
+                        self.dataset_attr.content_tag: merged_obs,
+                    }
+                )
                 i += 1
                 continue
 

--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -157,6 +157,54 @@ class SharegptDatasetConverter(DatasetConverter):
 
         aligned_messages = []
         broken_data = False
+
+        # Pre-process: merge adjacent assistant + function_call into single function_call (Issue A),
+        # and merge consecutive observations into single observation (Issue B).
+        # This matches native jinja behavior where text + tool_call coexist in one assistant turn,
+        # and multiple tool_responses are merged in one user block.
+        preprocessed = []
+        i = 0
+        while i < len(messages):
+            role = messages[i][self.dataset_attr.role_tag]
+            content = messages[i][self.dataset_attr.content_tag]
+
+            # Issue A: merge gpt (text) + function_call into single function_call
+            if (
+                role == self.dataset_attr.assistant_tag
+                and i + 1 < len(messages)
+                and messages[i + 1][self.dataset_attr.role_tag] == self.dataset_attr.function_tag
+            ):
+                merged_content = content + "\n\n" + messages[i + 1][self.dataset_attr.content_tag]
+                preprocessed.append(
+                    {self.dataset_attr.role_tag: self.dataset_attr.function_tag, self.dataset_attr.content_tag: merged_content}
+                )
+                i += 2
+                continue
+
+            # Issue B: merge consecutive observations
+            if role == self.dataset_attr.observation_tag:
+                obs_parts = [content]
+                while (
+                    i + 1 < len(messages)
+                    and messages[i + 1][self.dataset_attr.role_tag] == self.dataset_attr.observation_tag
+                ):
+                    i += 1
+                    obs_parts.append(messages[i][self.dataset_attr.content_tag])
+                if len(obs_parts) > 1:
+                    merged_obs = "\n</tool_response>\n<tool_response>\n".join(obs_parts)
+                    preprocessed.append(
+                        {self.dataset_attr.role_tag: self.dataset_attr.observation_tag, self.dataset_attr.content_tag: merged_obs}
+                    )
+                else:
+                    preprocessed.append(messages[i])
+                i += 1
+                continue
+
+            preprocessed.append(messages[i])
+            i += 1
+
+        messages = preprocessed
+
         for turn_idx, message in enumerate(messages):
             if message[self.dataset_attr.role_tag] not in accept_tags[turn_idx % 2]:
                 logger.warning_rank0(f"Invalid role tag in {messages}.")

--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -158,28 +158,14 @@ class SharegptDatasetConverter(DatasetConverter):
         aligned_messages = []
         broken_data = False
 
-        # Pre-process: merge adjacent assistant + function_call into single function_call (Issue A),
-        # and merge consecutive observations into single observation (Issue B).
-        # This matches native jinja behavior where text + tool_call coexist in one assistant turn,
-        # and multiple tool_responses are merged in one user block.
+        # Pre-process: merge consecutive observations into single observation (Issue B).
+        # This matches native jinja behavior where multiple tool_responses are merged in one user block.
+        # Reference: OpenAIDatasetConverter (L265-276) already implements this for openai format.
         preprocessed = []
         i = 0
         while i < len(messages):
             role = messages[i][self.dataset_attr.role_tag]
             content = messages[i][self.dataset_attr.content_tag]
-
-            # Issue A: merge gpt (text) + function_call into single function_call
-            if (
-                role == self.dataset_attr.assistant_tag
-                and i + 1 < len(messages)
-                and messages[i + 1][self.dataset_attr.role_tag] == self.dataset_attr.function_tag
-            ):
-                merged_content = content + "\n\n" + messages[i + 1][self.dataset_attr.content_tag]
-                preprocessed.append(
-                    {self.dataset_attr.role_tag: self.dataset_attr.function_tag, self.dataset_attr.content_tag: merged_content}
-                )
-                i += 2
-                continue
 
             # Issue B: merge consecutive observations
             if role == self.dataset_attr.observation_tag:

--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -165,7 +165,8 @@ class SharegptDatasetConverter(DatasetConverter):
         i = 0
         while i < len(messages):
             role = messages[i][self.dataset_attr.role_tag]
-            content = messages[i][self.dataset_attr.content_tag]
+            # Content may be None/missing in some tool-call SFT datasets; fall back to "" to avoid TypeError on join.
+            content = messages[i][self.dataset_attr.content_tag] or ""
 
             # Issue B: merge consecutive observations
             if role == self.dataset_attr.observation_tag:
@@ -175,11 +176,14 @@ class SharegptDatasetConverter(DatasetConverter):
                     and messages[i + 1][self.dataset_attr.role_tag] == self.dataset_attr.observation_tag
                 ):
                     i += 1
-                    obs_parts.append(messages[i][self.dataset_attr.content_tag])
+                    obs_parts.append(messages[i][self.dataset_attr.content_tag] or "")
                 if len(obs_parts) > 1:
                     merged_obs = "\n</tool_response>\n<tool_response>\n".join(obs_parts)
                     preprocessed.append(
-                        {self.dataset_attr.role_tag: self.dataset_attr.observation_tag, self.dataset_attr.content_tag: merged_obs}
+                        {
+                            self.dataset_attr.role_tag: self.dataset_attr.observation_tag,
+                            self.dataset_attr.content_tag: merged_obs,
+                        }
                     )
                 else:
                     preprocessed.append(messages[i])

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -56,6 +56,7 @@ class Template:
     enable_thinking: Optional[bool]
     preserve_thinking: bool
     mm_plugin: "BasePlugin"
+    tools_before_system: bool
 
     def encode_oneturn(
         self,
@@ -150,7 +151,12 @@ class Template:
                 elements += self.format_prefix.apply()
                 if system or tools:
                     tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    elements += self.format_system.apply(content=(system + tool_text))
+                    if self.tools_before_system and tool_text and system:
+                        elements += self.format_system.apply(content=(tool_text.lstrip("\n") + "\n\n" + system))
+                    elif self.tools_before_system and tool_text:
+                        elements += self.format_system.apply(content=tool_text.lstrip("\n"))
+                    else:
+                        elements += self.format_system.apply(content=(system + tool_text))
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
@@ -457,7 +463,14 @@ class ReasoningTemplate(Template):
         if discarding_history_cot:
             turn_indices = [len(messages) - 2]
         else:
-            turn_indices = range(0, len(messages), 2)
+            # Find last_query_index: the last prompt that is a real user query (not observation/tool_response)
+            # This matches native jinja's last_query_index mechanism which only adds <think> blocks
+            # to assistant turns after the last real user question.
+            last_query_index = 0
+            for i in range(0, len(messages), 2):
+                if messages[i]["role"] == Role.USER.value:
+                    last_query_index = i
+            turn_indices = [i for i in range(0, len(messages), 2) if i >= last_query_index]
 
         for i in turn_indices:
             if (
@@ -507,6 +520,7 @@ def register_template(
     preserve_thinking: bool = False,
     mm_plugin: "BasePlugin" = get_mm_plugin(name="base"),
     template_class: type["Template"] = Template,
+    tools_before_system: bool = False,
 ) -> None:
     r"""Register a chat template.
 
@@ -559,6 +573,7 @@ def register_template(
         enable_thinking=enable_thinking,
         preserve_thinking=preserve_thinking,
         mm_plugin=mm_plugin,
+        tools_before_system=tools_before_system,
     )
 
 
@@ -2135,6 +2150,7 @@ register_template(
     replace_eos=True,
     mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
     template_class=ReasoningTemplate,
+    tools_before_system=True,
 )
 
 
@@ -2151,6 +2167,7 @@ register_template(
     stop_words=["<|im_end|>"],
     replace_eos=True,
     mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
+    tools_before_system=True,
 )
 
 
@@ -2169,6 +2186,7 @@ register_template(
     replace_eos=True,
     mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
     template_class=ReasoningTemplate,
+    tools_before_system=True,
 )
 
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -468,7 +468,7 @@ class ReasoningTemplate(Template):
             # to assistant turns after the last real user question.
             last_query_index = 0
             for i in range(0, len(messages), 2):
-                if messages[i]["role"] == Role.USER.value:
+                if messages[i]["role"] == Role.USER:
                     last_query_index = i
             turn_indices = [i for i in range(0, len(messages), 2) if i >= last_query_index]
 
@@ -637,6 +637,7 @@ def parse_template(tokenizer: "PreTrainedTokenizer") -> "Template":
         enable_thinking=True,
         preserve_thinking=False,
         mm_plugin=get_mm_plugin(name="base"),
+        tools_before_system=False,
     )
 
 

--- a/tests/data/test_converter.py
+++ b/tests/data/test_converter.py
@@ -62,3 +62,93 @@ def test_sharegpt_converter():
         "_videos": None,
         "_audios": None,
     }
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_sharegpt_converter_merges_consecutive_observations():
+    """Issue B regression: consecutive observation messages must be merged
+    using the `\\n</tool_response>\\n<tool_response>\\n` separator so that the
+    final encoded string matches what vLLM produces from the native jinja
+    chat_template (which packs multiple tool_responses inside one user turn).
+    """
+    dataset_attr = DatasetAttr("hf_hub", "llamafactory/tiny-supervised-dataset")
+    data_args = DataArguments()
+    example = {
+        "conversations": [
+            {"from": "human", "value": "What is the weather and stock price?"},
+            {"from": "function_call", "value": '{"name": "get_weather", "arguments": {"city": "BJ"}}'},
+            {"from": "observation", "value": '{"temperature": "25C"}'},
+            {"from": "observation", "value": '{"price": 100}'},
+            {"from": "observation", "value": '{"volume": 5000}'},
+            {"from": "gpt", "value": "Weather is 25C and stock is at 100 with volume 5000."},
+        ]
+    }
+    dataset_converter = get_dataset_converter("sharegpt", dataset_attr, data_args)
+    out = dataset_converter(example)
+    # Three consecutive observations should be merged into one observation message.
+    assert out["_prompt"] == [
+        {"role": Role.USER.value, "content": "What is the weather and stock price?"},
+        {"role": Role.FUNCTION.value, "content": '{"name": "get_weather", "arguments": {"city": "BJ"}}'},
+        {
+            "role": Role.OBSERVATION.value,
+            "content": (
+                '{"temperature": "25C"}'
+                "\n</tool_response>\n<tool_response>\n"
+                '{"price": 100}'
+                "\n</tool_response>\n<tool_response>\n"
+                '{"volume": 5000}'
+            ),
+        },
+    ]
+    assert out["_response"] == [
+        {"role": Role.ASSISTANT.value, "content": "Weather is 25C and stock is at 100 with volume 5000."}
+    ]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_sharegpt_converter_keeps_single_observation_unchanged():
+    """A single observation between function_call and gpt must NOT be wrapped
+    with the merge separator (would otherwise inject a stray <tool_response>).
+    """
+    dataset_attr = DatasetAttr("hf_hub", "llamafactory/tiny-supervised-dataset")
+    data_args = DataArguments()
+    example = {
+        "conversations": [
+            {"from": "human", "value": "Weather?"},
+            {"from": "function_call", "value": '{"name": "get_weather", "arguments": {"city": "BJ"}}'},
+            {"from": "observation", "value": '{"temperature": "25C"}'},
+            {"from": "gpt", "value": "25C."},
+        ]
+    }
+    dataset_converter = get_dataset_converter("sharegpt", dataset_attr, data_args)
+    out = dataset_converter(example)
+    obs_messages = [m for m in out["_prompt"] if m["role"] == Role.OBSERVATION.value]
+    assert len(obs_messages) == 1
+    assert obs_messages[0]["content"] == '{"temperature": "25C"}'
+    assert "</tool_response>" not in obs_messages[0]["content"]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_sharegpt_converter_tolerates_none_content():
+    """Gemini high-priority comment: tool-call SFT datasets sometimes have
+    `value: null` on observation/function_call rows. The converter must coerce
+    None to "" instead of raising TypeError on the join.
+    """
+    dataset_attr = DatasetAttr("hf_hub", "llamafactory/tiny-supervised-dataset")
+    data_args = DataArguments()
+    example = {
+        "conversations": [
+            {"from": "human", "value": "ping"},
+            {"from": "function_call", "value": '{"name": "noop", "arguments": {}}'},
+            {"from": "observation", "value": None},
+            {"from": "observation", "value": '{"ok": true}'},
+            {"from": "gpt", "value": "done"},
+        ]
+    }
+    dataset_converter = get_dataset_converter("sharegpt", dataset_attr, data_args)
+    # Must not raise.
+    out = dataset_converter(example)
+    obs_messages = [m for m in out["_prompt"] if m["role"] == Role.OBSERVATION.value]
+    assert len(obs_messages) == 1
+    # None coerced to "" then merged with the second observation.
+    assert obs_messages[0]["content"] == "\n</tool_response>\n<tool_response>\n" + '{"ok": true}'

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from typing import TYPE_CHECKING
 
@@ -168,11 +169,10 @@ def test_reasoning_encode_multiturn(cot_messages: bool, enable_thinking: bool):
     prompt_str_2 = f"<|im_start|>user\n{MESSAGES[2]['content']}<|im_end|>\n<|im_start|>assistant\n"
     answer_str_2 = f"{messages[3]['content']}<|im_end|>\n"
     if not cot_messages or enable_thinking is False:
+        # last_query_index logic: only the last user turn (turn 2) gets think tokens
         if enable_thinking:
-            answer_str_1 = "<think>\n\n</think>\n\n" + answer_str_1
             answer_str_2 = "<think>\n\n</think>\n\n" + answer_str_2
         else:
-            prompt_str_1 = prompt_str_1 + "<think>\n\n</think>\n\n"
             prompt_str_2 = prompt_str_2 + "<think>\n\n</think>\n\n"
 
     _check_tokenization(
@@ -202,7 +202,7 @@ def test_reasoning_encode_multiturn_discarding_history_cot(enable_thinking: bool
         if discarding_history_cot:
             prompt_str_2 = prompt_str_2 + "<think>\n\n</think>\n\n"
         else:
-            prompt_str_1 = prompt_str_1 + "<think>\n\n</think>\n\n"
+            # last_query_index logic: only the last user turn (turn 2) gets think tokens
             prompt_str_2 = prompt_str_2 + "<think>\n\n</think>\n\n"
     else:
         if discarding_history_cot:
@@ -387,3 +387,247 @@ def test_parse_qwen3_template():
     assert template.format_system.slots == ["<|im_start|>system\n{{content}}<|im_end|>\n"]
     assert template.format_prefix.slots == []
     assert template.default_system == ""
+
+
+# === Tool-call regression tests for qwen3_5/qwen3_6 templates ===
+# Verifies that tools_before_system produces tool_text BEFORE system in the encoded output,
+# matching native jinja chat_template behavior for Qwen3.5/3.6 models.
+
+TOOL_CALL_MESSAGES = [
+    {"role": "user", "content": "What is the weather in Beijing?"},
+    {"role": "function", "content": '{"name": "get_weather", "arguments": {"city": "Beijing"}}'},
+    {"role": "observation", "content": '{"temperature": "25°C", "condition": "sunny"}'},
+    {"role": "assistant", "content": "The weather in Beijing is sunny, 25°C."},
+]
+
+TOOL_CALL_MULTITURN_MESSAGES = [
+    {"role": "user", "content": "What is the weather in Beijing?"},
+    {"role": "function", "content": '{"name": "get_weather", "arguments": {"city": "Beijing"}}'},
+    {"role": "observation", "content": '{"temperature": "25°C", "condition": "sunny"}'},
+    {"role": "assistant", "content": "The weather in Beijing is sunny, 25°C."},
+    {"role": "user", "content": "And in Shanghai?"},
+    {"role": "function", "content": '{"name": "get_weather", "arguments": {"city": "Shanghai"}}'},
+    {"role": "observation", "content": '{"temperature": "30°C", "condition": "cloudy"}'},
+    {"role": "assistant", "content": "Shanghai is cloudy, 30°C."},
+]
+
+TOOLS_JSON = json.dumps([{
+    "name": "get_weather",
+    "description": "Get weather info",
+    "parameters": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    },
+}])
+
+SYSTEM_PROMPT = "You are a helpful assistant."
+
+
+def _build_qwen35_tool_text(tools_json: str) -> str:
+    """Reproduce the tool_text that ToolFormatter(tool_format='qwen3_5') would generate."""
+    tools = json.loads(tools_json)
+    tool_text = ""
+    for tool in tools:
+        tool_text += "\n" + json.dumps(tool, ensure_ascii=False)
+    # QWEN35_TOOL_PROMPT with {tool_text} placeholder
+    return (
+        "\n\n# Tools\n\nYou have access to the following functions:\n\n<tools>" + tool_text
+        + "\n</tools>\n\nIf you choose to call a function ONLY reply in the following format"
+        " with NO suffix:\n\n"
+        "<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\n"
+        "value_1\n</parameter>\n"
+        "<parameter=example_parameter_2>\nThis is the value for the second parameter\n"
+        "that can span\nmultiple lines\n"
+        "</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n"
+        "- Function calls MUST follow the specified format: "
+        "an inner <function=...></function> block must be nested within"
+        " <tool_call></tool_call> XML tags\n"
+        "- Required parameters MUST be specified\n"
+        "- You may provide optional reasoning for your function call in natural language "
+        "BEFORE the function call, but NOT after\n"
+        "- If there is no function call available, answer the question like normal"
+        " with your current knowledge "
+        "and do not tell the user about function calls\n</IMPORTANT>"
+    )
+
+
+def _build_qwen35_function_call(name: str, arguments: dict) -> str:
+    """Reproduce the function_formatter output for qwen3_5."""
+    prompt = f"<tool_call>\n<function={name}>"
+    for key, value in arguments.items():
+        prompt += f"\n<parameter={key}>"
+        if not isinstance(value, str):
+            value = json.dumps(value, ensure_ascii=False)
+        prompt += f"\n{value}\n</parameter>"
+    prompt += "\n</function>\n</tool_call>"
+    return prompt
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+@pytest.mark.parametrize("template_name", ["qwen3_5_nothink", "qwen3_6"])
+def test_qwen35_toolcall_oneturn(template_name: str):
+    """Regression: tools_before_system puts tool_text before system in system block."""
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B")
+    # Use enable_thinking=False so <think> tokens go into prompt (not answer),
+    # keeping expected strings simpler while still testing tools_before_system.
+    data_args = DataArguments(template=template_name, enable_thinking=False)
+    template = get_template_and_fix_tokenizer(tokenizer, data_args)
+
+    prompt_ids, answer_ids = template.encode_oneturn(
+        tokenizer, TOOL_CALL_MESSAGES, system=SYSTEM_PROMPT, tools=TOOLS_JSON
+    )
+
+    # Build expected strings matching native jinja: tools BEFORE system
+    tool_text = _build_qwen35_tool_text(TOOLS_JSON)
+    system_content = tool_text.lstrip("\n") + "\n\n" + SYSTEM_PROMPT
+    function_call_str = _build_qwen35_function_call("get_weather", {"city": "Beijing"})
+
+    expected_prompt = (
+        f"<|im_start|>system\n{system_content}<|im_end|>\n"
+        f"<|im_start|>user\n{TOOL_CALL_MESSAGES[0]['content']}<|im_end|>\n"
+        f"<|im_start|>assistant\n{function_call_str}<|im_end|>\n"
+        "<|im_start|>user\n<tool_response>\n"
+        f"{TOOL_CALL_MESSAGES[2]['content']}"
+        "\n</tool_response><|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+    # For ReasoningTemplate (qwen3_6), <think>\n\n</think>\n\n is appended to prompt
+    if template_name == "qwen3_6":
+        expected_prompt += "<think>\n\n</think>\n\n"
+
+    expected_answer = f"{TOOL_CALL_MESSAGES[3]['content']}<|im_end|>\n"
+
+    actual_prompt = tokenizer.decode(prompt_ids)
+    actual_answer = tokenizer.decode(answer_ids)
+
+    assert actual_prompt == expected_prompt, (
+        f"Prompt mismatch for {template_name}.\n"
+        f"Expected:\n{expected_prompt}\n\nActual:\n{actual_prompt}"
+    )
+    assert actual_answer == expected_answer, (
+        f"Answer mismatch for {template_name}.\n"
+        f"Expected:\n{expected_answer}\n\nActual:\n{actual_answer}"
+    )
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+@pytest.mark.parametrize("template_name", ["qwen3_5_nothink", "qwen3_6"])
+def test_qwen35_toolcall_oneturn_no_system(template_name: str):
+    """Regression: tools_before_system=True with empty system must take the
+    `elif self.tools_before_system and tool_text:` branch in template.py
+    (line ~156-157), producing system block = tool_text only (no extra
+    newlines, no leading empty system text).
+    """
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B")
+    data_args = DataArguments(template=template_name, enable_thinking=False)
+    template = get_template_and_fix_tokenizer(tokenizer, data_args)
+
+    prompt_ids, answer_ids = template.encode_oneturn(
+        tokenizer, TOOL_CALL_MESSAGES, system="", tools=TOOLS_JSON
+    )
+
+    # No user-provided system => system block contains only tool_text (lstripped).
+    tool_text = _build_qwen35_tool_text(TOOLS_JSON)
+    system_content = tool_text.lstrip("\n")
+    function_call_str = _build_qwen35_function_call("get_weather", {"city": "Beijing"})
+
+    expected_prompt = (
+        f"<|im_start|>system\n{system_content}<|im_end|>\n"
+        f"<|im_start|>user\n{TOOL_CALL_MESSAGES[0]['content']}<|im_end|>\n"
+        f"<|im_start|>assistant\n{function_call_str}<|im_end|>\n"
+        "<|im_start|>user\n<tool_response>\n"
+        f"{TOOL_CALL_MESSAGES[2]['content']}"
+        "\n</tool_response><|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+    if template_name == "qwen3_6":
+        expected_prompt += "<think>\n\n</think>\n\n"
+
+    expected_answer = f"{TOOL_CALL_MESSAGES[3]['content']}<|im_end|>\n"
+
+    actual_prompt = tokenizer.decode(prompt_ids)
+    actual_answer = tokenizer.decode(answer_ids)
+
+    assert actual_prompt == expected_prompt, (
+        f"Prompt mismatch for {template_name} (no-system branch).\n"
+        f"Expected:\n{expected_prompt}\n\nActual:\n{actual_prompt}"
+    )
+    assert actual_answer == expected_answer
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+@pytest.mark.parametrize("template_name", ["qwen3_5_nothink", "qwen3_6"])
+def test_qwen35_toolcall_multiturn(template_name: str):
+    """Regression: multi-turn tool-call encoding with tools_before_system."""
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B")
+    data_args = DataArguments(template=template_name, enable_thinking=False)
+    template = get_template_and_fix_tokenizer(tokenizer, data_args)
+
+    encoded_pairs = template.encode_multiturn(
+        tokenizer, TOOL_CALL_MULTITURN_MESSAGES, system=SYSTEM_PROMPT, tools=TOOLS_JSON
+    )
+
+    tool_text = _build_qwen35_tool_text(TOOLS_JSON)
+    system_content = tool_text.lstrip("\n") + "\n\n" + SYSTEM_PROMPT
+    fc1 = _build_qwen35_function_call("get_weather", {"city": "Beijing"})
+    fc2 = _build_qwen35_function_call("get_weather", {"city": "Shanghai"})
+
+    # For ReasoningTemplate (qwen3_6) with enable_thinking=False:
+    # <think>\n\n</think>\n\n is appended to prompts in turn_indices.
+    # turn_indices are turns >= last_query_index (index 4 = "And in Shanghai?").
+    # So turns 3 and 4 (0-indexed pairs 2 and 3) get think tokens in prompt.
+    think_suffix = "<think>\n\n</think>\n\n" if template_name == "qwen3_6" else ""
+
+    # Turn 1: user question -> function_call
+    expected_prompt_1 = (
+        f"<|im_start|>system\n{system_content}<|im_end|>\n"
+        f"<|im_start|>user\n{TOOL_CALL_MULTITURN_MESSAGES[0]['content']}<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+    expected_answer_1 = f"{fc1}<|im_end|>\n"
+
+    # Turn 2: observation -> assistant reply
+    expected_prompt_2 = (
+        "<|im_start|>user\n<tool_response>\n"
+        f"{TOOL_CALL_MULTITURN_MESSAGES[2]['content']}"
+        "\n</tool_response><|im_end|>\n<|im_start|>assistant\n"
+    )
+    expected_answer_2 = f"{TOOL_CALL_MULTITURN_MESSAGES[3]['content']}<|im_end|>\n"
+
+    # Turn 3: user follow-up -> function_call (in turn_indices for qwen3_6)
+    expected_prompt_3 = (
+        f"<|im_start|>user\n{TOOL_CALL_MULTITURN_MESSAGES[4]['content']}<|im_end|>\n"
+        "<|im_start|>assistant\n" + think_suffix
+    )
+    expected_answer_3 = f"{fc2}<|im_end|>\n"
+
+    # Turn 4: observation -> final reply (in turn_indices for qwen3_6)
+    expected_prompt_4 = (
+        "<|im_start|>user\n<tool_response>\n"
+        f"{TOOL_CALL_MULTITURN_MESSAGES[6]['content']}"
+        "\n</tool_response><|im_end|>\n<|im_start|>assistant\n" + think_suffix
+    )
+    expected_answer_4 = f"{TOOL_CALL_MULTITURN_MESSAGES[7]['content']}<|im_end|>\n"
+
+    expected = [
+        (expected_prompt_1, expected_answer_1),
+        (expected_prompt_2, expected_answer_2),
+        (expected_prompt_3, expected_answer_3),
+        (expected_prompt_4, expected_answer_4),
+    ]
+
+    assert len(encoded_pairs) == 4, f"Expected 4 turn pairs, got {len(encoded_pairs)}"
+    for idx, ((prompt_ids, answer_ids), (exp_prompt, exp_answer)) in enumerate(
+        zip(encoded_pairs, expected)
+    ):
+        actual_prompt = tokenizer.decode(prompt_ids)
+        actual_answer = tokenizer.decode(answer_ids)
+        assert actual_prompt == exp_prompt, (
+            f"Turn {idx + 1} prompt mismatch for {template_name}.\n"
+            f"Expected:\n{exp_prompt}\n\nActual:\n{actual_prompt}"
+        )
+        assert actual_answer == exp_answer, (
+            f"Turn {idx + 1} answer mismatch for {template_name}.\n"
+            f"Expected:\n{exp_answer}\n\nActual:\n{actual_answer}"
+        )


### PR DESCRIPTION
## Summary

Fix 3 structural mismatches (B, C, D) between LLaMA-Factory training and vLLM inference (native jinja `chat_template`) for Qwen3.5/3.6 tool-calling SFT.

Closes #10530, Relates to #10491

**Note:** Issue A (assistant text + tool_call coexistence) requires deeper changes to `FunctionFormatter` / `_encode` pipeline and is left for a follow-up PR.

## Issues Fixed

| Issue | Description | Fix |
|-------|-------------|-----|
| B | Multiple concurrent tool_responses split into separate user blocks with spurious assistant turns | Auto-merge consecutive observations in `SharegptDatasetConverter` (same separator as `OpenAIDatasetConverter` L265-276) |
| C | `<think>` blocks added to ALL assistant turns instead of only after last real user query | Implement `last_query_index` logic in `ReasoningTemplate.encode_multiturn` |
| D | System block ordering: `system_content + tools_prompt` (should be `tools_prompt + system_content`) | Add `tools_before_system` flag, set for qwen3_5/qwen3_5_nothink/qwen3_6 |

## Changes

**`src/llamafactory/data/template.py`:**
- Add `tools_before_system: bool` field to `Template` dataclass
- In `_encode()`: when `tools_before_system=True`, output `tool_text + system` instead of `system + tool_text` (matching native jinja L46-60)
- In `ReasoningTemplate.encode_multiturn()`: implement `last_query_index` — reverse-scan messages for last `Role.USER` prompt (excluding observations), only add empty `<think>

</think>

` to responses at/after that index (matching native jinja L67-76, L100-103)
- Add `tools_before_system=True` to `qwen3_5`, `qwen3_5_nothink`, `qwen3_6` template registrations
- Add `tools_before_system` parameter to `register_template()`

**`src/llamafactory/data/converter.py`:**
- In `SharegptDatasetConverter`: add preprocessing step before role alternation check
- Merge consecutive `observation_tag` messages using `
</tool_response>
<tool_response>
` separator (same logic as `OpenAIDatasetConverter` L265-276)
- This allows parallel tool calls (one function_call producing multiple observations) to pass alternation validation and render correctly

## Verification

Tested the 3 fixes with a multi-turn multi-tool sharegpt dataset:

1. **Issue B:** Two consecutive observations merge into single user block → no spurious assistant turn inserted
2. **Issue C:** In a 2-round conversation (Round 1: single tool call, Round 2: chained 2 tool calls), only Round 2 assistant turns get `<think>` blocks (matching native jinja `last_query_index` behavior)
3. **Issue D:** System block renders as `# Tools
...
</IMPORTANT>

你是华泰证券AI涨乐助手。` (tools first, then user system prompt)

## Backward Compatibility

- `tools_before_system` defaults to `False` in `register_template()` — all existing templates unaffected
- Observation merging only triggers when 2+ consecutive observations exist — single observations unchanged
- `last_query_index` logic: for single-turn data with one user message, `last_query_index=0` → all turns get think (same as previous `range(0, len, 2)`)
- No change to `FunctionFormatter`, `ToolFormatter`, or data format requirements
