### PR TITLE
[data] fix LFM2 tool extractor dropping positional arguments

### DIFF
--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -866,6 +866,13 @@ class LFM2ToolUtils(ToolUtils):
             else:
                 return content
 
+            # LFM2 tool calls only carry keyword arguments. Positional ones
+            # can't be mapped to the tool's named parameters here, so bail to
+            # the raw content rather than silently dropping them and emitting a
+            # call with missing arguments.
+            if node.args:
+                return content
+
             # Extract keyword arguments
             args_dict = {}
             for keyword in node.keywords:

--- a/tests/data/test_formatter.py
+++ b/tests/data/test_formatter.py
@@ -363,6 +363,18 @@ def test_lfm2_tool_extractor_with_list_arg():
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_lfm2_tool_extractor_positional_args():
+    # Positional arguments can't be mapped to the tool's named parameters, so a
+    # call that uses them is left as raw content instead of silently emitting a
+    # call with the positional values dropped.
+    formatter = ToolFormatter(tool_format="lfm2")
+    only_positional = """<|tool_call_start|>[test_tool(1, 2, 3)]<|tool_call_end|>"""
+    assert formatter.extract(only_positional) == only_positional
+    mixed = """<|tool_call_start|>[test_tool(1, size=10)]<|tool_call_end|>"""
+    assert formatter.extract(mixed) == mixed
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 def test_lfm2_tool_extractor_no_match():
     formatter = ToolFormatter(tool_format="lfm2")
     result = "This is a regular response without tool calls."


### PR DESCRIPTION
# What does this PR do?

`LFM2ToolUtils.tool_extractor` parses a generated Pythonic tool call and only reads `node.keywords`, so any positional argument is silently dropped:

```python
from llamafactory.data.tool_utils import LFM2ToolUtils

LFM2ToolUtils.tool_extractor("<|tool_call_start|>[process(1, 2, 3)]<|tool_call_end|>")
# [FunctionCall(name='process', arguments='{}')]      <- all three args gone

LFM2ToolUtils.tool_extractor("<|tool_call_start|>[process(1, size=10)]<|tool_call_end|>")
# [FunctionCall(name='process', arguments='{"size": 10}')]   <- positional 1 gone
```

That turns a malformed call into a clean-looking one with missing arguments, which then gets executed with the wrong inputs. Positional values can't be mapped to the tool's named parameters at this point (there's no schema here), so this PR bails to the raw content instead — the same fallback the method already uses for an unparseable call or a bad argument value. This matches the recent SeedToolUtils fix (#10408) where the extractor returns content rather than emitting a broken call.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests? (`test_lfm2_tool_extractor_positional_args` in `tests/data/test_formatter.py`, covering positional-only and mixed positional/keyword calls)
