### PR TITLE
fix(data): return content when llama3/mistral tool extractors find no calls

### DIFF
--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -441,9 +441,13 @@ class Llama3ToolUtils(ToolUtils):
 
         tools = [tools] if not isinstance(tools, list) else tools
         try:
-            return [FunctionCall(tool["name"], json.dumps(tool["parameters"], ensure_ascii=False)) for tool in tools]
+            results = [
+                FunctionCall(tool["name"], json.dumps(tool["parameters"], ensure_ascii=False)) for tool in tools
+            ]
         except KeyError:
             return content
+
+        return results if results else content
 
 
 class MiniMaxM1ToolUtils(ToolUtils):
@@ -580,9 +584,11 @@ class MistralToolUtils(ToolUtils):
 
         tools = [tools] if not isinstance(tools, list) else tools
         try:
-            return [FunctionCall(tool["name"], json.dumps(tool["arguments"], ensure_ascii=False)) for tool in tools]
+            results = [FunctionCall(tool["name"], json.dumps(tool["arguments"], ensure_ascii=False)) for tool in tools]
         except KeyError:
             return content
+
+        return results if results else content
 
 
 class QwenToolUtils(ToolUtils):

--- a/tests/data/test_formatter.py
+++ b/tests/data/test_formatter.py
@@ -190,6 +190,20 @@ def test_llama3_multi_tool_extractor():
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_llama3_tool_extractor_empty_returns_content():
+    # An empty tool array means no function calls; return the content string,
+    # matching the Qwen3.5/Seed/LFM2 extractors, not an empty list.
+    formatter = ToolFormatter(tool_format="llama3")
+    assert formatter.extract("[]") == "[]"
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_mistral_tool_extractor_empty_returns_content():
+    formatter = ToolFormatter(tool_format="mistral")
+    assert formatter.extract("[]") == "[]"
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 def test_mistral_function_formatter():
     formatter = FunctionFormatter(slots=["[TOOL_CALLS] {{content}}", "</s>"], tool_format="mistral")
     tool_calls = json.dumps(FUNCTION)


### PR DESCRIPTION
### What does this PR do?

`tool_extractor` returns a `str` (the original content) when the assistant message contains no function calls, and a `list[FunctionCall]` otherwise. `Llama3ToolUtils.tool_extractor` and `MistralToolUtils.tool_extractor` returned the list comprehension directly, so a payload that parses to an empty list (e.g. `"[]"`) produced `[]` instead of the content string:

```python
Llama3ToolUtils.tool_extractor("[]")   # -> []   (should be "[]")
MistralToolUtils.tool_extractor("[]")  # -> []   (should be "[]")
```

The Qwen3.5, Seed, and LFM2 extractors already guard this with `return results if results else content` (Seed via #10408). This PR applies the same guard to the llama3 and mistral extractors so they stay consistent with the documented `str | list[FunctionCall]` contract.

### Tests

Added `test_llama3_tool_extractor_empty_returns_content` and `test_mistral_tool_extractor_empty_returns_content` in `tests/data/test_formatter.py`, asserting `ToolFormatter(tool_format=...).extract("[]") == "[]"`. Both fail before the change (they return `[]`) and pass after.

```
PYTHONPATH=src python -m pytest tests/data/test_formatter.py   # 36 passed
ruff check . && ruff format --check .                          # clean on the changed files
```
