### PR TITLE
fix(qwen): align tool-call training templates with native format

### DIFF
--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -259,11 +259,11 @@ class SharegptDatasetConverter(DatasetConverter):
             prompt = aligned_messages
             response = [
                 {
-                    "role": tag_mapping[chosen[self.dataset_attr.role_tag]],
+                    "role": tag_mapping[_get_role(chosen)],
                     "content": _get_content(chosen),
                 },
                 {
-                    "role": tag_mapping[rejected[self.dataset_attr.role_tag]],
+                    "role": tag_mapping[_get_role(rejected)],
                     "content": _get_content(rejected),
                 },
             ]

--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -145,28 +145,84 @@ class SharegptDatasetConverter(DatasetConverter):
         even_tags = (self.dataset_attr.assistant_tag, self.dataset_attr.function_tag)
         accept_tags = (odd_tags, even_tags)
         messages = example[self.dataset_attr.messages]
+
+        def _get_role(message: dict[str, Any]) -> str:
+            return message[self.dataset_attr.role_tag]
+
+        def _get_content(message: dict[str, Any]) -> str:
+            return message.get(self.dataset_attr.content_tag) or ""
+
+        def _wrap_tool_call(content: str) -> str:
+            if "<tool_call>" in content and "</tool_call>" in content:
+                return content
+
+            return f"<tool_call>\n{content}\n</tool_call>"
+
         if (
             self.dataset_attr.system_tag
             and len(messages) != 0
-            and messages[0][self.dataset_attr.role_tag] == self.dataset_attr.system_tag
+            and _get_role(messages[0]) == self.dataset_attr.system_tag
         ):
-            system = messages[0][self.dataset_attr.content_tag]
+            system = _get_content(messages[0])
             messages = messages[1:]
         else:
             system = example[self.dataset_attr.system] if self.dataset_attr.system else ""
 
         aligned_messages = []
         broken_data = False
+
+        preprocessed = []
+        i = 0
+        while i < len(messages):
+            role = _get_role(messages[i])
+            content = _get_content(messages[i])
+
+            if (
+                role == self.dataset_attr.assistant_tag
+                and i + 1 < len(messages)
+                and _get_role(messages[i + 1]) == self.dataset_attr.function_tag
+            ):
+                function_content = _wrap_tool_call(_get_content(messages[i + 1]))
+                merged_content = f"{content}\n\n{function_content}" if content else function_content
+                preprocessed.append(
+                    {
+                        self.dataset_attr.role_tag: self.dataset_attr.function_tag,
+                        self.dataset_attr.content_tag: merged_content,
+                    }
+                )
+                i += 2
+                continue
+
+            if role == self.dataset_attr.observation_tag:
+                obs_parts = [content]
+                while i + 1 < len(messages) and _get_role(messages[i + 1]) == self.dataset_attr.observation_tag:
+                    i += 1
+                    obs_parts.append(_get_content(messages[i]))
+
+                preprocessed.append(
+                    {
+                        self.dataset_attr.role_tag: self.dataset_attr.observation_tag,
+                        self.dataset_attr.content_tag: "\n</tool_response>\n<tool_response>\n".join(obs_parts),
+                    }
+                )
+                i += 1
+                continue
+
+            preprocessed.append({**messages[i], self.dataset_attr.content_tag: content})
+            i += 1
+
+        messages = preprocessed
+
         for turn_idx, message in enumerate(messages):
-            if message[self.dataset_attr.role_tag] not in accept_tags[turn_idx % 2]:
+            if _get_role(message) not in accept_tags[turn_idx % 2]:
                 logger.warning_rank0(f"Invalid role tag in {messages}.")
                 broken_data = True
                 break
 
             aligned_messages.append(
                 {
-                    "role": tag_mapping[message[self.dataset_attr.role_tag]],
-                    "content": message[self.dataset_attr.content_tag],
+                    "role": tag_mapping[_get_role(message)],
+                    "content": _get_content(message),
                 }
             )
 
@@ -204,11 +260,11 @@ class SharegptDatasetConverter(DatasetConverter):
             response = [
                 {
                     "role": tag_mapping[chosen[self.dataset_attr.role_tag]],
-                    "content": chosen[self.dataset_attr.content_tag],
+                    "content": _get_content(chosen),
                 },
                 {
                     "role": tag_mapping[rejected[self.dataset_attr.role_tag]],
-                    "content": rejected[self.dataset_attr.content_tag],
+                    "content": _get_content(rejected),
                 },
             ]
         else:  # normal example

--- a/src/llamafactory/data/formatter.py
+++ b/src/llamafactory/data/formatter.py
@@ -132,8 +132,14 @@ class FunctionFormatter(StringFormatter):
             if thought_match:
                 function_str = thought_match.group(0) + function_str
         else:
