### PR TITLE
[docs] fix Ascend NPU docs link

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -55,7 +55,7 @@ https://github.com/user-attachments/assets/43b700c6-a178-41db-b1f8-8190a5d3fcfc
 - **入门教程**：https://zhuanlan.zhihu.com/p/695287607
 - **微调视频教程**：https://www.bilibili.com/video/BV1djgRzxEts/
 - **框架文档**：https://llamafactory.readthedocs.io/zh-cn/latest/
-- **框架文档（昇腾 NPU）**：https://ascend.github.io/docs/sources/llamafactory/
+- **框架文档（昇腾 NPU）**：https://ascend.readthedocs.io/zh-cn/latest/sources/llamafactory/
 - **官方博客**：https://blog.llamafactory.net/
 
 > [!NOTE]


### PR DESCRIPTION
## What does this PR do?

Fixes #10527.

Updates the Chinese README's Ascend NPU documentation entry to the current Read the Docs URL. The previous `ascend.github.io` link now returns 404, while the new `ascend.readthedocs.io` link opens the LLaMA-Factory Ascend documentation.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests? This is a README link-only change; no code tests are needed.

## Validation

- `git diff --check upstream/main..HEAD`
- Verified `https://ascend.readthedocs.io/zh-cn/latest/sources/llamafactory/` returns HTTP 200
