### PR TITLE
[data] fix GLM4V video metadata

### DIFF
--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -2464,10 +2464,14 @@ class GLM4VPlugin(Qwen2VLPlugin):
             )
             # prepare video metadata
             video_metadata = [
-                {"fps": 2, "duration": duration, "total_frames": len(video)}
+                {
+                    "fps": getattr(processor, "video_fps", 2.0),
+                    "duration": duration,
+                    "total_num_frames": len(video),
+                }
                 for video, duration in zip(video_data["videos"], video_data["durations"])
             ]
-            mm_inputs.update(video_processor(images=None, videos=video_data["videos"], video_metadata=video_metadata))
+            mm_inputs.update(video_processor(videos=video_data["videos"], video_metadata=video_metadata))
 
         return mm_inputs
 

--- a/tests/data/test_mm_plugin.py
+++ b/tests/data/test_mm_plugin.py
@@ -474,6 +474,39 @@ def test_qwen3_vl_plugin_video_path():
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_glm4v_video_metadata_kwargs():
+    class FakeVideoProcessor:
+        def __call__(self, **kwargs):
+            self.kwargs = kwargs
+            return {"video_grid_thw": torch.tensor([[len(kwargs["videos"][0]), 1, 1]])}
+
+    class FakeProcessor:
+        video_fps = 1.5
+        video_max_pixels = 4096
+        video_min_pixels = 1
+        video_maxlen = 8
+
+        def __init__(self):
+            self.video_processor = FakeVideoProcessor()
+
+    processor = FakeProcessor()
+    glm4v_plugin = get_mm_plugin(name="glm4v", image_token="<|image|>", video_token="<|video|>")
+    glm4v_plugin._get_mm_inputs([], VIDEOS, [], processor)
+
+    video_processor_kwargs = processor.video_processor.kwargs
+    assert "images" not in video_processor_kwargs
+    assert video_processor_kwargs["videos"] == VIDEOS
+    assert video_processor_kwargs["video_metadata"] == [
+        {
+            "fps": processor.video_fps,
+            "duration": len(VIDEOS[0]) / processor.video_fps,
+            "total_num_frames": len(VIDEOS[0]),
+        }
+    ]
+    assert "total_frames" not in video_processor_kwargs["video_metadata"][0]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 @pytest.mark.skipif(not is_transformers_version_greater_than("4.47.0"), reason="Requires transformers>=4.47.0")
 def test_video_llava_plugin():
     image_seqlen = 256


### PR DESCRIPTION
## What does this PR do?

Fixes #9447.

Updates the GLM4V video metadata passed to the transformers video processor:
- use `total_num_frames`, matching the current `VideoMetadata` field name
- avoid passing `images=None` to the video processor

This keeps the existing video regularization path unchanged while preventing the metadata constructor error reported when preprocessing GLM-4V video datasets.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/CONTRIBUTING.md#contributing-guidelines)?
- [x] Did you write any new necessary tests?

## Validation

- `python -m py_compile src/llamafactory/data/mm_plugin.py tests/data/test_mm_plugin.py`
- `git diff --check`
- `ruff check src/llamafactory/data/mm_plugin.py tests/data/test_mm_plugin.py`
- `ruff format --check src/llamafactory/data/mm_plugin.py tests/data/test_mm_plugin.py`
- `PYTHONPATH=src python -m pytest tests/data/test_mm_plugin.py::test_glm4v_video_metadata_kwargs -q`