### PR TITLE
fix: add defensive fallback for Qwen VL mrope get_rope_index shape mismatch

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -221,14 +221,11 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
     def _fallback_rope_position_ids(input_ids: "torch.Tensor", attention_mask: "torch.Tensor"):
         r"""Flat positional fallback: every non-pad token gets a monotonic position; all 3 mrope axes identical."""
         bsz, seq_len = input_ids.shape
-        position_ids = torch.zeros(3, bsz, seq_len, dtype=input_ids.dtype, device=input_ids.device)
-        rope_deltas = torch.zeros(bsz, dtype=input_ids.dtype, device=input_ids.device)
-        for batch_idx in range(bsz):
-            valid_len = int(attention_mask[batch_idx].bool().sum().item())
-            positions = torch.arange(seq_len, device=input_ids.device)
-            position_ids[:, batch_idx] = positions.view(1, -1).expand(3, -1)
-            rope_deltas[batch_idx] = positions.max() + 1 - valid_len if valid_len > 0 else 0
-        return position_ids, rope_deltas
+        positions = torch.arange(seq_len, device=input_ids.device, dtype=input_ids.dtype)
+        position_ids = positions.view(1, 1, seq_len).expand(3, bsz, seq_len).contiguous()
+        valid_len = attention_mask.bool().sum(dim=-1)
+        rope_deltas = torch.where(valid_len > 0, seq_len - valid_len, torch.zeros_like(valid_len))
+        return position_ids, rope_deltas.to(dtype=input_ids.dtype)
 
     def _log_rope_mismatch(self, err: Exception, features: dict[str, "torch.Tensor"], mm_inputs: dict[str, Any]) -> None:
         r"""Print a one-line diagnostic when the mrope fallback path is taken."""

--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -199,7 +199,55 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
             features["position_ids"], rope_deltas = self.get_rope_func(**rope_index_kwargs)
             features["rope_deltas"] = rope_deltas - (1 - rope_index_kwargs["attention_mask"]).sum(dim=-1).unsqueeze(-1)
         else:  # for qwen vl
-            features["position_ids"], features["rope_deltas"] = self.get_rope_func(**rope_index_kwargs)
+            try:
+                features["position_ids"], features["rope_deltas"] = self.get_rope_func(**rope_index_kwargs)
+            except RuntimeError as err:
+                # Defensive fallback for the mrope get_rope_index shape mismatch
+                # ("value tensor of shape [3, A] cannot be broadcast to indexing result of shape [3, B]")
+                # which fires when the vision placeholder token count in input_ids disagrees with the
+                # image_grid_thw / video_grid_thw declared by the processor. This happens on a tiny
+                # fraction of samples (e.g. a truncated or irregular-grid video) and would otherwise
+                # kill the whole run. Degrade to a flat positional encoding (3 identical axes) for the
+                # offending batch so training continues, and log it for later data-level cleanup.
+                if "shape mismatch" not in str(err) and "cannot be broadcast" not in str(err):
+                    raise
+                self._log_rope_mismatch(err, features, mm_inputs)
+                features["position_ids"], features["rope_deltas"] = self._fallback_rope_position_ids(
+                    features["input_ids"], rope_index_kwargs["attention_mask"]
+                )
+
+
+    @staticmethod
+    def _fallback_rope_position_ids(input_ids: "torch.Tensor", attention_mask: "torch.Tensor"):
+        r"""Flat positional fallback: every non-pad token gets a monotonic position; all 3 mrope axes identical."""
+        bsz, seq_len = input_ids.shape
+        position_ids = torch.zeros(3, bsz, seq_len, dtype=input_ids.dtype, device=input_ids.device)
+        rope_deltas = torch.zeros(bsz, dtype=input_ids.dtype, device=input_ids.device)
+        for batch_idx in range(bsz):
+            valid_len = int(attention_mask[batch_idx].bool().sum().item())
+            positions = torch.arange(seq_len, device=input_ids.device)
+            position_ids[:, batch_idx] = positions.view(1, -1).expand(3, -1)
+            rope_deltas[batch_idx] = positions.max() + 1 - valid_len if valid_len > 0 else 0
+        return position_ids, rope_deltas
+
+    def _log_rope_mismatch(self, err: Exception, features: dict[str, "torch.Tensor"], mm_inputs: dict[str, Any]) -> None:
+        r"""Print a one-line diagnostic when the mrope fallback path is taken."""
+        input_ids = features.get("input_ids")
+        image_grid = mm_inputs.get("image_grid_thw")
+        video_grid = mm_inputs.get("video_grid_thw")
+        image_token_id = getattr(self.model.config, "image_token_id", None) if self.model is not None else None
+        video_token_id = getattr(self.model.config, "video_token_id", None) if self.model is not None else None
+        n_img = int((input_ids == image_token_id).sum().item()) if image_token_id is not None and input_ids is not None else -1
+        n_vid = int((input_ids == video_token_id).sum().item()) if video_token_id is not None and input_ids is not None else -1
+        print(
+            "rope_fallback: get_rope_index shape mismatch caught -> "
+            f"input_ids={tuple(input_ids.shape) if input_ids is not None else None} "
+            f"image_tokens={n_img} video_tokens={n_vid} "
+            f"image_grid_thw={image_grid.tolist() if image_grid is not None else None} "
+            f"video_grid_thw={video_grid.tolist() if video_grid is not None else None} "
+            f"err={err}",
+            flush=True,
+        )
 
     def _compute_rope_position_ids_with_packing(
         self,


### PR DESCRIPTION
## Description

When training Qwen VL models with mixed multimodal data, `get_rope_index` can raise:

```
RuntimeError: "value tensor of shape [3, A] cannot be broadcast to indexing result of shape [3, B]"
```

This is not a frame-count issue — it is caused by **missing media files triggering inconsistent fallback paths**.

### Root cause chain

1. Some samples reference npy/video files that are missing from the dataset directory
2. The custom video loader catches the load error and produces a fallback volume (e.g. a fixed-shape all-black array)
3. **Tokenize stage** processes this fallback through custom grid metadata logic, producing a `video_grid_thw` with specific placeholder token count (e.g. 462 or 504)
4. **Forward stage** re-loads the same missing file, also fallback, but computes `video_grid_thw` via transformers' native `video_processor` — a different code path → token count diverges
5. Placeholder count in `input_ids` ≠ actual visual feature count → shape mismatch in `get_rope_index`

In a 9.16M-sample run, only 19 unique IDs triggered this (105 rows, 0.0011%), all referencing missing files in M3D_CT/MedMNIST.

### Fix

1. **try/except** around `get_rope_func` (qwen vl branch), catching only the known shape mismatch
2. **_fallback_rope_position_ids**: flat 3-axis positional encoding, fully vectorized
3. **_log_rope_mismatch**: one-line diagnostic for downstream data cleaning

### Validation

- 9.16M-sample Qwen3.5-27B run: 0 false positives, step 279+ stable
- 105 affected samples identified via diagnostic log and cleaned at data level