### PR TITLE
Fix Qwen3.5 tool prompt order

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -56,6 +56,7 @@ class Template:
     enable_thinking: Optional[bool]
     preserve_thinking: bool
     mm_plugin: "BasePlugin"
+    tools_first: bool = False
 
     def encode_oneturn(
         self,
@@ -129,6 +130,13 @@ class Template:
 
         return token_ids
 
+    def _concat_system_and_tools(self, system: str, tool_text: str) -> str:
+        r"""Return the combined system and tool prompt."""
+        if self.tools_first:
+            return tool_text + ("\n\n" if tool_text and system else "") + system
+
+        return system + tool_text
+
     def _encode(
         self,
         tokenizer: "PreTrainedTokenizer",
@@ -150,7 +158,7 @@ class Template:
                 elements += self.format_prefix.apply()
                 if system or tools:
                     tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    elements += self.format_system.apply(content=(system + tool_text))
+                    elements += self.format_system.apply(content=self._concat_system_and_tools(system, tool_text))
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
@@ -355,7 +363,7 @@ class Llama2Template(Template):
                 elements += self.format_prefix.apply()
                 if system or tools:
                     tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    system_text = self.format_system.apply(content=(system + tool_text))[0]
+                    system_text = self.format_system.apply(content=self._concat_system_and_tools(system, tool_text))[0]
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=system_text + message["content"])
@@ -506,6 +514,7 @@ def register_template(
     enable_thinking: Optional[bool] = True,
     preserve_thinking: bool = False,
     mm_plugin: "BasePlugin" = get_mm_plugin(name="base"),
+    tools_first: bool = False,
     template_class: type["Template"] = Template,
 ) -> None:
     r"""Register a chat template.
@@ -559,6 +568,7 @@ def register_template(
         enable_thinking=enable_thinking,
         preserve_thinking=preserve_thinking,
         mm_plugin=mm_plugin,
+        tools_first=tools_first,
     )
 
 
@@ -2134,6 +2144,7 @@ register_template(
     stop_words=["<|im_end|>"],
     replace_eos=True,
     mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
+    tools_first=True,
     template_class=ReasoningTemplate,
 )
 
@@ -2151,6 +2162,7 @@ register_template(
     stop_words=["<|im_end|>"],
     replace_eos=True,
     mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
+    tools_first=True,
 )
 
 
@@ -2168,6 +2180,7 @@ register_template(
     stop_words=["<|im_end|>"],
     replace_eos=True,
     mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
+    tools_first=True,
     template_class=ReasoningTemplate,
 )
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from typing import TYPE_CHECKING
 
@@ -19,7 +20,7 @@ import pytest
 from transformers import AutoTokenizer
 
 from llamafactory.data import get_template_and_fix_tokenizer
-from llamafactory.data.template import parse_template
+from llamafactory.data.template import TEMPLATES, parse_template
 from llamafactory.extras.packages import is_transformers_version_greater_than
 from llamafactory.hparams import DataArguments
 
@@ -46,6 +47,34 @@ MESSAGES_WITH_THOUGHT = [
     {"role": "user", "content": "你好"},
     {"role": "assistant", "content": "<think>\n模型思考内容\n</think>\n\n很高兴认识你！"},
 ]
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search",
+            "description": "search docs",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+]
+
+
+class CharTokenizer:
+    eos_token_id = 0
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return [ord(char) for char in text]
+
+    def decode(self, input_ids: list[int]) -> str:
+        return "".join(chr(input_id) for input_id in input_ids)
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        return ord(token[0])
 
 
 def _check_tokenization(
@@ -89,6 +118,23 @@ def _check_template(
     assert content_str == prompt_str + answer_str
     assert content_ids == prompt_ids + answer_ids
     _check_tokenization(tokenizer, (prompt_ids, answer_ids), (prompt_str, answer_str))
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+@pytest.mark.parametrize("template_name", ["qwen3_5", "qwen3_5_nothink", "qwen3_6"])
+def test_qwen35_tools_precede_system(template_name: str):
+    tokenizer = CharTokenizer()
+    template = TEMPLATES[template_name]
+    prompt_ids, _ = template.encode_oneturn(
+        tokenizer,
+        messages=[{"role": "user", "content": "query"}, {"role": "assistant", "content": "answer"}],
+        system="system content",
+        tools=json.dumps(TOOLS, ensure_ascii=False),
+    )
+    prompt = tokenizer.decode(prompt_ids)
+
+    assert prompt.index("# Tools") < prompt.index("system content")
+    assert "</IMPORTANT>\n\nsystem content<|im_end|>" in prompt
 
 
 @pytest.mark.runs_on(["cpu", "mps"])


### PR DESCRIPTION
## Summary

- add a per-template `tools_first` switch for templates whose native tool-calling chat template places the tool prompt before system content
- enable it only for `qwen3_5`, `qwen3_5_nothink`, and `qwen3_6`
- add an offline tokenizer test covering the Qwen3.5/Qwen3.6 tool/system ordering

Related to #10491 and #10530.

## Why

For Qwen3.5/Qwen3.6 tool-calling SFT, LLaMA-Factory currently concatenates `system + tool_text`, while the native tokenizer/vLLM chat template expects the tools section before system content. This can create a train/inference prompt-order mismatch for tool-calling data.

The change is intentionally scoped to the affected templates. Existing templates keep the previous default ordering.

## Validation

Verified on the requested server with Python 3.11.10:

- `python -m py_compile src/llamafactory/data/template.py tests/data/test_template.py`
- `ruff check src/llamafactory/data/template.py tests/data/test_template.py`
- `ruff format --check src/llamafactory/data/template.py tests/data/test_template.py`
- `pytest -vv --import-mode=importlib tests/data/test_template.py::test_qwen35_tools_precede_system`
- `python tests/check_license.py scripts src tests tests_v1`
- `ruff check scripts src tests tests_v1`
- `ruff format --check scripts src tests tests_v1`

The targeted regression test passed for `qwen3_5`, `qwen3_5_nothink`, and `qwen3_6`.

I also ran the full pytest suite. The new Qwen ordering tests passed, while the suite had unrelated baseline/environment failures from remote Hugging Face model/config/tokenizer loading.