### PR TITLE
fix: pass batch index to multimodal slice

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -261,7 +261,7 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                     "attention_mask": features["attention_mask"][sample_idx : sample_idx + 1],
                 }
                 mm_inputs_for_sample = _slice_mm_inputs_for_sample(
-                    mm_inputs, batch_imglens, batch_vidlens, sample_idx=sample_idx
+                    mm_inputs, batch_imglens, batch_vidlens, batch_idx=sample_idx
                 )
                 self._compute_rope_position_ids(sample_features, mm_inputs_for_sample)
                 all_position_ids.append(sample_features["position_ids"])

--- a/tests/data/test_collator.py
+++ b/tests/data/test_collator.py
@@ -137,6 +137,45 @@ def test_multimodal_collator():
         assert batch_input[k].eq(torch.tensor(expected_input[k])).all()
 
 
+def test_mrope_non_packed_multimodal_slice_uses_batch_index():
+    data_collator = object.__new__(MultiModalDataCollatorForSeq2Seq)
+    captured_mm_inputs = []
+
+    def fake_compute_rope_position_ids(features, mm_inputs):
+        captured_mm_inputs.append(mm_inputs)
+        seq_len = features["attention_mask"].size(1)
+        features["position_ids"] = torch.arange(seq_len).unsqueeze(0)
+        features["rope_deltas"] = torch.zeros(1)
+
+    data_collator._compute_rope_position_ids = fake_compute_rope_position_ids
+    features = {
+        "input_ids": torch.tensor([[1, 2, 3], [4, 5, 6]]),
+        "attention_mask": torch.tensor([[1, 1, 1], [1, 1, 1]]),
+    }
+    mm_inputs = {
+        "image_grid_thw": torch.tensor([[1, 1, 1], [2, 2, 2], [3, 3, 3]]),
+        "video_grid_thw": torch.tensor([[4, 4, 4]]),
+        "second_per_grid_ts": torch.tensor([0.5]),
+    }
+
+    data_collator._compute_rope_position_ids_with_packing(
+        features,
+        mm_inputs,
+        packing_params_list=[None, None],
+        batch_imglens=[1, 2],
+        batch_vidlens=[0, 1],
+        batch_audlens=[0, 0],
+        has_dummy_image=False,
+    )
+
+    assert torch.equal(captured_mm_inputs[0]["image_grid_thw"], mm_inputs["image_grid_thw"][:1])
+    assert captured_mm_inputs[0]["video_grid_thw"] is None
+    assert torch.equal(captured_mm_inputs[1]["image_grid_thw"], mm_inputs["image_grid_thw"][1:])
+    assert torch.equal(captured_mm_inputs[1]["video_grid_thw"], mm_inputs["video_grid_thw"])
+    assert torch.equal(captured_mm_inputs[1]["second_per_grid_ts"], mm_inputs["second_per_grid_ts"])
+    assert features["position_ids"].shape == (2, 3)
+
+
 def _make_packed_feature(
     *,
     packing_params: dict,


### PR DESCRIPTION
## Summary

Fixes the non-packed multimodal MRoPE path in `MultiModalDataCollatorForSeq2Seq`.

`_slice_mm_inputs_for_sample()` takes `batch_idx`, but the `num_sub_seqs <= 1` branch called it with `sample_idx=sample_idx`. That raises:

```text
TypeError: _slice_mm_inputs_for_sample() got an unexpected keyword argument 'sample_idx'
```

The packed branch already passes the sample index positionally. This patch makes the non-packed branch pass the same value with the correct keyword and adds a focused regression test around the per-sample multimodal slicing.

Closes #10497.

## To verify

- `python -m py_compile src\llamafactory\data\collator.py tests\data\test_collator.py`
- `python -m ruff check src\llamafactory\data\collator.py tests\data\test_collator.py`
- `git diff --check`
- direct regression script for `_compute_rope_position_ids_with_packing()` with two non-packed multimodal samples: passed

I also tried the pytest target:

```text
PYTHONPATH=src python -m pytest tests\data\test_collator.py::test_mrope_non_packed_multimodal_slice_uses_batch_index -q
```

On my local Windows environment this does not reach the test yet because the repository-wide `tests/conftest.py` imports the full training stack and currently stops on a missing local `omegaconf` dependency. The direct regression script exercises the same branch without loading that conftest.
