### PR TITLE
[chat] fix hf engine input kwargs defaults

### DIFF
--- a/src/llamafactory/chat/hf_engine.py
+++ b/src/llamafactory/chat/hf_engine.py
@@ -82,8 +82,9 @@ class HuggingfaceEngine(BaseEngine):
         images: Optional[list["ImageInput"]] = None,
         videos: Optional[list["VideoInput"]] = None,
         audios: Optional[list["AudioInput"]] = None,
-        input_kwargs: Optional[dict[str, Any]] = {},
+        input_kwargs: Optional[dict[str, Any]] = None,
     ) -> tuple[dict[str, Any], int]:
+        input_kwargs = input_kwargs.copy() if input_kwargs is not None else {}
         mm_input_dict = {"images": [], "videos": [], "audios": [], "imglens": [0], "vidlens": [0], "audlens": [0]}
         if images is not None:
             mm_input_dict.update({"images": images, "imglens": [len(images)]})
@@ -221,7 +222,7 @@ class HuggingfaceEngine(BaseEngine):
         images: Optional[list["ImageInput"]] = None,
         videos: Optional[list["VideoInput"]] = None,
         audios: Optional[list["AudioInput"]] = None,
-        input_kwargs: Optional[dict[str, Any]] = {},
+        input_kwargs: Optional[dict[str, Any]] = None,
     ) -> list["Response"]:
         gen_kwargs, prompt_length = HuggingfaceEngine._process_args(
             model,
@@ -276,7 +277,7 @@ class HuggingfaceEngine(BaseEngine):
         images: Optional[list["ImageInput"]] = None,
         videos: Optional[list["VideoInput"]] = None,
         audios: Optional[list["AudioInput"]] = None,
-        input_kwargs: Optional[dict[str, Any]] = {},
+        input_kwargs: Optional[dict[str, Any]] = None,
     ) -> Callable[[], str]:
         gen_kwargs, _ = HuggingfaceEngine._process_args(
             model,
@@ -315,8 +316,9 @@ class HuggingfaceEngine(BaseEngine):
         model: "PreTrainedModelWrapper",
         tokenizer: "PreTrainedTokenizer",
         batch_input: list[str],
-        input_kwargs: Optional[dict[str, Any]] = {},
+        input_kwargs: Optional[dict[str, Any]] = None,
     ) -> list[float]:
+        input_kwargs = input_kwargs.copy() if input_kwargs is not None else {}
         max_length: Optional[int] = input_kwargs.pop("max_length", None)
         device = getattr(model.pretrained_model, "device", "cuda")
         inputs: dict[str, torch.Tensor] = tokenizer(
@@ -329,7 +331,7 @@ class HuggingfaceEngine(BaseEngine):
         ).to(device)
         values: torch.Tensor = model(**inputs, return_dict=True, use_cache=False)[-1]
         scores = values.gather(dim=-1, index=(inputs["attention_mask"].sum(dim=-1, keepdim=True) - 1))
-        return scores
+        return scores.squeeze(-1).tolist()
 
     @override
     async def chat(

--- a/tests/chat/test_hf_engine.py
+++ b/tests/chat/test_hf_engine.py
@@ -1,0 +1,75 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from inspect import signature
+
+import torch
+
+from llamafactory.chat.hf_engine import HuggingfaceEngine
+
+
+class DummyBatch(dict):
+    def to(self, device: str) -> "DummyBatch":
+        return self
+
+
+class DummyTokenizer:
+    max_length: int
+
+    def __call__(
+        self,
+        batch_input: list[str],
+        padding: bool,
+        truncation: bool,
+        max_length: int,
+        return_tensors: str,
+        add_special_tokens: bool,
+    ) -> DummyBatch:
+        self.max_length = max_length
+        return DummyBatch({"attention_mask": torch.ones(len(batch_input), max_length, dtype=torch.long)})
+
+
+class DummyPretrainedModel:
+    device = "cpu"
+
+
+class DummyConfig:
+    max_position_embeddings = 3
+
+
+class DummyModel:
+    pretrained_model = DummyPretrainedModel()
+    config = DummyConfig()
+
+    def __call__(self, **inputs):
+        batch_size, seq_len = inputs["attention_mask"].shape
+        values = torch.arange(batch_size * seq_len, dtype=torch.float).reshape(batch_size, seq_len)
+        return (values,)
+
+
+def test_hf_engine_input_kwargs_default_to_none():
+    for method_name in ["_process_args", "_chat", "_stream_chat", "_get_scores"]:
+        method = HuggingfaceEngine.__dict__[method_name].__func__
+        assert signature(method).parameters["input_kwargs"].default is None
+
+
+def test_get_scores_does_not_mutate_input_kwargs():
+    input_kwargs = {"max_length": 2}
+    tokenizer = DummyTokenizer()
+
+    scores = HuggingfaceEngine._get_scores(DummyModel(), tokenizer, ["first", "second"], input_kwargs)
+
+    assert input_kwargs == {"max_length": 2}
+    assert tokenizer.max_length == 2
+    assert scores == [1.0, 3.0]


### PR DESCRIPTION
# What does this PR do?

Fixes #10476

Updates the Hugging Face engine helpers to use `None` for `input_kwargs` defaults and copy per-call kwargs before consuming generation or scoring options. This prevents a shared default dict from being reused and avoids mutating explicitly provided kwargs when the static helpers are called directly.

The score helper now also returns a flat `list[float]`, matching the `BaseEngine.get_scores` interface and avoiding tensor values in score API responses.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

## Tests

- `ruff check src/llamafactory/chat/hf_engine.py tests/chat/test_hf_engine.py`
- `ruff format --check src/llamafactory/chat/hf_engine.py tests/chat/test_hf_engine.py`
- `PYTHONPATH=src python -m pytest tests/chat/test_hf_engine.py -q`
- `git diff --check`
- `python -m py_compile src/llamafactory/chat/hf_engine.py tests/chat/test_hf_engine.py`