### PR TITLE
fix(data): wrap MiniMax-M2 tool calls in <minimax:tool_call> tags

### DIFF
--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -521,7 +521,7 @@ class MiniMaxM2ToolUtils(ToolUtils):
             prompt += "\n</invoke>"
             function_texts.append(prompt)
 
-        return "\n".join(function_texts)
+        return "<minimax:tool_call>\n" + "\n".join(function_texts) + "\n</minimax:tool_call>"
 
     @override
     @staticmethod

--- a/tests/data/test_formatter.py
+++ b/tests/data/test_formatter.py
@@ -295,6 +295,54 @@ def test_qwen_multi_tool_extractor():
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_minimax2_function_formatter():
+    formatter = FunctionFormatter(slots=["{{content}}"], tool_format="minimax2")
+    tool_calls = json.dumps(FUNCTION)
+    assert formatter.apply(content=tool_calls) == [
+        "<minimax:tool_call>\n"
+        '<invoke name="tool_name">\n'
+        '<parameter name="foo">bar</parameter>\n'
+        '<parameter name="size">10</parameter>\n'
+        "</invoke>\n"
+        "</minimax:tool_call>"
+    ]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_minimax2_multi_function_formatter():
+    formatter = FunctionFormatter(slots=["{{content}}"], tool_format="minimax2")
+    tool_calls = json.dumps([FUNCTION] * 2)
+    invoke = '<invoke name="tool_name">\n<parameter name="foo">bar</parameter>\n<parameter name="size">10</parameter>\n</invoke>'
+    assert formatter.apply(content=tool_calls) == [f"<minimax:tool_call>\n{invoke}\n{invoke}\n</minimax:tool_call>"]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_minimax2_tool_extractor():
+    formatter = ToolFormatter(tool_format="minimax2")
+    result = (
+        "<minimax:tool_call>\n"
+        '<invoke name="test_tool">\n'
+        '<parameter name="foo">bar</parameter>\n'
+        '<parameter name="size">10</parameter>\n'
+        "</invoke>\n"
+        "</minimax:tool_call>"
+    )
+    assert formatter.extract(result) == [("test_tool", """{"foo": "bar", "size": 10}""")]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_minimax2_tool_round_trip():
+    formatter = FunctionFormatter(slots=["{{content}}"], tool_format="minimax2")
+    tool_formatter = ToolFormatter(tool_format="minimax2")
+    original = {"name": "my_func", "arguments": {"arg1": "hello", "arg2": 42, "arg3": True}}
+    formatted = formatter.apply(content=json.dumps(original))
+    extracted = tool_formatter.extract(formatted[0])
+    assert len(extracted) == 1
+    assert extracted[0][0] == original["name"]
+    assert json.loads(extracted[0][1]) == original["arguments"]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 def test_lfm2_function_formatter():
     formatter = FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="lfm2")
     tool_calls = json.dumps(FUNCTION)


### PR DESCRIPTION
# What does this PR do?

`MiniMaxM2ToolUtils.function_formatter` emits the `<invoke>...</invoke>` blocks but never wraps them in the `<minimax:tool_call>...</minimax:tool_call>` tags. That is the wrapper the tool prompt (`MINIMAX_M2_TOOL_PROMPT`) tells the model to produce, and the same wrapper `tool_extractor` requires:

```python
regex = re.compile(r"<minimax:tool_call>\s*(.+?)\s*</minimax:tool_call>", re.DOTALL)
```

So the assistant tool-call targets built during training don't match the format the model is taught to emit, and a round trip through `function_formatter` -> `tool_extractor` returns the raw string instead of the parsed calls.

Repro on current main:

```python
tu = get_tool_utils("minimax2")
f = tu.function_formatter([FunctionCall("get_weather", json.dumps({"city": "NYC"}))])
# f has no <minimax:tool_call> wrapper
tu.tool_extractor(f)  # returns the raw string, extraction fails
```

The fix wraps the joined invoke blocks in the tags, matching both the prompt spec and the extractor:

```python
return "<minimax:tool_call>\n" + "\n".join(function_texts) + "\n</minimax:tool_call>"
```

After the fix the round trip returns `[FunctionCall(name='get_weather', arguments='{"city": "NYC"}')]` for both single and parallel calls.

## How I tested

Added regression tests in `tests/data/test_formatter.py` (single, parallel, extractor, round trip), mirroring the existing qwen/lfm2 cases.

```
python -m pytest tests/data/test_formatter.py -q   # 38 passed
ruff check                                          # clean
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
