### PR TITLE
[fix] Correct multimodal collator batch index keyword

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -257,7 +257,7 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
 
             if num_sub_seqs <= 1:
                 sample_features = {
-                    "input_ids": features["input_ids"],
+                    "input_ids": features["input_ids"][sample_idx : sample_idx + 1],
                     "attention_mask": features["attention_mask"][sample_idx : sample_idx + 1],
                 }
                 mm_inputs_for_sample = _slice_mm_inputs_for_sample(

--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -261,7 +261,7 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                     "attention_mask": features["attention_mask"][sample_idx : sample_idx + 1],
                 }
                 mm_inputs_for_sample = _slice_mm_inputs_for_sample(
-                    mm_inputs, batch_imglens, batch_vidlens, sample_idx=sample_idx
+                    mm_inputs, batch_imglens, batch_vidlens, batch_idx=sample_idx
                 )
                 self._compute_rope_position_ids(sample_features, mm_inputs_for_sample)
                 all_position_ids.append(sample_features["position_ids"])

--- a/tests/data/test_collator.py
+++ b/tests/data/test_collator.py
@@ -270,6 +270,37 @@ def _get_expected_position_ids(
     return torch.cat(all_position_ids, dim=-1)
 
 
+def test_multimodal_collator_single_sequence_packing_slices_mm_inputs():
+    collator = object.__new__(MultiModalDataCollatorForSeq2Seq)
+    seen_mm_inputs = {}
+
+    def fake_compute_rope_position_ids(features, mm_inputs):
+        seen_mm_inputs.update(mm_inputs)
+        seq_len = features["attention_mask"].size(1)
+        features["position_ids"] = torch.arange(seq_len).unsqueeze(0)
+        features["rope_deltas"] = torch.zeros(features["attention_mask"].size(0))
+
+    collator._compute_rope_position_ids = fake_compute_rope_position_ids
+    features = {
+        "input_ids": torch.tensor([[0, 1, 2]]),
+        "attention_mask": torch.tensor([[1, 1, 1]]),
+    }
+    mm_inputs = {"image_grid_thw": torch.tensor([[1, 4, 4]])}
+
+    collator._compute_rope_position_ids_with_packing(
+        features=features,
+        mm_inputs=mm_inputs,
+        packing_params_list=[{"sequence_boundaries": [0, 3]}],
+        batch_imglens=[1],
+        batch_vidlens=[0],
+        batch_audlens=[0],
+        has_dummy_image=False,
+    )
+
+    assert features["position_ids"].eq(torch.tensor([[0, 1, 2]])).all()
+    assert seen_mm_inputs["image_grid_thw"].eq(torch.tensor([[1, 4, 4]])).all()
+
+
 @pytest.mark.runs_on(["cpu", "mps"])
 def test_multimodal_collator_with_packing():
     model_args, data_args, *_ = get_infer_args(

--- a/tests/data/test_collator.py
+++ b/tests/data/test_collator.py
@@ -270,35 +270,48 @@ def _get_expected_position_ids(
     return torch.cat(all_position_ids, dim=-1)
 
 
+@pytest.mark.runs_on(["cpu", "mps"])
 def test_multimodal_collator_single_sequence_packing_slices_mm_inputs():
     collator = object.__new__(MultiModalDataCollatorForSeq2Seq)
-    seen_mm_inputs = {}
+    seen_calls = []
 
     def fake_compute_rope_position_ids(features, mm_inputs):
-        seen_mm_inputs.update(mm_inputs)
-        seq_len = features["attention_mask"].size(1)
-        features["position_ids"] = torch.arange(seq_len).unsqueeze(0)
-        features["rope_deltas"] = torch.zeros(features["attention_mask"].size(0))
+        assert features["input_ids"].shape == features["attention_mask"].shape
+        seen_calls.append(
+            {
+                "input_ids": features["input_ids"].clone(),
+                "attention_mask": features["attention_mask"].clone(),
+                "image_grid_thw": mm_inputs["image_grid_thw"].clone(),
+            }
+        )
+        features["position_ids"] = features["input_ids"].clone()
+        features["rope_deltas"] = torch.zeros(features["input_ids"].size(0))
 
     collator._compute_rope_position_ids = fake_compute_rope_position_ids
     features = {
-        "input_ids": torch.tensor([[0, 1, 2]]),
-        "attention_mask": torch.tensor([[1, 1, 1]]),
+        "input_ids": torch.tensor([[0, 1, 2], [3, 4, 5]]),
+        "attention_mask": torch.tensor([[1, 1, 1], [1, 1, 0]]),
     }
-    mm_inputs = {"image_grid_thw": torch.tensor([[1, 4, 4]])}
+    mm_inputs = {"image_grid_thw": torch.tensor([[1, 4, 4], [1, 8, 8]])}
 
     collator._compute_rope_position_ids_with_packing(
         features=features,
         mm_inputs=mm_inputs,
-        packing_params_list=[{"sequence_boundaries": [0, 3]}],
-        batch_imglens=[1],
-        batch_vidlens=[0],
-        batch_audlens=[0],
+        packing_params_list=[{"sequence_boundaries": [0, 3]}, {"sequence_boundaries": [0, 3]}],
+        batch_imglens=[1, 1],
+        batch_vidlens=[0, 0],
+        batch_audlens=[0, 0],
         has_dummy_image=False,
     )
 
-    assert features["position_ids"].eq(torch.tensor([[0, 1, 2]])).all()
-    assert seen_mm_inputs["image_grid_thw"].eq(torch.tensor([[1, 4, 4]])).all()
+    assert features["position_ids"].eq(torch.tensor([[0, 1, 2], [3, 4, 5]])).all()
+    assert len(seen_calls) == 2
+    assert seen_calls[0]["input_ids"].eq(torch.tensor([[0, 1, 2]])).all()
+    assert seen_calls[0]["attention_mask"].eq(torch.tensor([[1, 1, 1]])).all()
+    assert seen_calls[0]["image_grid_thw"].eq(torch.tensor([[1, 4, 4]])).all()
+    assert seen_calls[1]["input_ids"].eq(torch.tensor([[3, 4, 5]])).all()
+    assert seen_calls[1]["attention_mask"].eq(torch.tensor([[1, 1, 0]])).all()
+    assert seen_calls[1]["image_grid_thw"].eq(torch.tensor([[1, 8, 8]])).all()
 
 
 @pytest.mark.runs_on(["cpu", "mps"])


### PR DESCRIPTION
## Summary

- Fix the multimodal collator single-sequence packing path to pass `batch_idx` to `_slice_mm_inputs_for_sample`.
- Add a lightweight regression test covering that branch and sliced multimodal inputs.

Closes #10497

## Tests

- `python3 -m py_compile src/llamafactory/data/collator.py tests/data/test_collator.py`
- `git diff --check`
- `ruff check src/llamafactory/data/collator.py tests/data/test_collator.py`
- `ruff format --check src/llamafactory/data/collator.py tests/data/test_collator.py`
- `CUDA_VISIBLE_DEVICES= PYTHONPATH=src HF_ENDPOINT=https://hf-mirror.com python -m pytest tests/data/test_collator.py -q` (`5 passed` on `z-direct`, Python 3.11.14 / transformers 4.56.2)