### PR TITLE
[data] fix MiniMax tool_extractor to return content when no tool call parses

### DIFF
--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -490,7 +490,7 @@ class MiniMaxM1ToolUtils(ToolUtils):
             except json.JSONDecodeError:
                 continue
 
-        return results
+        return results if results else content
 
 
 class MiniMaxM2ToolUtils(ToolUtils):
@@ -548,7 +548,7 @@ class MiniMaxM2ToolUtils(ToolUtils):
 
             results.append(FunctionCall(func_name.strip(), json.dumps(args_dict, ensure_ascii=False)))
 
-        return results
+        return results if results else content
 
 
 class MistralToolUtils(ToolUtils):

--- a/tests/data/test_tool_utils.py
+++ b/tests/data/test_tool_utils.py
@@ -1,0 +1,44 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from llamafactory.data.tool_utils import FunctionCall, MiniMaxM1ToolUtils, MiniMaxM2ToolUtils
+
+
+def test_minimax_m1_returns_content_when_no_valid_tool_call():
+    # The wrapper tag is present but its body is not valid JSON, so no call is
+    # parsed. The extractor should return the original content, not an empty list.
+    content = "<tool_calls>\nthis is not json\n</tool_calls>"
+    assert MiniMaxM1ToolUtils.tool_extractor(content) == content
+
+
+def test_minimax_m1_parses_valid_tool_call():
+    content = '<tool_calls>\n{"name": "get_weather", "arguments": {"city": "NYC"}}\n</tool_calls>'
+    result = MiniMaxM1ToolUtils.tool_extractor(content)
+    assert result == [FunctionCall("get_weather", '{"city": "NYC"}')]
+
+
+def test_minimax_m2_returns_content_when_no_valid_tool_call():
+    # The wrapper tag is present but there is no well-formed <invoke> block, so
+    # no call is parsed. The extractor should return the original content.
+    content = "<minimax:tool_call>\nno invoke block here\n</minimax:tool_call>"
+    assert MiniMaxM2ToolUtils.tool_extractor(content) == content
+
+
+def test_minimax_m2_parses_valid_tool_call():
+    content = (
+        '<minimax:tool_call>\n<invoke name="get_weather">'
+        '<parameter name="city">NYC</parameter></invoke>\n</minimax:tool_call>'
+    )
+    result = MiniMaxM2ToolUtils.tool_extractor(content)
+    assert result == [FunctionCall("get_weather", '{"city": "NYC"}')]


### PR DESCRIPTION
## What does this PR do?

`MiniMaxM1ToolUtils.tool_extractor` and `MiniMaxM2ToolUtils.tool_extractor` return an empty list when the tool-call wrapper tag is present but no valid call parses out of it. M1 skips lines that fail `json.loads` (via `continue`), and M2 finds no `<invoke>` block, so `results` ends up empty. An empty list reads downstream as "a tool call with zero functions" rather than "plain content", so the original assistant text is dropped.

This returns the original `content` in that case, matching `SeedToolUtils` (fixed in #10408), `Qwen35ToolUtils` and `LFM2ToolUtils`, which already use `return results if results else content`. `DefaultToolUtils`, `QwenToolUtils` and `Gemma4ToolUtils` already handle it (they return content on a parse failure, or append one call per regex match), so only the two MiniMax extractors needed the change.

Added `tests/data/test_tool_utils.py` covering both the empty case (tag present, nothing parses, returns content) and the valid case (a real call still returns the `FunctionCall` list).

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