-            thought_content = content.replace(tool_call_match.group(0), "")
-            functions = _parse_functions(tool_call_match.group(1))
+            extracted = self.tool_utils.tool_extractor(content)
+            if isinstance(extracted, list):
+                thought_content = re.sub(tool_call_regex, "", content)
+                functions = extracted
+            else:
+                thought_content = content.replace(tool_call_match.group(0), "")
+                functions = _parse_functions(tool_call_match.group(1))
+
             function_str = self.tool_utils.function_formatter(functions)
             function_str = thought_content + function_str
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -464,9 +464,10 @@ class ReasoningTemplate(Template):
             turn_indices = [len(messages) - 2]
         else:
             last_query_index = 0
-            for i in range(0, len(messages), 2):
+            for i in range(len(messages) - 2, -1, -2):
                 if messages[i]["role"] == Role.USER:
                     last_query_index = i
+                    break
 
             turn_indices = [i for i in range(0, len(messages), 2) if i >= last_query_index]
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -56,6 +56,7 @@ class Template:
     enable_thinking: Optional[bool]
     preserve_thinking: bool
     mm_plugin: "BasePlugin"
+    tools_before_system: bool = False
 
     def encode_oneturn(
         self,
@@ -110,6 +111,13 @@ class Template:
         r"""Get the token ids of thought words."""
         return tokenizer.encode(self.add_thought(), add_special_tokens=False)
 
+    def _get_system_content(self, system: str, tools: Optional[str]) -> str:
+        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+        if self.tools_before_system and tool_text:
+            return tool_text.lstrip("\n") + (f"\n\n{system}" if system else "")
+
+        return system + tool_text
+
     def _convert_elements_to_ids(self, tokenizer: "PreTrainedTokenizer", elements: "SLOTS") -> list[int]:
         r"""Convert elements to token ids."""
         token_ids = []
@@ -149,8 +157,7 @@ class Template:
             if i == 0:
                 elements += self.format_prefix.apply()
                 if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    elements += self.format_system.apply(content=(system + tool_text))
+                    elements += self.format_system.apply(content=self._get_system_content(system, tools))
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
@@ -354,8 +361,7 @@ class Llama2Template(Template):
             if i == 0:
                 elements += self.format_prefix.apply()
                 if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    system_text = self.format_system.apply(content=(system + tool_text))[0]
+                    system_text = self.format_system.apply(content=self._get_system_content(system, tools))[0]
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=system_text + message["content"])
@@ -457,7 +463,12 @@ class ReasoningTemplate(Template):
         if discarding_history_cot:
             turn_indices = [len(messages) - 2]
         else:
