### PR TITLE
[data] fix MiniMax tool_extractor to return content when no tool call parses

### DIFF
--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -490,7 +490,7 @@ class MiniMaxM1ToolUtils(ToolUtils):
             except json.JSONDecodeError:
                 continue
 
-        return results
+        return results if results else content
 
 
 class MiniMaxM2ToolUtils(ToolUtils):
@@ -548,7 +548,7 @@ class MiniMaxM2ToolUtils(ToolUtils):
 
             results.append(FunctionCall(func_name.strip(), json.dumps(args_dict, ensure_ascii=False)))
 
-        return results
+        return results if results else content
 
 
 class MistralToolUtils(ToolUtils):

--- a/tests/data/test_tool_utils.py
+++ b/tests/data/test_tool_utils.py
@@ -1,0 +1,45 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from llamafactory.data.tool_utils import MiniMaxM1ToolUtils, MiniMaxM2ToolUtils
+
+
+def test_minimax_m1_parses_valid_tool_call():
+    content = '<tool_calls>\n{"name": "get_weather", "arguments": {"city": "NYC"}}\n</tool_calls>'
+    result = MiniMaxM1ToolUtils.tool_extractor(content)
+    assert isinstance(result, list) and len(result) == 1
+    assert result[0].name == "get_weather"
+
+
+def test_minimax_m1_returns_content_when_no_valid_tool_call():
+    # Wrapper tag is present but its body is not valid JSON, so nothing parses.
+    # The extractor should return the original content, not an empty list.
+    content = "<tool_calls>\nthis is not json\n</tool_calls>"
+    assert MiniMaxM1ToolUtils.tool_extractor(content) == content
+
+
+def test_minimax_m1_empty_wrapper_returns_content():
+    content = "<tool_calls>\n\n</tool_calls>"
+    assert MiniMaxM1ToolUtils.tool_extractor(content) == content
+
+
+def test_minimax_m2_returns_content_when_no_valid_tool_call():
+    # Wrapper tag is present but there is no well-formed <invoke> block.
+    content = "<minimax:tool_call>\nno invoke block here\n</minimax:tool_call>"
+    assert MiniMaxM2ToolUtils.tool_extractor(content) == content
+
+
+def test_minimax_m2_empty_wrapper_returns_content():
+    content = "<minimax:tool_call>\n\n</minimax:tool_call>"
+    assert MiniMaxM2ToolUtils.tool_extractor(content) == content


### PR DESCRIPTION
### What does this PR do?

`MiniMaxM1ToolUtils.tool_extractor` and `MiniMaxM2ToolUtils.tool_extractor` returned an empty list when the wrapper tag (`<tool_calls>` / `<minimax:tool_call>`) was present but nothing parsed inside it — M1 skips bad-JSON lines, M2 finds no `<invoke>` block. An empty list silently drops the original assistant content downstream.

The sibling extractors `SeedToolUtils`, `Qwen35ToolUtils` and `LFM2ToolUtils` already guard this with `return results if results else content`. This applies the same guard to MiniMax M1/M2 so a wrapped-but-unparseable response keeps its content instead of vanishing.

Added `tests/data/test_tool_utils.py` covering the no-valid-call and empty-wrapper paths for both extractors, plus a valid-call case to confirm normal parsing is unchanged.

### Verification

`PYTHONPATH=src pytest tests/data/test_tool_utils.py` — 5 passed (the four no-call assertions fail before this change, pass after). `ruff check` and `ruff format --check` clean.
