### PR TITLE
fix: avoid mutable input kwargs defaults

### DIFF
--- a/src/llamafactory/chat/hf_engine.py
+++ b/src/llamafactory/chat/hf_engine.py
@@ -82,8 +82,9 @@ class HuggingfaceEngine(BaseEngine):
         images: Optional[list["ImageInput"]] = None,
         videos: Optional[list["VideoInput"]] = None,
         audios: Optional[list["AudioInput"]] = None,
-        input_kwargs: Optional[dict[str, Any]] = {},
+        input_kwargs: Optional[dict[str, Any]] = None,
     ) -> tuple[dict[str, Any], int]:
+        input_kwargs = input_kwargs or {}
         mm_input_dict = {"images": [], "videos": [], "audios": [], "imglens": [0], "vidlens": [0], "audlens": [0]}
         if images is not None:
             mm_input_dict.update({"images": images, "imglens": [len(images)]})
@@ -221,7 +222,7 @@ class HuggingfaceEngine(BaseEngine):
         images: Optional[list["ImageInput"]] = None,
         videos: Optional[list["VideoInput"]] = None,
         audios: Optional[list["AudioInput"]] = None,
-        input_kwargs: Optional[dict[str, Any]] = {},
+        input_kwargs: Optional[dict[str, Any]] = None,
     ) -> list["Response"]:
         gen_kwargs, prompt_length = HuggingfaceEngine._process_args(
             model,
@@ -276,7 +277,7 @@ class HuggingfaceEngine(BaseEngine):
         images: Optional[list["ImageInput"]] = None,
         videos: Optional[list["VideoInput"]] = None,
         audios: Optional[list["AudioInput"]] = None,
-        input_kwargs: Optional[dict[str, Any]] = {},
+        input_kwargs: Optional[dict[str, Any]] = None,
     ) -> Callable[[], str]:
         gen_kwargs, _ = HuggingfaceEngine._process_args(
             model,
@@ -315,8 +316,9 @@ class HuggingfaceEngine(BaseEngine):
         model: "PreTrainedModelWrapper",
         tokenizer: "PreTrainedTokenizer",
         batch_input: list[str],
-        input_kwargs: Optional[dict[str, Any]] = {},
+        input_kwargs: Optional[dict[str, Any]] = None,
     ) -> list[float]:
+        input_kwargs = input_kwargs or {}
         max_length: Optional[int] = input_kwargs.pop("max_length", None)
         device = getattr(model.pretrained_model, "device", "cuda")
         inputs: dict[str, torch.Tensor] = tokenizer(

--- a/tests/chat/test_hf_engine.py
+++ b/tests/chat/test_hf_engine.py
@@ -1,0 +1,29 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+
+from llamafactory.chat.hf_engine import HuggingfaceEngine
+
+
+def test_hf_engine_input_kwargs_default_is_not_mutable():
+    methods = [
+        HuggingfaceEngine._process_args,
+        HuggingfaceEngine._chat,
+        HuggingfaceEngine._stream_chat,
+        HuggingfaceEngine._get_scores,
+    ]
+
+    for method in methods:
+        assert inspect.signature(method).parameters["input_kwargs"].default is None


### PR DESCRIPTION
## Summary

Removes the shared mutable `{}` defaults from the HuggingFace chat engine helpers.

`_process_args()` and `_get_scores()` both consume `input_kwargs` with `.pop()`. With `{}` as the function default, calls that omitted `input_kwargs` shared the same dict object. This patch changes the four HuggingfaceEngine helper signatures to default to `None` and normalizes to a fresh dict in the two helpers that pop values.

Closes #10476.

## To verify

- `PYTHONPATH=src python -m pytest tests\chat\test_hf_engine.py -q`
- `python -m py_compile src\llamafactory\chat\hf_engine.py tests\chat\test_hf_engine.py`
- `python -m ruff check src\llamafactory\chat\hf_engine.py tests\chat\test_hf_engine.py`
- `git diff --check`
