### PR TITLE
fix(collator): pass batch index positionally in single-subseq mrope path

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -260,9 +260,7 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                     "input_ids": features["input_ids"],
                     "attention_mask": features["attention_mask"][sample_idx : sample_idx + 1],
                 }
-                mm_inputs_for_sample = _slice_mm_inputs_for_sample(
-                    mm_inputs, batch_imglens, batch_vidlens, sample_idx=sample_idx
-                )
+                mm_inputs_for_sample = _slice_mm_inputs_for_sample(mm_inputs, batch_imglens, batch_vidlens, sample_idx)
                 self._compute_rope_position_ids(sample_features, mm_inputs_for_sample)
                 all_position_ids.append(sample_features["position_ids"])
                 all_rope_deltas.append(sample_features["rope_deltas"])

--- a/tests/data/test_collator.py
+++ b/tests/data/test_collator.py
@@ -364,3 +364,44 @@ def test_4d_attention_mask():
 
 if __name__ == "__main__":
     test_multimodal_collator()
+
+
+def test_packing_rope_single_subseq_slices_without_crashing(monkeypatch):
+    """Regression test for the ``sample_idx=`` keyword crash (#10497).
+
+    The ``num_sub_seqs <= 1`` branch of the packed mrope path must pass the batch
+    index positionally to ``_slice_mm_inputs_for_sample``, like the packed ``> 1``
+    branch does.
+    """
+    model_args, data_args, *_ = get_infer_args(
+        {"model_name_or_path": "Qwen/Qwen2-VL-2B-Instruct", "template": "qwen2_vl"}
+    )
+    tokenizer_module = load_tokenizer(model_args)
+    template = get_template_and_fix_tokenizer(tokenizer_module["tokenizer"], data_args)
+    config = AutoConfig.from_pretrained(model_args.model_name_or_path)
+    with torch.device("meta"):
+        model = AutoModelForImageTextToText.from_config(config)
+
+    collator = MultiModalDataCollatorForSeq2Seq(
+        template=template,
+        model=model,
+        label_pad_token_id=IGNORE_INDEX,
+        **tokenizer_module,
+    )
+
+    def fake_rope(features, mm_inputs):
+        seq_len = features["input_ids"].shape[1]
+        features["position_ids"] = torch.zeros(3, 1, seq_len, dtype=torch.long)
+        features["rope_deltas"] = torch.zeros(1, 1, dtype=torch.long)
+
+    monkeypatch.setattr(collator, "_compute_rope_position_ids", fake_rope)
+
+    features = {
+        "input_ids": torch.tensor([[0, 1, 2, 3]]),
+        "attention_mask": torch.tensor([[1, 1, 1, 1]]),
+    }
+    # packing_params_list=[{}] has no sequence_boundaries, so num_sub_seqs == 1
+    # and the single-subsequence branch (which held the bug) is exercised.
+    collator._compute_rope_position_ids_with_packing(features, {}, [{}], [0], [0], [0], False)
+
+    assert features["position_ids"].shape == (3, 1, 4)


### PR DESCRIPTION
## What

`MultiModalDataCollatorForSeq2Seq._compute_rope_position_ids_with_packing` crashes on the single-subsequence branch:

```python
mm_inputs_for_sample = _slice_mm_inputs_for_sample(
    mm_inputs, batch_imglens, batch_vidlens, sample_idx=sample_idx
)
```

`_slice_mm_inputs_for_sample` has no `sample_idx` parameter — its fourth parameter is `batch_idx` — so any packed multimodal mrope batch that reaches the `num_sub_seqs <= 1` path raises:

```
TypeError: _slice_mm_inputs_for_sample() got an unexpected keyword argument 'sample_idx'
```

The parallel `num_sub_seqs > 1` branch a few lines below already passes the index positionally (`_slice_mm_inputs_for_sample(mm_inputs, batch_imglens, batch_vidlens, sample_idx, ...)`), so only the single-subsequence branch is affected. Fixes #10497.

## Fix

Pass the batch index positionally, matching the packed branch.

## Test

Added `test_packing_rope_single_subseq_slices_without_crashing` to `tests/data/test_collator.py`. It drives `_compute_rope_position_ids_with_packing` through the `num_sub_seqs <= 1` branch (mocking the per-sample rope call to isolate the slicing). The test raises the `TypeError` on `main` and passes with the fix; the existing `test_collator.py` suite stays green (5 passed).

```
PYTHONPATH=src python -m pytest tests/data/test_collator.py -q   # 5 passed
```
