### PR TITLE
Fix WebUI training hang from subprocess log pipe

### DIFF
--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -375,7 +375,16 @@ class Runner:
                 env["FORCE_TORCHRUN"] = "1"
 
             # NOTE: DO NOT USE shell=True to avoid security risk
-            self.trainer = Popen(["llamafactory-cli", "train", save_cmd(args)], env=env, stderr=PIPE, text=True)
+            webui_log_path = os.path.join(args["output_dir"], "webui_subprocess.log")
+            webui_log = open(webui_log_path, "a", encoding="utf-8")
+            self.trainer = Popen(
+                ["llamafactory-cli", "train", save_cmd(args)],
+                env=env,
+                stdout=webui_log,
+                stderr=webui_log,
+                text=True,
+            )
+            webui_log.close()
             yield from self.monitor()
 
     def _build_config_dict(self, data: dict["Component", Any]) -> dict[str, Any]:

--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -16,7 +16,7 @@ import json
 import os
 from collections.abc import Generator
 from copy import deepcopy
-from subprocess import PIPE, Popen, TimeoutExpired
+from subprocess import Popen, TimeoutExpired
 from typing import TYPE_CHECKING, Any
 
 from transformers.utils import is_torch_npu_available
@@ -460,6 +460,16 @@ class Runner:
             else:
                 finish_log = load_eval_results(os.path.join(output_path, "all_results.json")) + "\n\n" + running_log
         else:
+            if stderr is None:
+                webui_log_path = os.path.join(output_path, "webui_subprocess.log")
+                if os.path.exists(webui_log_path):
+                    with open(webui_log_path, "rb") as f:
+                        f.seek(0, os.SEEK_END)
+                        f.seek(max(f.tell() - 20000, 0))
+                        stderr = f.read().decode("utf-8", errors="replace")
+                else:
+                    stderr = "No subprocess log file found."
+
             print(stderr)
             finish_info = ALERTS["err_failed"][lang]
             finish_log = ALERTS["err_failed"][lang] + f" Exit code: {return_code}\n\n```\n{stderr}\n```\n"


### PR DESCRIPTION
# What does this PR do?

Fixes a WebUI training hang that can happen when launching multi-GPU training jobs.

Previously, the WebUI launched `llamafactory-cli train` with `stderr=PIPE`, but the pipe was only consumed after the process exited. When the child process or its torchrun workers produced enough stderr output, the pipe could become full and block the training process.

In practice this can leave all worker processes stuck in `pipe_write`, with GPU memory allocated but GPU utilization staying at 0%.

This PR redirects subprocess stdout/stderr to a log file under the output directory, so logs are still preserved while avoiding pipe backpressure during long-running training.

Fixes #

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
No new tests were added because this change affects subprocess log handling in the WebUI runner and was manually verified with an 8-GPU WebUI training launch.