-            turn_indices = range(0, len(messages), 2)
+            last_query_index = 0
+            for i in range(0, len(messages), 2):
+                if messages[i]["role"] == Role.USER:
+                    last_query_index = i
+
+            turn_indices = [i for i in range(0, len(messages), 2) if i >= last_query_index]
 
         for i in turn_indices:
             if (
@@ -507,6 +518,7 @@ def register_template(
     preserve_thinking: bool = False,
     mm_plugin: "BasePlugin" = get_mm_plugin(name="base"),
     template_class: type["Template"] = Template,
+    tools_before_system: bool = False,
 ) -> None:
     r"""Register a chat template.
 
@@ -559,6 +571,7 @@ def register_template(
         enable_thinking=enable_thinking,
         preserve_thinking=preserve_thinking,
         mm_plugin=mm_plugin,
+        tools_before_system=tools_before_system,
     )
 
 
@@ -2135,6 +2148,7 @@ register_template(
     replace_eos=True,
     mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
     template_class=ReasoningTemplate,
+    tools_before_system=True,
 )
 
 
@@ -2151,6 +2165,7 @@ register_template(
     stop_words=["<|im_end|>"],
     replace_eos=True,
     mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
+    tools_before_system=True,
 )
 
 
@@ -2169,6 +2184,7 @@ register_template(
     replace_eos=True,
     mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
     template_class=ReasoningTemplate,
+    tools_before_system=True,
 )
 
 

--- a/tests/data/test_converter.py
+++ b/tests/data/test_converter.py
@@ -62,3 +62,69 @@ def test_sharegpt_converter():
         "_videos": None,
         "_audios": None,
     }
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_sharegpt_converter_merges_assistant_text_with_function_call():
+    dataset_attr = DatasetAttr("hf_hub", "llamafactory/tiny-supervised-dataset")
+    data_args = DataArguments()
+    example = {
+        "conversations": [
+            {"from": "human", "value": "What is the weather in Beijing?"},
+            {"from": "gpt", "value": "Let me check that for you."},
+            {"from": "function_call", "value": '{"name": "get_weather", "arguments": {"city": "Beijing"}}'},
+        ]
+    }
+    dataset_converter = get_dataset_converter("sharegpt", dataset_attr, data_args)
+    assert dataset_converter(example)["_response"] == [
+        {
+            "role": Role.FUNCTION.value,
+            "content": (
+                "Let me check that for you.\n\n"
+                '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Beijing"}}\n</tool_call>'
+            ),
+        }
+    ]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_sharegpt_converter_merges_consecutive_observations():
+    dataset_attr = DatasetAttr("hf_hub", "llamafactory/tiny-supervised-dataset")
+    data_args = DataArguments()
+    example = {
+        "conversations": [
+            {"from": "human", "value": "Fetch both results."},
+            {"from": "function_call", "value": '{"name": "lookup", "arguments": {"query": "both"}}'},
+            {"from": "observation", "value": '{"result": "first"}'},
+            {"from": "observation", "value": '{"result": "second"}'},
+            {"from": "gpt", "value": "Done."},
+        ]
+    }
+    dataset_converter = get_dataset_converter("sharegpt", dataset_attr, data_args)
+    out = dataset_converter(example)
+    assert out["_prompt"] == [
+        {"role": Role.USER.value, "content": "Fetch both results."},
+        {"role": Role.FUNCTION.value, "content": '{"name": "lookup", "arguments": {"query": "both"}}'},
+        {
+            "role": Role.OBSERVATION.value,
+            "content": '{"result": "first"}\n</tool_response>\n<tool_response>\n{"result": "second"}',
+        },
+    ]
+    assert out["_response"] == [{"role": Role.ASSISTANT.value, "content": "Done."}]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_sharegpt_converter_coerces_single_none_observation():
+    dataset_attr = DatasetAttr("hf_hub", "llamafactory/tiny-supervised-dataset")
+    data_args = DataArguments()
+    example = {
+        "conversations": [
+            {"from": "human", "value": "Run noop."},
+            {"from": "function_call", "value": '{"name": "noop", "arguments": {}}'},
+            {"from": "observation", "value": None},
+            {"from": "gpt", "value": "Done."},
+        ]
+    }
+    dataset_converter = get_dataset_converter("sharegpt", dataset_attr, data_args)
+    out = dataset_converter(example)
+    assert out["_prompt"][2] == {"role": Role.OBSERVATION.value, "content": ""}

--- a/tests/data/test_formatter.py
+++ b/tests/data/test_formatter.py
@@ -261,6 +261,50 @@ def test_qwen_multi_function_formatter():
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_qwen35_function_formatter_preserves_text_before_native_tool_call():
+    formatter = FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="qwen3_5")
+    content = (
+        "Let me check that for you.\n\n"
+        "<tool_call>\n"
+        "<function=get_weather>\n"
+        "<parameter=city>\n"
+        "Beijing\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
+    assert formatter.apply(content=content, tool_call_words=("<tool_call>", "</tool_call>")) == [
+        "Let me check that for you.\n\n"
+        "<tool_call>\n"
+        "<function=get_weather>\n"
+        "<parameter=city>\n"
+        "Beijing\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call><|im_end|>\n"
+    ]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_qwen35_function_formatter_preserves_text_before_json_tool_call():
+    formatter = FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="qwen3_5")
+    content = (
+        "Let me check that for you.\n\n"
+        '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Beijing"}}\n</tool_call>'
+    )
+    assert formatter.apply(content=content, tool_call_words=("<tool_call>", "</tool_call>")) == [
+        "Let me check that for you.\n\n"
+        "<tool_call>\n"
+        "<function=get_weather>\n"
+        "<parameter=city>\n"
+        "Beijing\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call><|im_end|>\n"
+    ]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 def test_qwen_tool_formatter():
     formatter = ToolFormatter(tool_format="qwen")
     wrapped_tool = {"type": "function", "function": TOOLS[0]}

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from typing import TYPE_CHECKING
 
@@ -46,6 +47,33 @@ MESSAGES_WITH_THOUGHT = [
     {"role": "user", "content": "你好"},
     {"role": "assistant", "content": "<think>\n模型思考内容\n</think>\n\n很高兴认识你！"},
 ]
+
+TOOL_CALL_MESSAGES = [
+    {"role": "user", "content": "What is the weather in Beijing?"},
+    {"role": "function", "content": '{"name": "get_weather", "arguments": {"city": "Beijing"}}'},
+    {"role": "observation", "content": '{"temperature": "25C"}'},
+    {"role": "assistant", "content": "It is 25C in Beijing."},
+    {"role": "user", "content": "And in Shanghai?"},
+    {"role": "function", "content": '{"name": "get_weather", "arguments": {"city": "Shanghai"}}'},
+    {"role": "observation", "content": '{"temperature": "30C"}'},
+    {"role": "assistant", "content": "It is 30C in Shanghai."},
+]
+
+TOOLS_JSON = json.dumps(
+    [
+        {
+            "name": "get_weather",
+            "description": "Get weather info",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+)
+
+SYSTEM_PROMPT = "You are a helpful assistant."
 
 
 def _check_tokenization(
@@ -169,10 +197,8 @@ def test_reasoning_encode_multiturn(cot_messages: bool, enable_thinking: bool):
     answer_str_2 = f"{messages[3]['content']}<|im_end|>\n"
     if not cot_messages or enable_thinking is False:
         if enable_thinking:
-            answer_str_1 = "<think>\n\n</think>\n\n" + answer_str_1
             answer_str_2 = "<think>\n\n</think>\n\n" + answer_str_2
         else:
-            prompt_str_1 = prompt_str_1 + "<think>\n\n</think>\n\n"
             prompt_str_2 = prompt_str_2 + "<think>\n\n</think>\n\n"
 
     _check_tokenization(
@@ -202,7 +228,6 @@ def test_reasoning_encode_multiturn_discarding_history_cot(enable_thinking: bool
         if discarding_history_cot:
             prompt_str_2 = prompt_str_2 + "<think>\n\n</think>\n\n"
         else:
-            prompt_str_1 = prompt_str_1 + "<think>\n\n</think>\n\n"
             prompt_str_2 = prompt_str_2 + "<think>\n\n</think>\n\n"
     else:
         if discarding_history_cot:
@@ -216,6 +241,30 @@ def test_reasoning_encode_multiturn_discarding_history_cot(enable_thinking: bool
         (encoded_pairs[0][0], encoded_pairs[0][1], encoded_pairs[1][0], encoded_pairs[1][1]),
         (prompt_str_1, answer_str_1, prompt_str_2, answer_str_2),
     )
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+@pytest.mark.parametrize("template_name", ["qwen3_5", "qwen3_5_nothink", "qwen3_6"])
+def test_qwen35_tool_prompt_precedes_system_prompt(template_name: str):
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B")
+    template = get_template_and_fix_tokenizer(tokenizer, DataArguments(template=template_name, enable_thinking=False))
+    prompt_ids, _ = template.encode_oneturn(tokenizer, TOOL_CALL_MESSAGES[:4], system=SYSTEM_PROMPT, tools=TOOLS_JSON)
+    prompt = tokenizer.decode(prompt_ids)
+    assert prompt.startswith("<|im_start|>system\n# Tools")
+    assert prompt.index("# Tools") < prompt.index(SYSTEM_PROMPT)
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+@pytest.mark.parametrize("template_name", ["qwen3_5", "qwen3_6"])
+def test_qwen35_thinking_starts_after_last_real_user_query(template_name: str):
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B")
+    template = get_template_and_fix_tokenizer(tokenizer, DataArguments(template=template_name, enable_thinking=False))
+    encoded_pairs = template.encode_multiturn(tokenizer, TOOL_CALL_MESSAGES, system=SYSTEM_PROMPT, tools=TOOLS_JSON)
+    decoded_prompts = [tokenizer.decode(prompt_ids) for prompt_ids, _ in encoded_pairs]
+    assert "<think>\n\n</think>\n\n" not in decoded_prompts[0]
+    assert "<think>\n\n</think>\n\n" not in decoded_prompts[1]
+    assert decoded_prompts[2].endswith("<|im_start|>assistant\n<think>\n\n</think>\n\n")
+    assert decoded_prompts[3].endswith("<|im_start|>assistant\n<think>\n\n</think>\n\n")
 
 
 @pytest.mark.runs_on(["cpu", "mps"])


### PR DESCRIPTION
## Summary

- support ShareGPT assistant text followed by `function_call` as one function turn, preserving the text before the tool call
- merge consecutive ShareGPT observations into one tool-response block and normalize missing tool-response content to an empty string
- match Qwen3.5/Qwen3.6 native template behavior for tool prompt placement and thinking blocks after the last real user query

Closes #10530.
Fixes #10491.

## Tests

- `WANDB_DISABLED=true .venv/bin/pytest -vv --import-mode=importlib tests/data/test_converter.py tests/data/test_formatter.py tests/data/test_template.py tests/data/test_collator.py`
  - 77 passed, 4 skipped, 3 xpassed
- `WANDB_DISABLED=true .venv/bin/pytest -vv --import-mode=importlib tests/data`
  - 108 passed, 6 skipped, 3 xpassed
- `.venv/bin/ruff check src/llamafactory/data/converter.py src/llamafactory/data/formatter.py src/llamafactory/data/template.py tests/data/test_converter.py tests/data/test_formatter.py tests/data/test_template.py`
- `.venv/bin/ruff format --check src/llamafactory/data/converter.py src/llamafactory/data/formatter.py src/llamafactory/data/template.py tests/data/test_converter.py tests/data/test_formatter.py tests/data/test_template.py`
- `git diff --check`