### PR TITLE
[fix] redundant `transformers` check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "torch>=2.4.0",
     "torchvision>=0.19.0",
     "torchaudio>=2.4.0",
-    "transformers>=4.55.0,<=5.6.0,!=4.52.0,!=4.57.0",
+    "transformers>=4.55.0,<=5.6.0,!=4.57.0",
     "datasets>=2.16.0,<=4.0.0",
     "accelerate>=1.3.0,<=1.11.0",
     "peft>=0.18.0,<=0.18.1",


### PR DESCRIPTION
since `transformers` should be `>=4.55` there is not need for `!=4.52.0`

# What does this PR do?

Fixes redundant check in pyproject.toml

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
