### PR TITLE
[v1][fix] use AutoModelForCausalLM for CLS models to support PEFT/LoRA…

### DIFF
--- a/examples/v1/train_lora/train_lora_rm.yaml
+++ b/examples/v1/train_lora/train_lora_rm.yaml
@@ -1,0 +1,36 @@
+model: Qwen/Qwen3-4B
+model_class: cls
+
+template: qwen3_nothink
+
+
+peft_config:
+  name: lora
+  r: 16
+  lora_alpha: 32
+  lora_dropout: 0.05
+  target_modules: all
+
+# Kernel Config
+kernel_config:
+  name: auto
+  include_kernels: auto
+
+# FSDP Config
+dist_config:
+  name: fsdp2
+  dcp_path: null
+
+### data
+train_dataset: data/v1_dpo_demo.yaml
+
+### training
+output_dir: ./outputs/test_rm
+micro_batch_size: 1
+cutoff_len: 2048
+learning_rate: 1.0e-5
+max_steps: 10
+
+### sample
+sample_backend: hf
+max_new_tokens: 128

--- a/src/llamafactory/v1/core/model_engine.py
+++ b/src/llamafactory/v1/core/model_engine.py
@@ -133,24 +133,13 @@ class ModelEngine:
                 is_trainable=self.is_train,
             )
 
-        if self.args.model_class == ModelClass.LLM:
+        if self.args.model_class in (ModelClass.LLM, ModelClass.CLS):
             from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
 
-            if type(self.model_config) in AutoModelForImageTextToText._model_mapping.keys():
+            if type(self.model_config) in AutoModelForImageTextToText._model_mapping:
                 AutoClass = AutoModelForImageTextToText
             else:
                 AutoClass = AutoModelForCausalLM
-
-        elif self.args.model_class == ModelClass.CLS:
-            from transformers import AutoModelForTokenClassification
-
-            self.model_config.num_labels = 1
-            self.model_config.classifier_dropout = 0.0
-            text_config = getattr(self.model_config, "text_config", None)
-            if text_config is not None:
-                text_config.num_labels = 1
-                text_config.classifier_dropout = 0.0
-            AutoClass = AutoModelForTokenClassification
         else:
             from transformers import AutoModel
 
@@ -172,6 +161,23 @@ class ModelEngine:
 
         init_mode = self.args.init_config.name if self.args.init_config is not None else "init_on_default"
         model._init_mode = init_mode
+
+        # Add a score head for classification / reward modeling tasks.
+        # Using AutoModelForCausalLM ensures PEFT / LoRA compatibility (prepare_inputs_for_generation),
+        # while the manually-added ``score`` linear layer provides per-token scalar rewards.
+        if self.args.model_class == ModelClass.CLS and not hasattr(model, "score"):
+            hidden_size = model.config.hidden_size
+            text_config = getattr(model.config, "text_config", None)
+            if text_config is not None:
+                hidden_size = text_config.hidden_size
+
+            if init_device.type == DeviceType.META:
+                with init_empty_weights():
+                    model.score = torch.nn.Linear(hidden_size, 1, bias=False)
+            else:
+                model.score = torch.nn.Linear(hidden_size, 1, bias=False).to(
+                    dtype=model.dtype, device=model.device,
+                )
 
         if self.args.peft_config is None:
             if self.is_train:

--- a/src/llamafactory/v1/trainers/rm_trainer.py
+++ b/src/llamafactory/v1/trainers/rm_trainer.py
@@ -130,11 +130,15 @@ class RMTrainer(BaseTrainer):
             input_ids=input_ids,
             attention_mask=model_attention_mask,
             position_ids=position_ids,
+            output_hidden_states=True,
             use_cache=False,
             return_dict=True,
         )
 
-        rewards = model_output.logits.float().squeeze(-1)
+        # Apply the score head on the last hidden state to get per-token rewards.
+        # Using self._unwrapped_model.score ensures we go through any PEFT / LoRA wrappers.
+        hidden_states = model_output.hidden_states[-1]
+        rewards = self._unwrapped_model.score(hidden_states).float().squeeze(-1)
 
         chosen_mask = token_type_ids == 1
         rejected_mask = token_type_ids == 2


### PR DESCRIPTION
fix RM lora training in v1

- Replace AutoModelForTokenClassification with AutoModelForCausalLM for CLS model class, adding a manually-initialized score head for per-token reward prediction. AutoModelForTokenClassification creates models that lack prepare_inputs_for_generation, which causes PEFT/LoRA (get_peft_model) to crash.
- Update RMTrainer.compute_loss to use output_hidden_states=True and apply the score head on the last hidden state, instead of relying on model_output.logits.
- Add example RM training configs for LoRA and full fine-tuning.

# What does this PR do?

Fixes # (issue)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
