### PR TITLE
[feat] add embedding init methods and freeze original embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,6 +897,8 @@ If you have a project that should be incorporated, please contact via email or c
 1. Liang et al. I-SHEEP: Self-Alignment of LLM from Scratch through an Iterative Self-Enhancement Paradigm. 2024. [[arxiv]](https://arxiv.org/abs/2408.08072)
 1. Bai et al. Aligning Large Language Model with Direct Multi-Preference Optimization for Recommendation. CIKM 2024. [[paper]](https://dl.acm.org/doi/10.1145/3627673.3679611)
 1. Zhang et al. CPsyCoun: A Report-based Multi-turn Dialogue Reconstruction and Evaluation Framework for Chinese Psychological Counseling. ACL 2024. [[paper]](https://aclanthology.org/2024.findings-acl.830.pdf)
+1. Xing et al. Empowering LLMs to Understand and Generate Complex Vector Graphics. CVPR 2025. [[arxiv]](https://arxiv.org/abs/2412.11102)
+1. Xing et al. Hierarchical SVG Tokenization: Learning Compact Visual Programs for Scalable Vector Graphics Modeling. 2026. [[arxiv]](https://arxiv.org/abs/2604.05072)
 1. **[StarWhisper](https://github.com/Yu-Yang-Li/StarWhisper)**: A large language model for Astronomy, based on ChatGLM2-6B and Qwen-14B.
 1. **[DISC-LawLLM](https://github.com/FudanDISC/DISC-LawLLM)**: A large language model specialized in Chinese legal domain, based on Baichuan-13B, is capable of retrieving and reasoning on legal knowledge.
 1. **[Sunsimiao](https://github.com/X-D-Lab/Sunsimiao)**: A large language model specialized in Chinese medical domain, based on Baichuan-7B and ChatGLM-6B.

--- a/README_zh.md
+++ b/README_zh.md
@@ -900,6 +900,8 @@ swanlab_run_name: test_run # 可选
 1. Xia et al. Using Pre-trained Language Model for Accurate ESG Prediction. FinNLP 2024. [[paper]](https://aclanthology.org/2024.finnlp-2.1/)
 1. Liang et al. I-SHEEP: Self-Alignment of LLM from Scratch through an Iterative Self-Enhancement Paradigm. 2024. [[arxiv]](https://arxiv.org/abs/2408.08072)
 1. Bai et al. Aligning Large Language Model with Direct Multi-Preference Optimization for Recommendation. CIKM 2024. [[paper]](https://dl.acm.org/doi/10.1145/3627673.3679611)
+1. Xing et al. Empowering LLMs to Understand and Generate Complex Vector Graphics. CVPR 2025. [[arxiv]](https://arxiv.org/abs/2412.11102)
+1. Xing et al. Hierarchical SVG Tokenization: Learning Compact Visual Programs for Scalable Vector Graphics Modeling. 2026. [[arxiv]](https://arxiv.org/abs/2604.05072)
 1. **[StarWhisper](https://github.com/Yu-Yang-Li/StarWhisper)**: 天文大模型 StarWhisper，基于 ChatGLM2-6B 和 Qwen-14B 在天文数据上微调而得。
 1. **[DISC-LawLLM](https://github.com/FudanDISC/DISC-LawLLM)**: 中文法律领域大模型 DISC-LawLLM，基于 Baichuan-13B 微调而得，具有法律推理和知识检索能力。
 1. **[Sunsimiao](https://github.com/X-D-Lab/Sunsimiao)**: 孙思邈中文医疗大模型 Sumsimiao，基于 Baichuan-7B 和 ChatGLM-6B 在中文医疗数据上微调而得。

--- a/data/add_tokens_demo.json
+++ b/data/add_tokens_demo.json
@@ -1,0 +1,152 @@
+[
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a red circle on a white canvas",
+    "output": "<|START_OF_SVG|><|start_of_circle|>cx=\"50\" cy=\"50\" r=\"40\" fill=\"red\"<|end_of_circle|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a blue square",
+    "output": "<|START_OF_SVG|><|start_of_rect|>x=\"20\" y=\"20\" width=\"60\" height=\"60\" fill=\"blue\"<|end_of_rect|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a green ellipse stretched horizontally",
+    "output": "<|START_OF_SVG|><|start_of_ellipse|>cx=\"50\" cy=\"50\" rx=\"40\" ry=\"20\" fill=\"green\"<|end_of_ellipse|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a black diagonal line drawn as a path",
+    "output": "<|START_OF_SVG|><|start_of_path|>d=\"M10 10 L90 90\" stroke=\"black\" stroke-width=\"2\"<|end_of_path|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "the word Hi in dark gray",
+    "output": "<|START_OF_SVG|><|start_of_text|>x=\"10\" y=\"55\" font-size=\"40\" fill=\"#333\">Hi<|end_of_text|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "two stacked rectangles grouped together",
+    "output": "<|START_OF_SVG|><|start_of_g|><|start_of_rect|>x=\"10\" y=\"10\" width=\"80\" height=\"30\" fill=\"orange\"<|end_of_rect|><|start_of_rect|>x=\"10\" y=\"60\" width=\"80\" height=\"30\" fill=\"purple\"<|end_of_rect|><|end_of_g|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a yellow circle inside a thin black border circle",
+    "output": "<|START_OF_SVG|><|start_of_circle|>cx=\"50\" cy=\"50\" r=\"45\" fill=\"none\" stroke=\"black\"<|end_of_circle|><|start_of_circle|>cx=\"50\" cy=\"50\" r=\"25\" fill=\"yellow\"<|end_of_circle|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a triangle drawn with a path",
+    "output": "<|START_OF_SVG|><|start_of_path|>d=\"M50 10 L90 90 L10 90 Z\" fill=\"teal\"<|end_of_path|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a rounded rectangle in light blue",
+    "output": "<|START_OF_SVG|><|start_of_rect|>x=\"15\" y=\"25\" width=\"70\" height=\"50\" rx=\"10\" fill=\"lightblue\"<|end_of_rect|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a small circle next to a small square",
+    "output": "<|START_OF_SVG|><|start_of_circle|>cx=\"30\" cy=\"50\" r=\"15\" fill=\"crimson\"<|end_of_circle|><|start_of_rect|>x=\"55\" y=\"35\" width=\"30\" height=\"30\" fill=\"navy\"<|end_of_rect|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a horizontal red line",
+    "output": "<|START_OF_SVG|><|start_of_path|>d=\"M10 50 L90 50\" stroke=\"red\" stroke-width=\"4\"<|end_of_path|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a styled blue heading text that says SVG",
+    "output": "<|START_OF_SVG|><|start_of_style|>.title { fill: blue; font-weight: bold; }<|end_of_style|><|start_of_text|>x=\"20\" y=\"55\" class=\"title\" font-size=\"36\">SVG<|end_of_text|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "three dots in a row",
+    "output": "<|START_OF_SVG|><|start_of_g|><|start_of_circle|>cx=\"25\" cy=\"50\" r=\"8\" fill=\"black\"<|end_of_circle|><|start_of_circle|>cx=\"50\" cy=\"50\" r=\"8\" fill=\"black\"<|end_of_circle|><|start_of_circle|>cx=\"75\" cy=\"50\" r=\"8\" fill=\"black\"<|end_of_circle|><|end_of_g|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "an orange ellipse",
+    "output": "<|START_OF_SVG|><|start_of_ellipse|>cx=\"50\" cy=\"50\" rx=\"35\" ry=\"25\" fill=\"orange\"<|end_of_ellipse|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a checkmark drawn as a path",
+    "output": "<|START_OF_SVG|><|start_of_path|>d=\"M20 50 L40 70 L80 25\" stroke=\"green\" stroke-width=\"6\" fill=\"none\"<|end_of_path|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a purple square with a centered white circle",
+    "output": "<|START_OF_SVG|><|start_of_rect|>x=\"10\" y=\"10\" width=\"80\" height=\"80\" fill=\"purple\"<|end_of_rect|><|start_of_circle|>cx=\"50\" cy=\"50\" r=\"20\" fill=\"white\"<|end_of_circle|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "the letter A in red",
+    "output": "<|START_OF_SVG|><|start_of_text|>x=\"35\" y=\"60\" font-size=\"48\" fill=\"red\">A<|end_of_text|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a wavy line path in blue",
+    "output": "<|START_OF_SVG|><|start_of_path|>d=\"M10 50 Q30 20 50 50 T90 50\" stroke=\"blue\" stroke-width=\"3\" fill=\"none\"<|end_of_path|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a group with a circle and a label below it",
+    "output": "<|START_OF_SVG|><|start_of_g|><|start_of_circle|>cx=\"50\" cy=\"35\" r=\"20\" fill=\"gold\"<|end_of_circle|><|start_of_text|>x=\"30\" y=\"80\" font-size=\"16\">sun<|end_of_text|><|end_of_g|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a tall thin rectangle",
+    "output": "<|START_OF_SVG|><|start_of_rect|>x=\"40\" y=\"10\" width=\"20\" height=\"80\" fill=\"saddlebrown\"<|end_of_rect|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a pink circle",
+    "output": "<|START_OF_SVG|><|start_of_circle|>cx=\"50\" cy=\"50\" r=\"30\" fill=\"pink\"<|end_of_circle|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a closed pentagon path",
+    "output": "<|START_OF_SVG|><|start_of_path|>d=\"M50 10 L90 40 L75 90 L25 90 L10 40 Z\" fill=\"indigo\"<|end_of_path|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "two overlapping ellipses",
+    "output": "<|START_OF_SVG|><|start_of_ellipse|>cx=\"40\" cy=\"50\" rx=\"30\" ry=\"18\" fill=\"cyan\"<|end_of_ellipse|><|start_of_ellipse|>cx=\"60\" cy=\"50\" rx=\"30\" ry=\"18\" fill=\"magenta\"<|end_of_ellipse|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a green rectangle with the word go centered",
+    "output": "<|START_OF_SVG|><|start_of_rect|>x=\"10\" y=\"30\" width=\"80\" height=\"40\" fill=\"green\"<|end_of_rect|><|start_of_text|>x=\"35\" y=\"57\" font-size=\"24\" fill=\"white\">go<|end_of_text|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a simple house: a square base and a triangle roof",
+    "output": "<|START_OF_SVG|><|start_of_g|><|start_of_rect|>x=\"25\" y=\"50\" width=\"50\" height=\"40\" fill=\"sienna\"<|end_of_rect|><|start_of_path|>d=\"M20 50 L50 20 L80 50 Z\" fill=\"firebrick\"<|end_of_path|><|end_of_g|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a dashed black circle outline",
+    "output": "<|START_OF_SVG|><|start_of_circle|>cx=\"50\" cy=\"50\" r=\"35\" fill=\"none\" stroke=\"black\" stroke-dasharray=\"6 4\"<|end_of_circle|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a styled red box class applied to a rectangle",
+    "output": "<|START_OF_SVG|><|start_of_style|>.box { fill: red; stroke: black; }<|end_of_style|><|start_of_rect|>x=\"20\" y=\"20\" width=\"60\" height=\"60\" class=\"box\"<|end_of_rect|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "an arrow pointing right drawn as a path",
+    "output": "<|START_OF_SVG|><|start_of_path|>d=\"M10 50 L70 50 M55 35 L70 50 L55 65\" stroke=\"black\" stroke-width=\"4\" fill=\"none\"<|end_of_path|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "a small grey ellipse shadow under a black circle",
+    "output": "<|START_OF_SVG|><|start_of_g|><|start_of_ellipse|>cx=\"50\" cy=\"80\" rx=\"25\" ry=\"6\" fill=\"lightgray\"<|end_of_ellipse|><|start_of_circle|>cx=\"50\" cy=\"45\" r=\"25\" fill=\"black\"<|end_of_circle|><|end_of_g|><|END_OF_SVG|>"
+  },
+  {
+    "instruction": "Generate an SVG illustration for the given description.",
+    "input": "the number 1 in blue",
+    "output": "<|START_OF_SVG|><|start_of_text|>x=\"42\" y=\"62\" font-size=\"44\" fill=\"blue\">1<|end_of_text|><|END_OF_SVG|>"
+  }
+]

--- a/data/dataset_info.json
+++ b/data/dataset_info.json
@@ -745,5 +745,8 @@
       "prompt": "content"
     },
     "folder": "python"
+  },
+  "add_tokens_demo": {
+    "file_name": "add_tokens_demo.json"
   }
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -290,3 +290,9 @@ llamafactory-cli train examples/extras/oft/llama3_oft_sft.yaml
 ```bash
 llamafactory-cli train examples/extras/qoft/llama3_oft_sft_bnb_npu.yaml
 ```
+
+#### Adding New Tokens with Embedding Initialization
+
+```bash
+llamafactory-cli train examples/extras/add_tokens/qwen3_add_tokens_vocab_mean_noise.yaml
+```

--- a/examples/README_zh.md
+++ b/examples/README_zh.md
@@ -290,3 +290,9 @@ llamafactory-cli train examples/extras/oft/llama3_oft_sft.yaml
 ```bash
 llamafactory-cli train examples/extras/qoft/llama3_oft_sft_bnb_npu.yaml
 ```
+
+#### 添加新词并初始化词向量
+
+```bash
+llamafactory-cli train examples/extras/add_tokens/qwen3_add_tokens_vocab_mean_noise.yaml
+```

--- a/examples/extras/add_tokens/README.md
+++ b/examples/extras/add_tokens/README.md
@@ -1,0 +1,90 @@
+# Adding New Tokens and Initializing Their Embeddings
+
+This example shows how to add new tokens to a model and control how their embeddings are
+initialized before training. This is useful when you extend a model with domain-specific
+markers (e.g. structural tags, tool-call delimiters, vector-graphics primitives).
+
+## How to add tokens
+
+There are three mutually exclusive ways to register new tokens, all gated by `resize_vocab: true`
+(which resizes the embedding layer to fit the new vocabulary):
+
+| Argument | Token kind | Descriptions | Use case |
+|---|---|---|---|
+| `add_tokens` | normal tokens | no | plain vocabulary expansion |
+| `add_special_tokens` | special tokens | no | special markers, no semantic init |
+| `new_special_tokens_config` | special tokens | yes (YAML) | special markers with semantic init |
+
+`new_special_tokens_config` points to a YAML file mapping each token to a short description
+(see [`tokens_cfg.yaml`](tokens_cfg.yaml)). It takes precedence over `add_special_tokens`.
+
+## Initialization methods (`init_special_tokens`)
+
+New rows are initialized with one of the methods below. The names follow a `<base>` / `<base>_noise`
+convention, where the `_noise` suffix adds a small Gaussian perturbation (scaled to the embedding std)
+so that otherwise-identical rows stay distinguishable.
+
+| `init_special_tokens` | Base | `+ noise` | Meaning |
+|---|---|---|---|
+| `vocab_mean` | vocab mean | no | mean of all existing token embeddings (all new rows identical) |
+| `vocab_mean_noise` (default) | vocab mean | yes | vocab mean + Gaussian noise |
+| `description` | description | no | mean embedding of each token's description tokens |
+| `description_noise` | description | yes | description mean + Gaussian noise |
+| `noise` | — | — | pure Gaussian noise (no base) |
+
+Notes:
+
+- `description` / `description_noise` require `new_special_tokens_config` (they need descriptions).
+  If no config is provided, they fall back to `vocab_mean_noise`.
+- Legacy names `noise_init` / `desc_init` / `desc_init_w_noise` are still accepted as deprecated
+  aliases of `vocab_mean_noise` / `description` / `description_noise`.
+
+## Training only the new embeddings (`freeze_original_embeddings`)
+
+Set `freeze_original_embeddings: true` to register a gradient mask that updates only the newly
+added token rows while keeping the original embeddings frozen. This is intended for setups where
+the embedding matrix is trained directly (e.g. `finetuning_type: full`).
+
+Under `finetuning_type: lora` with `resize_vocab`, the input/output embeddings are added to
+`additional_target` automatically, so the new token embeddings are already trainable and
+`freeze_original_embeddings` is not needed.
+
+## Demo dataset
+
+The example trains on `add_tokens_demo` (registered in [`data/dataset_info.json`](../../../data/dataset_info.json)),
+a tiny text-to-SVG set whose responses actually contain the new tokens declared in
+[`tokens_cfg.yaml`](tokens_cfg.yaml), e.g.:
+
+```text
+<|START_OF_SVG|><|start_of_circle|>cx="50" cy="50" r="40" fill="red"<|end_of_circle|><|END_OF_SVG|>
+```
+
+This matters: the added tokens must appear in the training data, otherwise their freshly
+initialized embeddings never receive gradients (and `freeze_original_embeddings: true` would
+train nothing). After training, the model should be able to emit these tokens. Swap in your
+own dataset the same way — just make sure its responses use the tokens you declared.
+
+## Run the examples
+
+```bash
+# Full SFT, vocab-mean initialization: add new tokens, initialize their embeddings, then train
+llamafactory-cli train examples/extras/add_tokens/qwen3_add_tokens_vocab_mean_noise.yaml
+
+# Full SFT, description (semantic) initialization: init each new row from its description tokens
+llamafactory-cli train examples/extras/add_tokens/qwen3_add_tokens_description.yaml
+```
+
+## Files
+
+- [`tokens_cfg.yaml`](tokens_cfg.yaml): new special tokens with descriptions.
+- [`qwen3_add_tokens_vocab_mean_noise.yaml`](qwen3_add_tokens_vocab_mean_noise.yaml): full SFT with `vocab_mean_noise` initialization.
+- [`qwen3_add_tokens_description.yaml`](qwen3_add_tokens_description.yaml): full SFT with `description` (semantic) initialization.
+- `add_tokens_demo` (in [`data/`](../../../data/add_tokens_demo.json)): text-to-SVG demo whose responses use the new tokens.
+
+## References
+
+The description-based and noisy initialization recipes here were distilled from work on
+vector-graphics modeling by Ximing Xing (ximinng):
+
+- Empowering LLMs to Understand and Generate Complex Vector Graphics. 2025. [[arxiv]](https://arxiv.org/abs/2412.11102)
+- Hierarchical SVG Tokenization: Learning Compact Visual Programs for Scalable Vector Graphics Modeling. 2026. [[arxiv]](https://arxiv.org/abs/2604.05072)

--- a/examples/extras/add_tokens/qwen3_add_tokens_description.yaml
+++ b/examples/extras/add_tokens/qwen3_add_tokens_description.yaml
@@ -1,0 +1,53 @@
+### model
+model_name_or_path: Qwen/Qwen3-4B-Instruct-2507
+trust_remote_code: true
+
+### tokens
+# Resize the embedding layer to fit the newly added tokens (required when adding tokens).
+resize_vocab: true
+# Load the new special tokens together with their descriptions from a YAML config.
+# 'description' initialization REQUIRES this config (it needs the per-token descriptions).
+new_special_tokens_config: examples/extras/add_tokens/tokens_cfg.yaml
+# Semantic initialization: each new token embedding is the mean embedding of its description
+# tokens (e.g. "<|start_of_circle|>" -> mean of the tokens of "start of an SVG circle element").
+# Use 'description_noise' to add a small Gaussian perturbation on top.
+init_special_tokens: description
+# Freeze the original embedding rows and train only the newly added token embeddings.
+# This works under full finetuning where the embedding matrix is trained directly.
+freeze_original_embeddings: false
+
+### method
+stage: sft
+do_train: true
+finetuning_type: full
+deepspeed: examples/deepspeed/ds_z3_config.json  # choices: [ds_z0_config.json, ds_z2_config.json, ds_z3_config.json]
+
+### dataset
+# This demo set's responses actually contain the new SVG tokens declared in tokens_cfg.yaml,
+# so the newly added embeddings receive gradients and the feature is exercised end to end.
+dataset: add_tokens_demo
+template: qwen3_nothink
+cutoff_len: 2048
+max_samples: 1000
+preprocessing_num_workers: 16
+dataloader_num_workers: 4
+
+### output
+output_dir: saves/qwen3-4b/full/sft_add_tokens_desc
+logging_steps: 10
+save_steps: 500
+plot_loss: true
+overwrite_output_dir: true
+save_only_model: false
+report_to: none  # choices: [none, wandb, tensorboard, swanlab, mlflow]
+
+### train
+per_device_train_batch_size: 1
+gradient_accumulation_steps: 2
+learning_rate: 1.0e-5
+num_train_epochs: 3.0
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+bf16: true
+ddp_timeout: 180000000
+resume_from_checkpoint: null

--- a/examples/extras/add_tokens/qwen3_add_tokens_vocab_mean_noise.yaml
+++ b/examples/extras/add_tokens/qwen3_add_tokens_vocab_mean_noise.yaml
@@ -1,0 +1,50 @@
+### model
+model_name_or_path: Qwen/Qwen3-4B-Instruct-2507
+trust_remote_code: true
+
+### tokens
+# Resize the embedding layer to fit the newly added tokens (required when adding tokens).
+resize_vocab: true
+# Load the new special tokens together with their descriptions from a YAML config.
+new_special_tokens_config: examples/extras/add_tokens/tokens_cfg.yaml
+# Initialize the new token embeddings from their descriptions, plus a small Gaussian noise.
+init_special_tokens: vocab_mean_noise
+# Freeze the original embedding rows and train only the newly added token embeddings.
+# This works under full finetuning where the embedding matrix is trained directly.
+freeze_original_embeddings: false
+
+### method
+stage: sft
+do_train: true
+finetuning_type: full
+deepspeed: examples/deepspeed/ds_z3_config.json  # choices: [ds_z0_config.json, ds_z2_config.json, ds_z3_config.json]
+
+### dataset
+# This demo set's responses actually contain the new SVG tokens declared in tokens_cfg.yaml,
+# so the newly added embeddings receive gradients and the feature is exercised end to end.
+dataset: add_tokens_demo
+template: qwen3_nothink
+cutoff_len: 2048
+max_samples: 1000
+preprocessing_num_workers: 16
+dataloader_num_workers: 4
+
+### output
+output_dir: saves/qwen3-4b/full/sft_add_tokens
+logging_steps: 10
+save_steps: 500
+plot_loss: true
+overwrite_output_dir: true
+save_only_model: false
+report_to: none  # choices: [none, wandb, tensorboard, swanlab, mlflow]
+
+### train
+per_device_train_batch_size: 1
+gradient_accumulation_steps: 2
+learning_rate: 1.0e-5
+num_train_epochs: 3.0
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+bf16: true
+ddp_timeout: 180000000
+resume_from_checkpoint: null

--- a/examples/extras/add_tokens/tokens_cfg.yaml
+++ b/examples/extras/add_tokens/tokens_cfg.yaml
@@ -1,3 +1,14 @@
+# New special tokens with descriptions, used by `new_special_tokens_config`.
+#
+# Format: each entry maps a token string to a short natural-language description.
+#   "<token>": "description text"
+#
+# The token strings are added to the tokenizer (as special tokens), and the
+# descriptions are used by the `description` / `description_noise` initialization
+# methods: each new token embedding is initialized from the mean embedding of its
+# description tokens. The descriptions are ignored by the `vocab_mean*` / `noise`
+# methods. The example tokens below describe a small SVG vocabulary.
+
 # SVG Container Tags
 "<|START_OF_SVG|>": "Marks the beginning of an SVG document"
 "<|END_OF_SVG|>": "Marks the end of an SVG document"

--- a/src/llamafactory/hparams/model_args.py
+++ b/src/llamafactory/hparams/model_args.py
@@ -90,15 +90,37 @@ class BaseModelArguments:
             )
         },
     )
-    init_special_tokens: Literal["noise_init", "desc_init", "desc_init_w_noise"] = field(
-        default="noise_init",
+    init_special_tokens: Literal[
+        "vocab_mean",
+        "noise",
+        "vocab_mean_noise",
+        "description",
+        "description_noise",
+        "noise_init",
+        "desc_init",
+        "desc_init_w_noise",
+    ] = field(
+        default="vocab_mean_noise",
         metadata={
             "help": (
                 "Initialization method for new special tokens: "
-                "'noise_init' (default, random noise around mean), "
-                "'desc_init' (semantic initialization from descriptions), "
-                "'desc_init_w_noise' (semantic + random noise). "
-                "Note: 'desc_init' methods require new_special_tokens_config."
+                "'vocab_mean_noise' (default, vocab mean + Gaussian noise), "
+                "'noise' (pure Gaussian noise), "
+                "'vocab_mean' (pure mean of existing vocab embeddings), "
+                "'description' (semantic initialization from descriptions), "
+                "'description_noise' (semantic + Gaussian noise). "
+                "Note: 'description'/'description_noise' require new_special_tokens_config. "
+                "Legacy aliases 'noise_init'->'vocab_mean_noise', 'desc_init'->'description', "
+                "'desc_init_w_noise'->'description_noise' are deprecated but still accepted."
+            )
+        },
+    )
+    freeze_original_embeddings: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to freeze the original embedding rows and train only the newly added "
+                "token embeddings. Only takes effect when resize_vocab is enabled."
             )
         },
     )
@@ -262,14 +284,28 @@ class BaseModelArguments:
             # No special tokens to add
             self._special_token_descriptions = None
 
-        # Validate init method
-        if self.init_special_tokens in ["desc_init", "desc_init_w_noise"]:
+        # Normalize deprecated init-method aliases to canonical names.
+        # NOTE: keep this mapping in sync with INIT_METHOD_ALIASES in model/model_utils/embedding.py.
+        init_method_aliases = {
+            "noise_init": "vocab_mean_noise",
+            "desc_init": "description",
+            "desc_init_w_noise": "description_noise",
+        }
+        if self.init_special_tokens in init_method_aliases:
+            canonical = init_method_aliases[self.init_special_tokens]
+            logger.warning_rank0(
+                f"init_special_tokens='{self.init_special_tokens}' is deprecated, use '{canonical}' instead."
+            )
+            self.init_special_tokens = canonical
+
+        # Validate init method: 'description'/'description_noise' require a descriptions config.
+        if self.init_special_tokens in ["description", "description_noise"]:
             if self._special_token_descriptions is None:
                 logger.warning_rank0(
                     f"init_special_tokens='{self.init_special_tokens}' requires new_special_tokens_config. "
-                    "Falling back to 'noise_init'"
+                    "Falling back to 'vocab_mean_noise'"
                 )
-                self.init_special_tokens = "noise_init"
+                self.init_special_tokens = "vocab_mean_noise"
 
 
 @dataclass

--- a/src/llamafactory/model/model_utils/embedding.py
+++ b/src/llamafactory/model/model_utils/embedding.py
@@ -29,6 +29,15 @@ if TYPE_CHECKING:
 
 logger = logging.get_logger(__name__)
 
+# Canonical init-method names are: 'vocab_mean', 'noise', 'vocab_mean_noise', 'description', 'description_noise'.
+# The following legacy names remain accepted as deprecated aliases for backward compatibility.
+# NOTE: keep this in sync with the same mapping referenced in hparams/model_args.py.
+INIT_METHOD_ALIASES = {
+    "noise_init": "vocab_mean_noise",
+    "desc_init": "description",
+    "desc_init_w_noise": "description_noise",
+}
+
 
 def get_embedding_vocab_size(model: "PreTrainedModel") -> int:
     r"""Get the vocab size from the input embedding layer.
@@ -102,7 +111,7 @@ def _existing_embeddings(
     return embed_weight
 
 
-def _noisy_mean_initialization(
+def _vocab_mean_noise_initialization(
     embed_weight: "torch.Tensor", num_new_tokens: int, token_ids: Optional[list[int]] = None
 ) -> None:
     """Initialize new token embeddings with mean + Gaussian noise.
@@ -131,7 +140,57 @@ def _noisy_mean_initialization(
         embed_weight[-num_new_tokens:] = avg_weight + noise_weight
 
 
-def _description_based_initialization(
+def _noise_initialization(
+    embed_weight: "torch.Tensor", num_new_tokens: int, token_ids: Optional[list[int]] = None
+) -> None:
+    """Initialize new token embeddings with pure Gaussian noise (no mean component).
+
+    The noise std matches the std of the existing embeddings so that the new rows
+    live on a comparable scale.
+
+    Args:
+        embed_weight: The embedding weight matrix to initialize (shape: [vocab_size, embedding_dim])
+        num_new_tokens: Number of new tokens added (used to compute the std baseline)
+        token_ids: Explicit token IDs to initialize. When ``None``, falls back to the last
+            ``num_new_tokens`` rows.
+    """
+    existing_std = _existing_embeddings(embed_weight, num_new_tokens, token_ids).std().item()
+
+    if token_ids:
+        noise_weight = torch.empty(
+            len(token_ids), embed_weight.size(1), device=embed_weight.device, dtype=embed_weight.dtype
+        )
+        noise_weight.normal_(mean=0, std=existing_std)
+        embed_weight[token_ids] = noise_weight
+    else:
+        noise_weight = torch.empty_like(embed_weight[-num_new_tokens:])
+        noise_weight.normal_(mean=0, std=existing_std)
+        embed_weight[-num_new_tokens:] = noise_weight
+
+
+def _vocab_mean_initialization(
+    embed_weight: "torch.Tensor", num_new_tokens: int, token_ids: Optional[list[int]] = None
+) -> None:
+    """Initialize all new token embeddings with the mean of the existing embeddings.
+
+    All new tokens share an identical embedding (no discriminability). Useful as a
+    deterministic baseline or when noise is undesirable.
+
+    Args:
+        embed_weight: The embedding weight matrix to initialize (shape: [vocab_size, embedding_dim])
+        num_new_tokens: Number of new tokens added (used to compute the mean baseline)
+        token_ids: Explicit token IDs to initialize. When ``None``, falls back to the last
+            ``num_new_tokens`` rows.
+    """
+    avg_weight = _existing_embeddings(embed_weight, num_new_tokens, token_ids).mean(dim=0, keepdim=True)
+
+    if token_ids:
+        embed_weight[token_ids] = avg_weight.expand(len(token_ids), -1).clone()
+    else:
+        embed_weight[-num_new_tokens:] = avg_weight.expand(num_new_tokens, -1).clone()
+
+
+def _description_initialization(
     embed_weight: "torch.Tensor",
     num_new_tokens: int,
     descriptions: dict[str, str],
@@ -187,7 +246,7 @@ def _description_based_initialization(
         # Resolve token ID for correct placement (robust to embedding padding)
         token_id = tokenizer.convert_tokens_to_ids(token_str)
         if token_id is None or token_id == unk_token_id or not (0 <= token_id < vocab_size):
-            logger.warning_rank0(f"desc_init: token '{token_str}' not found or out of range, skipping.")
+            logger.warning_rank0(f"description: token '{token_str}' not found or out of range, skipping.")
             continue
 
         # Tokenize description text
@@ -233,33 +292,49 @@ def _initialize_embeddings(
 
     This function selects the appropriate initialization method and applies it.
 
+    Available methods (canonical names; legacy aliases in INIT_METHOD_ALIASES still accepted):
+        - 'vocab_mean_noise' (default): μ + N(0, σ)            [legacy alias: 'noise_init']
+        - 'noise': N(0, σ) (pure Gaussian noise, no base)
+        - 'vocab_mean': μ (pure vocab mean, all new tokens identical)
+        - 'description': Σ semantic init from token descriptions [legacy alias: 'desc_init']
+        - 'description_noise': semantic init + Gaussian noise     [legacy alias: 'desc_init_w_noise']
+
     Args:
         embed_weight: The embedding weight matrix to initialize
         num_new_tokens: Number of new tokens added
-        init_method: Initialization method ('noise_init', 'desc_init', 'desc_init_w_noise')
-        new_special_tokens_config: Config dict with token descriptions (required for desc_init methods)
+        init_method: Initialization method (see above)
+        new_special_tokens_config: Config dict with token descriptions (required for description methods)
         tokenizer: The tokenizer instance
         model: The model instance
         new_token_ids: Explicit IDs of the newly added tokens (robust to embedding padding).
             When ``None``, the init helpers fall back to the last ``num_new_tokens`` rows.
     """
-    if init_method == "desc_init" and new_special_tokens_config:
-        logger.info_rank0("Using semantic initialization (desc_init) for new special tokens")
-        _description_based_initialization(
+    # Normalize legacy names so the dispatch below only deals with canonical names.
+    init_method = INIT_METHOD_ALIASES.get(init_method, init_method)
+
+    if init_method == "description" and new_special_tokens_config:
+        logger.info_rank0("Using semantic initialization (description) for new special tokens")
+        _description_initialization(
             embed_weight, num_new_tokens, new_special_tokens_config, tokenizer, model, new_token_ids, add_noise=False
         )
-    elif init_method == "desc_init_w_noise" and new_special_tokens_config:
-        logger.info_rank0("Using semantic initialization with noise (desc_init_w_noise) for new special tokens")
-        _description_based_initialization(
+    elif init_method == "description_noise" and new_special_tokens_config:
+        logger.info_rank0("Using semantic initialization with noise (description_noise) for new special tokens")
+        _description_initialization(
             embed_weight, num_new_tokens, new_special_tokens_config, tokenizer, model, new_token_ids, add_noise=True
         )
+    elif init_method == "noise":
+        logger.info_rank0("Using noise initialization (N(0, σ)) for new special tokens")
+        _noise_initialization(embed_weight, num_new_tokens, token_ids=new_token_ids)
+    elif init_method == "vocab_mean":
+        logger.info_rank0("Using vocab mean initialization (μ) for new special tokens")
+        _vocab_mean_initialization(embed_weight, num_new_tokens, token_ids=new_token_ids)
     else:
-        if init_method != "noise_init":
+        if init_method != "vocab_mean_noise":
             logger.warning_rank0(
-                f"init_method='{init_method}' requires descriptions config, falling back to 'noise_init'"
+                f"init_method='{init_method}' requires descriptions config, falling back to 'vocab_mean_noise'"
             )
-        logger.info_rank0("Using noisy mean initialization (noise_init) for new special tokens")
-        _noisy_mean_initialization(embed_weight, num_new_tokens, token_ids=new_token_ids)
+        logger.info_rank0("Using noisy vocab mean initialization (vocab_mean_noise) for new special tokens")
+        _vocab_mean_noise_initialization(embed_weight, num_new_tokens, token_ids=new_token_ids)
 
 
 def resize_embedding_layer(
@@ -267,7 +342,7 @@ def resize_embedding_layer(
     tokenizer: "PreTrainedTokenizer",
     new_tokens: Optional[Iterable[str]] = None,
     new_special_tokens_config: Optional[dict] = None,
-    init_special_tokens: str = "noise_init",
+    init_special_tokens: str = "vocab_mean_noise",
 ) -> None:
     r"""Resize token embeddings (when needed) and initialize the newly added tokens.
 
@@ -282,7 +357,9 @@ def resize_embedding_layer(
         new_tokens: Iterable of the newly added token strings. Used to locate the exact
             embedding rows to initialize, which is robust to pre-existing embedding padding.
         new_special_tokens_config: Optional dict with token descriptions for semantic initialization
-        init_special_tokens: Initialization method ('noise_init', 'desc_init', 'desc_init_w_noise')
+        init_special_tokens: Initialization method ('vocab_mean', 'noise', 'vocab_mean_noise',
+            'description', 'description_noise'; legacy aliases 'noise_init'/'desc_init'/'desc_init_w_noise'
+            are also accepted)
     """
     if is_deepspeed_zero3_enabled():
         import deepspeed  # type: ignore
@@ -362,3 +439,99 @@ def resize_embedding_layer(
             model.config.text_config.vocab_size = new_embedding_size
 
         logger.info_rank0(f"Resized token embeddings from {current_embedding_size} to {new_embedding_size}.")
+
+
+def _make_embedding_freeze_hook(orig_size: int, total_size: int):
+    """Create a gradient hook that zeros the gradient of the original embedding rows.
+
+    The hook keeps a lazily-built, per-(device, dtype) cached mask so it handles AMP
+    dtype switches (fp32 <-> bf16/fp16) and device migrations without repeated allocation.
+
+    It is robust to parameter-sharded setups (DeepSpeed ZeRO-3 / FSDP): per-row masking by
+    absolute index is only valid when the hook receives the full ``[total_size, dim]``
+    gradient. When the gradient arrives partitioned/flattened (a different shape), masking
+    by row offset would be wrong (and could even crash on the broadcast), so the hook leaves
+    the gradient untouched and warns once instead.
+    """
+    cached_masks: dict[tuple, "torch.Tensor"] = {}
+    warned = False
+
+    def hook(grad: "torch.Tensor") -> "torch.Tensor":
+        nonlocal warned
+        if grad.dim() != 2 or grad.size(0) != total_size:
+            if not warned:
+                logger.warning_rank0(
+                    f"Skipping embedding freeze: received a gradient of shape {tuple(grad.shape)}, "
+                    f"expected [{total_size}, *]. This usually means the embedding is sharded "
+                    "(DeepSpeed ZeRO-3 / FSDP), where per-row freezing is not supported; the "
+                    "original embeddings will also be updated."
+                )
+                warned = True
+
+            return grad
+
+        cache_key = (grad.device, grad.dtype)
+        if cache_key not in cached_masks:
+            # 0 for original rows, 1 for new rows; shape [vocab_size, 1] to broadcast.
+            mask = torch.zeros(total_size, 1, device=grad.device, dtype=grad.dtype)
+            mask[orig_size:] = 1.0
+            cached_masks[cache_key] = mask
+
+        return grad * cached_masks[cache_key]
+
+    return hook
+
+
+def apply_embedding_freeze(model: "PreTrainedModel", orig_vocab_size: int) -> None:
+    r"""Freeze original embedding rows, training only the newly added tokens.
+
+    Registers gradient hooks that zero out the gradients of the original embedding
+    rows, so only the new token embeddings receive updates. This is useful for
+    vocabulary expansion where the base embeddings should stay intact.
+
+    The freeze is permanent for the lifetime of the process (hook handles are not
+    returned). Output embeddings are handled automatically when tied (a single tensor
+    hook on the shared weight catches both backward paths), or hooked separately when
+    untied.
+
+    Note:
+        Per-row freezing requires the hook to see the full embedding gradient. Under
+        DeepSpeed ZeRO-3 / FSDP the embedding parameter (and its gradient) is sharded,
+        so the freeze cannot be applied reliably; in that case the hook detects the
+        partitioned gradient shape, leaves it untouched (no crash) and warns once.
+
+    Args:
+        model: The model with already-resized embeddings.
+        orig_vocab_size: The original vocabulary size before new tokens were added.
+    """
+    new_vocab_size = get_embedding_vocab_size(model)
+    num_new_tokens = new_vocab_size - orig_vocab_size
+
+    if num_new_tokens <= 0:
+        logger.warning_rank0("No new tokens to train, skipping embedding freeze.")
+        return
+
+    if is_deepspeed_zero3_enabled():
+        logger.warning_rank0(
+            "freeze_original_embeddings may not take effect under DeepSpeed ZeRO-3: the embedding "
+            "gradient is partitioned across ranks, so per-row freezing cannot be applied reliably. "
+            "Disable ZeRO-3 parameter sharding (or this flag) to train only the new tokens."
+        )
+
+    input_embed = model.get_input_embeddings()
+    input_embed.weight.register_hook(_make_embedding_freeze_hook(orig_vocab_size, new_vocab_size))
+    logger.info_rank0(
+        f"Registered gradient mask for input embeddings: frozen [0:{orig_vocab_size}], "
+        f"trainable [{orig_vocab_size}:{new_vocab_size}] ({num_new_tokens} new tokens)."
+    )
+
+    output_embed = model.get_output_embeddings()
+    if output_embed is not None:
+        if model.config.tie_word_embeddings:
+            logger.info_rank0("Output embeddings are tied; the gradient mask applies to both automatically.")
+        else:
+            output_embed.weight.register_hook(_make_embedding_freeze_hook(orig_vocab_size, new_vocab_size))
+            logger.info_rank0(
+                f"Registered gradient mask for output embeddings (untied): "
+                f"frozen [0:{orig_vocab_size}], trainable [{orig_vocab_size}:{new_vocab_size}]."
+            )

--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -27,7 +27,7 @@ from ..extras.misc import infer_optim_dtype
 from ..extras.packages import is_transformers_version_greater_than
 from .model_utils.attention import configure_attn_implementation, print_attn_implementation
 from .model_utils.checkpointing import prepare_model_for_training
-from .model_utils.embedding import resize_embedding_layer
+from .model_utils.embedding import apply_embedding_freeze, get_embedding_vocab_size, resize_embedding_layer
 from .model_utils.kv_cache import configure_kv_cache
 from .model_utils.longlora import configure_longlora
 from .model_utils.moe import add_z3_leaf_module, configure_moe
@@ -457,6 +457,9 @@ def patch_model(
         prepare_valuehead_model(model)
 
     if model_args.resize_vocab:
+        # Record the original vocab size before resizing (for the embedding freeze below).
+        orig_vocab_size = get_embedding_vocab_size(model)
+
         # Pass the explicit list of newly added tokens so their exact embedding rows can be
         # located and initialized, even when they land in a model's pre-existing padding zone.
         new_tokens = (model_args.add_tokens or []) + (model_args.add_special_tokens or [])
@@ -468,6 +471,10 @@ def patch_model(
             new_special_tokens_config=getattr(model_args, "_special_token_descriptions", None),
             init_special_tokens=model_args.init_special_tokens,
         )
+
+        # Freeze original embeddings if requested (only train the newly added tokens).
+        if is_trainable and model_args.freeze_original_embeddings:
+            apply_embedding_freeze(model, orig_vocab_size)
 
     if is_trainable:
         if getattr(model.config, "model_type", None) == "gemma3n":

--- a/tests/model/model_utils/test_embedding.py
+++ b/tests/model/model_utils/test_embedding.py
@@ -15,10 +15,14 @@
 import torch
 
 from llamafactory.model.model_utils.embedding import (
-    _description_based_initialization,
+    INIT_METHOD_ALIASES,
+    _description_initialization,
     _existing_embeddings,
-    _noisy_mean_initialization,
+    _make_embedding_freeze_hook,
+    _noise_initialization,
     _resolve_new_token_ids,
+    _vocab_mean_initialization,
+    _vocab_mean_noise_initialization,
 )
 
 
@@ -77,7 +81,7 @@ def test_existing_embeddings_excludes_new_token_ids():
     assert torch.allclose(everything, embed_weight)
 
 
-def test_noisy_mean_initialization_with_token_ids_targets_exact_rows():
+def test_vocab_mean_noise_initialization_with_token_ids_targets_exact_rows():
     """New tokens placed by explicit IDs must hit those rows, even inside the padding zone."""
     torch.manual_seed(0)
     vocab_size, embedding_dim = 20, 8
@@ -88,7 +92,7 @@ def test_noisy_mean_initialization_with_token_ids_targets_exact_rows():
     # num_new_tokens reflects the embedding resize delta (4 padded rows),
     # but the real new tokens sit at IDs 16 and 17 (inside what the tail slice would miss/over-cover).
     target_ids = [16, 17]
-    _noisy_mean_initialization(embed_weight, num_new_tokens=4, token_ids=target_ids)
+    _vocab_mean_noise_initialization(embed_weight, num_new_tokens=4, token_ids=target_ids)
 
     # targeted rows are initialized around the mean (~1.0) and not left at zero
     for tid in target_ids:
@@ -100,19 +104,51 @@ def test_noisy_mean_initialization_with_token_ids_targets_exact_rows():
     assert torch.allclose(embed_weight[19], torch.zeros(embedding_dim))
 
 
-def test_noisy_mean_initialization_tail_fallback():
+def test_vocab_mean_noise_initialization_tail_fallback():
     """Without token_ids, falls back to the last num_new_tokens rows."""
     torch.manual_seed(0)
     vocab_size, embedding_dim = 12, 8
     embed_weight = torch.zeros(vocab_size, embedding_dim)
     embed_weight[:10] = 1.0
 
-    _noisy_mean_initialization(embed_weight, num_new_tokens=2, token_ids=None)
+    _vocab_mean_noise_initialization(embed_weight, num_new_tokens=2, token_ids=None)
 
     # last two rows initialized, earlier rows untouched
     assert not torch.allclose(embed_weight[-1], torch.zeros(embedding_dim))
     assert not torch.allclose(embed_weight[-2], torch.zeros(embedding_dim))
     assert torch.allclose(embed_weight[0], torch.ones(embedding_dim))
+
+
+def test_noise_initialization_with_token_ids():
+    """Pure-noise init writes only the targeted rows and matches the existing std scale."""
+    torch.manual_seed(0)
+    vocab_size, embedding_dim = 64, 16
+    embed_weight = torch.zeros(vocab_size, embedding_dim)
+    embed_weight[:60].normal_(mean=0.0, std=0.02)
+
+    _noise_initialization(embed_weight, num_new_tokens=4, token_ids=[60, 61])
+
+    for tid in (60, 61):
+        assert not torch.allclose(embed_weight[tid], torch.zeros(embedding_dim))
+    # untouched rows stay zero
+    assert torch.allclose(embed_weight[62], torch.zeros(embedding_dim))
+    assert torch.allclose(embed_weight[63], torch.zeros(embedding_dim))
+
+
+def test_vocab_mean_initialization_assigns_identical_mean():
+    """Pure-mean init assigns the same mean vector to every targeted row."""
+    vocab_size, embedding_dim = 16, 8
+    # All rows are existing (2.0) except the two new tokens, which are excluded from the baseline.
+    embed_weight = torch.full((vocab_size, embedding_dim), 2.0)
+    embed_weight[12] = 0.0
+    embed_weight[13] = 0.0
+
+    _vocab_mean_initialization(embed_weight, num_new_tokens=4, token_ids=[12, 13])
+
+    expected = torch.full((embedding_dim,), 2.0)
+    assert torch.allclose(embed_weight[12], expected)
+    assert torch.allclose(embed_weight[13], expected)
+    assert torch.allclose(embed_weight[12], embed_weight[13])
 
 
 def test_description_init_excludes_new_token_ids_from_average():
@@ -129,7 +165,7 @@ def test_description_init_excludes_new_token_ids_from_average():
     tokenizer = _StubTokenizer({"<x>": 16}, desc_ids=[5, 17])
     model = _StubModel(embed_weight)
 
-    _description_based_initialization(
+    _description_initialization(
         embed_weight,
         num_new_tokens=4,
         descriptions={"<x>": "ignored, ids come from the stub"},
@@ -141,6 +177,42 @@ def test_description_init_excludes_new_token_ids_from_average():
 
     # row 16 must equal embedding of id 5 only (3.0), not the (5,17) average (1.5)
     assert torch.allclose(embed_weight[16], torch.full((embedding_dim,), 3.0))
+
+
+def test_embedding_freeze_hook_zeros_original_rows():
+    """The freeze hook must zero the gradient of original rows and keep new rows intact."""
+    vocab_size, embedding_dim, orig_size = 8, 4, 6
+    embed = torch.nn.Embedding(vocab_size, embedding_dim)
+    embed.weight.register_hook(_make_embedding_freeze_hook(orig_size, vocab_size))
+
+    # touch every row so each gets a gradient, then backprop
+    embed(torch.arange(vocab_size)).sum().backward()
+
+    grad = embed.weight.grad
+    assert torch.allclose(grad[:orig_size], torch.zeros(orig_size, embedding_dim))  # frozen
+    assert torch.all(grad[orig_size:] != 0.0)  # new rows still trainable
+
+
+def test_embedding_freeze_hook_passes_through_sharded_gradient():
+    """A partitioned/flattened gradient (ZeRO-3 / FSDP) is returned unchanged, never crashes."""
+    vocab_size, embedding_dim, orig_size = 8, 4, 6
+    hook = _make_embedding_freeze_hook(orig_size, vocab_size)
+
+    # 1D flat shard (FSDP-style) and a 2D shard with the wrong row count are both passed through
+    flat_shard = torch.ones(vocab_size * embedding_dim // 2)
+    assert torch.equal(hook(flat_shard), flat_shard)
+
+    row_shard = torch.ones(vocab_size // 2, embedding_dim)
+    assert torch.equal(hook(row_shard), row_shard)
+
+
+def test_legacy_init_method_aliases():
+    """Legacy init-method names map to their canonical equivalents."""
+    assert INIT_METHOD_ALIASES == {
+        "noise_init": "vocab_mean_noise",
+        "desc_init": "description",
+        "desc_init_w_noise": "description_noise",
+    }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Build on the new-token placement fix (#10547) to make embedding initialization more
expressive and controllable when expanding the vocabulary. No breaking changes — the
default path and all existing argument names keep working; everything here is additive.

## Initialization methods

- Introduce readable canonical names with a `<base>` / `<base>_noise` convention:
  `vocab_mean`, `vocab_mean_noise` (default), `noise`, `description`, `description_noise`.
- Legacy names (`noise_init` / `desc_init` / `desc_init_w_noise`) remain accepted as
  deprecated aliases for backward compatibility.
- Add pure-noise and pure vocab-mean initialization helpers.
- Rename the internal init helpers to match the public method names 1:1
  (`_vocab_mean_noise_initialization` / `_vocab_mean_initialization` /
  `_noise_initialization` / `_description_initialization`).

## Train only the new embeddings

- `freeze_original_embeddings`: register a gradient mask so only the newly added token
  rows are updated while the original embeddings stay frozen (intended for full
  finetuning; LoRA uses `additional_target` instead).

## Examples & docs

- `examples/extras/add_tokens`: runnable full SFT examples (`vocab_mean_noise` and
  `description` init), a token-description config, and a small text-to-SVG demo dataset
  (`add_tokens_demo`) whose responses actually use the new tokens, so the feature is
  exercised end to end.
- List LLM4SVG (CVPR 2025) and HiVG in the projects section.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?