### PR TITLE
[model] add Hy-MT2-1.8B/7B support

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1279,7 +1279,7 @@ register_template(
 register_template(
     name="hy_dense_1_8b",
     format_user=StringFormatter(slots=["<｜hy_User｜>{{content}}"]),
-    format_assistant=StringFormatter(slots=["<｜hy_Assistant｜>{{content}}", {"eos_token"}]),
+    format_assistant=StringFormatter(slots=["<｜hy_Assistant｜>{{content}}"]),
     format_system=StringFormatter(slots=["{{content}}<｜hy_place▁holder▁no▁3｜>"]),
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
     stop_words=["<｜hy_place▁holder▁no▁2｜>"],
@@ -1290,7 +1290,7 @@ register_template(
 register_template(
     name="hy_dense_7b",
     format_user=StringFormatter(slots=["{{content}}<|extra_0|>"]),
-    format_assistant=StringFormatter(slots=["{{content}}", {"eos_token"}]),
+    format_assistant=StringFormatter(slots=["{{content}}"]),
     format_system=StringFormatter(slots=["{{content}}<|extra_4|>"]),
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
     stop_words=["<|eos|>"],

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1274,6 +1274,30 @@ register_template(
 )
 
 
+# The following two templates are copied from the official Hy-MT2 chat templates:
+# https://github.com/Tencent-Hunyuan/Hy-MT2/blob/main/train/llama_factory_support/hy_dense_template.py
+register_template(
+    name="hy_dense_1_8b",
+    format_user=StringFormatter(slots=["<｜hy_User｜>{{content}}"]),
+    format_assistant=StringFormatter(slots=["<｜hy_Assistant｜>{{content}}", {"eos_token"}]),
+    format_system=StringFormatter(slots=["{{content}}<｜hy_place▁holder▁no▁3｜>"]),
+    format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
+    stop_words=["<｜hy_place▁holder▁no▁2｜>"],
+    efficient_eos=True,
+)
+
+
+register_template(
+    name="hy_dense_7b",
+    format_user=StringFormatter(slots=["{{content}}<|extra_0|>"]),
+    format_assistant=StringFormatter(slots=["{{content}}", {"eos_token"}]),
+    format_system=StringFormatter(slots=["{{content}}<|extra_4|>"]),
+    format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
+    stop_words=["<|eos|>"],
+    efficient_eos=True,
+)
+
+
 register_template(
     name="intern2",
     format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -1250,6 +1250,28 @@ register_model_group(
 
 register_model_group(
     models={
+        "Hy-MT2-1.8B-Instruct": {
+            DownloadSource.DEFAULT: "tencent/Hy-MT2-1.8B",
+            DownloadSource.MODELSCOPE: "Tencent-Hunyuan/Hy-MT2-1.8B",
+        },
+    },
+    template="hy_dense_1_8b",
+)
+
+
+register_model_group(
+    models={
+        "Hy-MT2-7B-Instruct": {
+            DownloadSource.DEFAULT: "tencent/Hy-MT2-7B",
+            DownloadSource.MODELSCOPE: "Tencent-Hunyuan/Hy-MT2-7B",
+        },
+    },
+    template="hy_dense_7b",
+)
+
+
+register_model_group(
+    models={
         "HY-MT1.5-1.8B-Instruct": {
             DownloadSource.DEFAULT: "tencent/HY-MT1.5-1.8B",
             DownloadSource.MODELSCOPE: "Tencent-Hunyuan/HY-MT1.5-1.8B",


### PR DESCRIPTION
# What does this PR do?

Add support for fine-tuning **Tencent Hunyuan Hy-MT2** dense models (1.8B and 7B) with LLaMA-Factory.

- Register `Hy-MT2-1.8B-Instruct` and `Hy-MT2-7B-Instruct` in `src/llamafactory/extras/constants.py`, with both Hugging Face (`tencent/Hy-MT2-1.8B`, `tencent/Hy-MT2-7B`) and ModelScope (`Tencent-Hunyuan/Hy-MT2-1.8B`, `Tencent-Hunyuan/Hy-MT2-7B`) download sources.
- Add two new chat templates `hy_dense_1_8b` and `hy_dense_7b` to `src/llamafactory/data/template.py`, ported from the official Hy-MT2 LLaMA-Factory support files to match the tokenizer's `chat_template.jinja` exactly.
- Bind the 1.8B model to `hy_dense_1_8b` and the 7B model to `hy_dense_7b`.

These templates are designed to be used with the official YAML configs in the Hy-MT2 repository (`hy_dense_1_8b_lora_sft.yaml`, `hy_dense_1_8b_full_sft.yaml`, `hy_dense_7b_lora_sft.yaml`, `hy_dense_7b_full_sft.yaml`).

Fixes #10604

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?  *(No new tests added: the new templates are covered by existing template infrastructure; verified with `pytest tests/data/test_template.py` and a runtime registry smoke check.)*