### PR TITLE
fix(data): stabilize mixed-modality SFT schema

### DIFF
--- a/src/llamafactory/data/loader.py
+++ b/src/llamafactory/data/loader.py
@@ -16,7 +16,7 @@ import os
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import numpy as np
-from datasets import Dataset, DatasetDict, load_dataset, load_from_disk
+from datasets import Dataset, DatasetDict, Features, Sequence, Value, load_dataset, load_from_disk
 
 from ..extras import logging
 from ..extras.constants import FILEEXT2TYPE
@@ -226,6 +226,20 @@ def _get_dataset_processor(
     return dataset_processor_class(template=template, tokenizer=tokenizer, processor=processor, data_args=data_args)
 
 
+def _get_sft_dataset_features(dataset: "Dataset") -> Features:
+    r"""Return stable output features for non-packed supervised preprocessing."""
+    return Features(
+        {
+            "input_ids": Sequence(Value("int32")),
+            "attention_mask": Sequence(Value("int8")),
+            "labels": Sequence(Value("int64")),
+            "images": dataset.features["_images"],
+            "videos": dataset.features["_videos"],
+            "audios": dataset.features["_audios"],
+        }
+    )
+
+
 def _get_preprocessed_dataset(
     dataset: Union["Dataset", "IterableDataset"] | None,
     data_args: "DataArguments",
@@ -251,6 +265,8 @@ def _get_preprocessed_dataset(
             load_from_cache_file=(not data_args.overwrite_cache) or (training_args.local_process_index != 0),
             desc="Running tokenizer on dataset",
         )
+        if stage == "sft" and not data_args.packing and not (training_args.predict_with_generate and is_eval):
+            kwargs["features"] = _get_sft_dataset_features(dataset)
 
     dataset = dataset.map(
         dataset_processor.preprocess_dataset,

--- a/src/llamafactory/data/loader.py
+++ b/src/llamafactory/data/loader.py
@@ -16,7 +16,7 @@ import os
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import numpy as np
-from datasets import Dataset, DatasetDict, Features, Sequence, Value, load_dataset, load_from_disk
+from datasets import Dataset, DatasetDict, load_dataset, load_from_disk
 
 from ..extras import logging
 from ..extras.constants import FILEEXT2TYPE
@@ -226,20 +226,6 @@ def _get_dataset_processor(
     return dataset_processor_class(template=template, tokenizer=tokenizer, processor=processor, data_args=data_args)
 
 
-def _get_sft_dataset_features(dataset: "Dataset") -> Features:
-    r"""Return stable output features for non-packed supervised preprocessing."""
-    return Features(
-        {
-            "input_ids": Sequence(Value("int32")),
-            "attention_mask": Sequence(Value("int8")),
-            "labels": Sequence(Value("int64")),
-            "images": dataset.features["_images"],
-            "videos": dataset.features["_videos"],
-            "audios": dataset.features["_audios"],
-        }
-    )
-
-
 def _get_preprocessed_dataset(
     dataset: Union["Dataset", "IterableDataset"] | None,
     data_args: "DataArguments",
@@ -265,8 +251,9 @@ def _get_preprocessed_dataset(
             load_from_cache_file=(not data_args.overwrite_cache) or (training_args.local_process_index != 0),
             desc="Running tokenizer on dataset",
         )
-        if stage == "sft" and not data_args.packing and not (training_args.predict_with_generate and is_eval):
-            kwargs["features"] = _get_sft_dataset_features(dataset)
+        features = dataset_processor.get_dataset_features(dataset)
+        if features is not None:
+            kwargs["features"] = features
 
     dataset = dataset.map(
         dataset_processor.preprocess_dataset,

--- a/src/llamafactory/data/processor/feedback.py
+++ b/src/llamafactory/data/processor/feedback.py
@@ -15,12 +15,16 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Optional
 
+from datasets import Sequence, Value
+
 from ...extras import logging
 from ...extras.constants import IGNORE_INDEX
-from .processor_utils import DatasetProcessor, infer_seqlen
+from .processor_utils import DatasetProcessor, build_dataset_features, infer_seqlen
 
 
 if TYPE_CHECKING:
+    from datasets import Dataset, Features
+
     from ..mm_plugin import AudioInput, ImageInput, VideoInput
 
 
@@ -28,6 +32,22 @@ logger = logging.get_logger(__name__)
 
 
 class FeedbackDatasetProcessor(DatasetProcessor):
+    @staticmethod
+    def get_dataset_features(dataset: "Dataset") -> "Features":
+        r"""Return the schema for the fields emitted by ``preprocess_dataset``."""
+        return build_dataset_features(
+            dataset,
+            {
+                "input_ids": Sequence(Value("int32")),
+                "attention_mask": Sequence(Value("int8")),
+                "labels": Sequence(Value("int64")),
+                "kl_input_ids": Sequence(Value("int32")),
+                "kl_attention_mask": Sequence(Value("int8")),
+                "kl_labels": Sequence(Value("int64")),
+                "kto_tags": Value("bool"),
+            },
+        )
+
     def _encode_data_example(
         self,
         prompt: list[dict[str, str]],
@@ -83,6 +103,7 @@ class FeedbackDatasetProcessor(DatasetProcessor):
         return input_ids, labels, kl_input_ids, kl_labels, kto_tag
 
     def preprocess_dataset(self, examples: dict[str, list[Any]]) -> dict[str, list[Any]]:
+        # Keep these output keys in sync with ``get_dataset_features`` above.
         # Creates mismatched pairs of prompts and completions for the KL dataset by adding a +1 offset to the order of completions.
         kl_response = [examples["_response"][-1]] + examples["_response"][:-1]
         model_inputs = defaultdict(list)

--- a/src/llamafactory/data/processor/pairwise.py
+++ b/src/llamafactory/data/processor/pairwise.py
@@ -15,12 +15,16 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Optional
 
+from datasets import Sequence, Value
+
 from ...extras import logging
 from ...extras.constants import IGNORE_INDEX
-from .processor_utils import DatasetProcessor, infer_seqlen
+from .processor_utils import DatasetProcessor, build_dataset_features, infer_seqlen
 
 
 if TYPE_CHECKING:
+    from datasets import Dataset, Features
+
     from ..mm_plugin import AudioInput, ImageInput, VideoInput
 
 
@@ -28,6 +32,21 @@ logger = logging.get_logger(__name__)
 
 
 class PairwiseDatasetProcessor(DatasetProcessor):
+    @staticmethod
+    def get_dataset_features(dataset: "Dataset") -> "Features":
+        r"""Return the schema for the fields emitted by ``preprocess_dataset``."""
+        return build_dataset_features(
+            dataset,
+            {
+                "chosen_input_ids": Sequence(Value("int32")),
+                "chosen_attention_mask": Sequence(Value("int8")),
+                "chosen_labels": Sequence(Value("int64")),
+                "rejected_input_ids": Sequence(Value("int32")),
+                "rejected_attention_mask": Sequence(Value("int8")),
+                "rejected_labels": Sequence(Value("int64")),
+            },
+        )
+
     def _encode_data_example(
         self,
         prompt: list[dict[str, str]],
@@ -69,6 +88,7 @@ class PairwiseDatasetProcessor(DatasetProcessor):
         return chosen_input_ids, chosen_labels, rejected_input_ids, rejected_labels
 
     def preprocess_dataset(self, examples: dict[str, list[Any]]) -> dict[str, list[Any]]:
+        # Keep these output keys in sync with ``get_dataset_features`` above.
         # build input pairs with format `<bos> X`, `Y1 <eos>` and `Y2 <eos>`
         model_inputs = defaultdict(list)
         for i in range(len(examples["_prompt"])):

--- a/src/llamafactory/data/processor/pretrain.py
+++ b/src/llamafactory/data/processor/pretrain.py
@@ -17,13 +17,30 @@
 
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from .processor_utils import DatasetProcessor
+from datasets import Sequence, Value
+
+from .processor_utils import DatasetProcessor, build_dataset_features
+
+
+if TYPE_CHECKING:
+    from datasets import Dataset, Features
 
 
 @dataclass
 class PretrainDatasetProcessor(DatasetProcessor):
+    def get_dataset_features(self, dataset: "Dataset") -> "Features":
+        r"""Return the schema for the fields emitted by ``preprocess_dataset``."""
+        output_features = {
+            "input_ids": Sequence(Value("int32")),
+            "attention_mask": Sequence(Value("int8")),
+        }
+        if "token_type_ids" in getattr(self.tokenizer, "model_input_names", []):
+            output_features["token_type_ids"] = Sequence(Value("int32"))
+
+        return build_dataset_features(dataset, output_features, include_multimodal=False)
+
     def preprocess_dataset(self, examples: dict[str, list[Any]]) -> dict[str, list[Any]]:
         # build grouped texts with format `X1 X2 X3 ...` if packing is enabled
         eos_token = "<|end_of_text|>" if self.data_args.template == "llama3" else self.tokenizer.eos_token
@@ -38,8 +55,8 @@ class PretrainDatasetProcessor(DatasetProcessor):
             )
         else:
             tokenized_examples = self.tokenizer(text_examples, add_special_tokens=False)
-            concatenated_examples = {k: list(chain(*tokenized_examples[k])) for k in tokenized_examples.keys()}
-            total_length = len(concatenated_examples[list(concatenated_examples.keys())[0]])
+            concatenated_examples = {k: list(chain(*tokenized_examples[k])) for k in tokenized_examples}
+            total_length = len(concatenated_examples[next(iter(concatenated_examples))])
             block_size = self.data_args.cutoff_len
             total_length = (total_length // block_size) * block_size
             result = {

--- a/src/llamafactory/data/processor/processor_utils.py
+++ b/src/llamafactory/data/processor/processor_utils.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 
 if TYPE_CHECKING:
+    from datasets import Dataset, Features
     from transformers import PreTrainedTokenizer, ProcessorMixin
 
     from ...hparams import DataArguments
@@ -43,6 +44,32 @@ class DatasetProcessor(ABC):
     def print_data_example(self, example: dict[str, list[int]]) -> None:
         r"""Print a data example to stdout."""
         ...
+
+    @staticmethod
+    def get_dataset_features(dataset: "Dataset") -> "Features | None":
+        r"""Return a stable output schema for ``Dataset.map``, or ``None`` to infer it."""
+        return None
+
+
+def build_dataset_features(
+    dataset: "Dataset", output_features: dict[str, Any], include_multimodal: bool = True
+) -> "Features":
+    r"""Build output features and validate the aligned dataset columns."""
+    from datasets import Features
+
+    output_features = dict(output_features)
+    if include_multimodal:
+        media_columns = {"_images": "images", "_videos": "videos", "_audios": "audios"}
+        missing_columns = [column for column in media_columns if column not in dataset.features]
+        if missing_columns:
+            raise ValueError(
+                "Expected an aligned dataset with multimodal columns, but the following columns are missing: "
+                + ", ".join(missing_columns)
+            )
+
+        output_features.update({target: dataset.features[source] for source, target in media_columns.items()})
+
+    return Features(output_features)
 
 
 def search_for_fit(numbers: list[int], capacity: int) -> int:

--- a/src/llamafactory/data/processor/supervised.py
+++ b/src/llamafactory/data/processor/supervised.py
@@ -16,12 +16,16 @@ from collections import defaultdict
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
+from datasets import Sequence, Value
+
 from ...extras import logging
 from ...extras.constants import IGNORE_INDEX
-from .processor_utils import DatasetProcessor, greedy_knapsack, infer_seqlen
+from .processor_utils import DatasetProcessor, build_dataset_features, greedy_knapsack, infer_seqlen
 
 
 if TYPE_CHECKING:
+    from datasets import Dataset, Features
+
     from ..mm_plugin import AudioInput, ImageInput, VideoInput
 
 
@@ -49,6 +53,18 @@ class PackingParams:
 
 @dataclass
 class SupervisedDatasetProcessor(DatasetProcessor):
+    @staticmethod
+    def get_dataset_features(dataset: "Dataset") -> "Features":
+        r"""Return the schema for the fields emitted by ``preprocess_dataset``."""
+        return build_dataset_features(
+            dataset,
+            {
+                "input_ids": Sequence(Value("int32")),
+                "attention_mask": Sequence(Value("int8")),
+                "labels": Sequence(Value("int64")),
+            },
+        )
+
     def _encode_data_example(
         self,
         prompt: list[dict[str, str]],
@@ -106,6 +122,7 @@ class SupervisedDatasetProcessor(DatasetProcessor):
         return input_ids, labels
 
     def preprocess_dataset(self, examples: dict[str, list[Any]]) -> dict[str, list[Any]]:
+        # Keep these output keys in sync with ``get_dataset_features`` above.
         # build inputs with format `<bos> X Y <eos>` and labels with format `<ignore> ... <ignore> Y <eos>`
         # for multiturn examples, we only mask the prompt part in each prompt-response pair.
         model_inputs = defaultdict(list)
@@ -144,6 +161,11 @@ class SupervisedDatasetProcessor(DatasetProcessor):
 
 @dataclass
 class PackedSupervisedDatasetProcessor(SupervisedDatasetProcessor):
+    @staticmethod
+    def get_dataset_features(dataset: "Dataset") -> None:
+        r"""Keep the inferred schema for packed outputs with packing metadata."""
+        return
+
     def preprocess_dataset(self, examples: dict[str, list[Any]]) -> dict[str, list[Any]]:
         # TODO: use `position_ids` to achieve packing
         # build inputs with format `<bos> X1 Y1 <eos> <bos> X2 Y2 <eos>`

--- a/src/llamafactory/data/processor/unsupervised.py
+++ b/src/llamafactory/data/processor/unsupervised.py
@@ -15,12 +15,16 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Optional
 
+from datasets import Sequence, Value
+
 from ...extras import logging
 from ..data_utils import Role
-from .processor_utils import DatasetProcessor, infer_seqlen
+from .processor_utils import DatasetProcessor, build_dataset_features, infer_seqlen
 
 
 if TYPE_CHECKING:
+    from datasets import Dataset, Features
+
     from ..mm_plugin import AudioInput, ImageInput, VideoInput
 
 
@@ -28,6 +32,18 @@ logger = logging.get_logger(__name__)
 
 
 class UnsupervisedDatasetProcessor(DatasetProcessor):
+    @staticmethod
+    def get_dataset_features(dataset: "Dataset") -> "Features":
+        r"""Return the schema for the fields emitted by ``preprocess_dataset``."""
+        return build_dataset_features(
+            dataset,
+            {
+                "input_ids": Sequence(Value("int32")),
+                "attention_mask": Sequence(Value("int8")),
+                "labels": Sequence(Value("int64")),
+            },
+        )
+
     def _encode_data_example(
         self,
         prompt: list[dict[str, str]],
@@ -57,6 +73,7 @@ class UnsupervisedDatasetProcessor(DatasetProcessor):
         return input_ids, labels
 
     def preprocess_dataset(self, examples: dict[str, list[Any]]) -> dict[str, list[Any]]:
+        # Keep these output keys in sync with ``get_dataset_features`` above.
         # build inputs with format `<bos> X` and labels with format `Y <eos>`
         model_inputs = defaultdict(list)
         for i in range(len(examples["_prompt"])):

--- a/tests/data/test_loader.py
+++ b/tests/data/test_loader.py
@@ -64,9 +64,9 @@ def test_sft_features_stabilize_mixed_modality_batches():
     def preprocess_dataset(examples):
         batch_size = len(examples["_prompt"])
         return {
-            "input_ids": [[1]] * batch_size,
-            "attention_mask": [[1]] * batch_size,
-            "labels": [[1]] * batch_size,
+            "input_ids": [[1] for _ in range(batch_size)],
+            "attention_mask": [[1] for _ in range(batch_size)],
+            "labels": [[1] for _ in range(batch_size)],
             "images": examples["_images"],
             "videos": examples["_videos"],
             "audios": examples["_audios"],

--- a/tests/data/test_loader.py
+++ b/tests/data/test_loader.py
@@ -15,7 +15,9 @@
 import os
 
 import pytest
+from datasets import Dataset, Features, Sequence, Value
 
+from llamafactory.data.loader import _get_sft_dataset_features
 from llamafactory.train.test_utils import load_dataset_module
 
 
@@ -38,6 +40,53 @@ TRAIN_ARGS = {
     "overwrite_output_dir": True,
     "fp16": True,
 }
+
+
+def test_sft_features_stabilize_mixed_modality_batches():
+    source_features = Features(
+        {
+            "_prompt": Value("string"),
+            "_images": Sequence(Value("string")),
+            "_videos": Sequence(Value("string")),
+            "_audios": Sequence(Value("string")),
+        }
+    )
+    dataset = Dataset.from_dict(
+        {
+            "_prompt": ["text 1", "text 2", "image", "video"],
+            "_images": [None, None, ["image.png"], None],
+            "_videos": [None, None, None, ["video.mp4"]],
+            "_audios": [None, None, None, None],
+        },
+        features=source_features,
+    )
+
+    def preprocess_dataset(examples):
+        batch_size = len(examples["_prompt"])
+        return {
+            "input_ids": [[1]] * batch_size,
+            "attention_mask": [[1]] * batch_size,
+            "labels": [[1]] * batch_size,
+            "images": examples["_images"],
+            "videos": examples["_videos"],
+            "audios": examples["_audios"],
+        }
+
+    processed_dataset = dataset.map(
+        preprocess_dataset,
+        batched=True,
+        batch_size=2,
+        remove_columns=dataset.column_names,
+        features=_get_sft_dataset_features(dataset),
+    )
+
+    assert processed_dataset.features["images"] == source_features["_images"]
+    assert processed_dataset.features["videos"] == source_features["_videos"]
+    assert processed_dataset.features["labels"] == Sequence(Value("int64"))
+    assert processed_dataset["images"][0] is None
+    assert processed_dataset["videos"][0] is None
+    assert processed_dataset["images"][2] == ["image.png"]
+    assert processed_dataset["videos"][3] == ["video.mp4"]
 
 
 @pytest.mark.runs_on(["cpu", "mps"])

--- a/tests/data/test_loader.py
+++ b/tests/data/test_loader.py
@@ -17,7 +17,7 @@ import os
 import pytest
 from datasets import Dataset, Features, Sequence, Value
 
-from llamafactory.data.loader import _get_sft_dataset_features
+from llamafactory.data.processor.supervised import SupervisedDatasetProcessor
 from llamafactory.train.test_utils import load_dataset_module
 
 
@@ -77,7 +77,7 @@ def test_sft_features_stabilize_mixed_modality_batches():
         batched=True,
         batch_size=2,
         remove_columns=dataset.column_names,
-        features=_get_sft_dataset_features(dataset),
+        features=SupervisedDatasetProcessor.get_dataset_features(dataset),
     )
 
     assert processed_dataset.features["images"] == source_features["_images"]
@@ -87,6 +87,13 @@ def test_sft_features_stabilize_mixed_modality_batches():
     assert processed_dataset["videos"][0] is None
     assert processed_dataset["images"][2] == ["image.png"]
     assert processed_dataset["videos"][3] == ["video.mp4"]
+
+
+def test_sft_features_require_aligned_media_columns():
+    dataset = Dataset.from_dict({"_prompt": ["text"]})
+
+    with pytest.raises(ValueError, match="_images, _videos, _audios"):
+        SupervisedDatasetProcessor.get_dataset_features(dataset)
 
 
 @pytest.mark.runs_on(["cpu", "mps"])


### PR DESCRIPTION
# What does this PR do?

Fixes #7266.
Fixes #9195.

Related to #5613 and #6223.

This PR stabilizes non-streaming dataset preprocessing for datasets that mix text-only, image-text, video-text, and audio-text samples.

Hugging Face Datasets infers the Arrow schema from processed batches. If an early batch contains no media, optional media columns may be inferred as `null`. A later batch containing media then fails with:

```text
TypeError: Couldn't cast array of type list<item: string> to null
```

The fix adds a `DatasetProcessor.get_dataset_features()` hook so each processor owns the schema for the fields emitted by its `preprocess_dataset()` implementation. The shared loader applies that schema to non-streaming `Dataset.map()` calls across pretraining, supervised fine-tuning, generation evaluation/PPO, pairwise RM/DPO, and KTO preprocessing.

Token columns use stable numeric types. Multimodal processors inherit the Arrow types of `images`, `videos`, and `audios` from the aligned input dataset, preserving supported media representations and missing values. The shared helper also validates the aligned-dataset media-column contract and raises a descriptive `ValueError` when required columns are missing.

Streaming preprocessing remains unchanged. Packed SFT intentionally keeps the inferred schema because it emits additional packing metadata such as `position_ids` and optional `packing_params`.

## Validation

- Added a regression test in which text-only samples are processed before image and video samples.
- Added a regression test for missing aligned media columns.
- Verified mixed-modality mapping and stable media feature types with `datasets==4.0.0`.
- Verified that supervised, unsupervised, pairwise, and feedback processor output keys match their declared schemas.
- Ran Ruff formatting and lint checks, Python syntax checks, and `git diff --check` on the modified files.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?