### PR TITLE
[data] fix KeyError on unmapped role tag in openai converter main loop

### DIFF
--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -275,6 +275,11 @@ class OpenAIDatasetConverter(DatasetConverter):
                 )
                 tool_responses = []
 
+            if role not in tag_mapping:
+                logger.warning_rank0(f"Invalid role tag in {messages}.")
+                broken_data = True
+                break
+
             aligned_messages.append(
                 {
                     "role": tag_mapping[role],

--- a/tests/data/test_converter.py
+++ b/tests/data/test_converter.py
@@ -62,3 +62,23 @@ def test_sharegpt_converter():
         "_videos": None,
         "_audios": None,
     }
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_openai_converter_skips_invalid_role():
+    # A message that carries a role tag not present in tag_mapping must be
+    # treated as an abnormal example and skipped, not crash with a KeyError when
+    # the converter builds aligned_messages. The sharegpt converter already
+    # guards its build loop; the openai converter only validated afterwards.
+    dataset_attr = DatasetAttr("hf_hub", "llamafactory/tiny-supervised-dataset")
+    data_args = DataArguments()
+    example = {
+        "conversations": [
+            {"from": "human", "value": "Solve the math problem.\n3 + 4"},
+            {"from": "not_a_role", "value": "The answer is 7."},
+        ]
+    }
+    dataset_converter = get_dataset_converter("openai", dataset_attr, data_args)
+    result = dataset_converter(example)
+    assert result["_prompt"] == []
+    assert result["_response"] == []


### PR DESCRIPTION
# What does this PR do?

`OpenAIDatasetConverter.__call__` builds `aligned_messages` like this:

```python
aligned_messages.append(
    {
        "role": tag_mapping[role],
        "content": content,
    }
)
```

`role` is never checked against `tag_mapping` before this lookup, so a single
message whose role tag isn't one of the configured tags (`user_tag`,
`assistant_tag`, `observation_tag`, `function_tag`, `system_tag`) raises a
`KeyError` and takes down the whole `datasets.map` conversion. The validity
loop right below only runs on `aligned_messages` after they're built, so it
never gets the chance to flag the row.

The `SharegptDatasetConverter` main loop already guards this exact case and
just skips the malformed example with a warning:

```python
if message[self.dataset_attr.role_tag] not in accept_tags[turn_idx % 2]:
    logger.warning_rank0(f"Invalid role tag in {messages}.")
    broken_data = True
    break
```

This adds the matching guard to the openai converter so one bad row gets
skipped with a warning instead of aborting the run.

Repro on `main` (the new test fails with `KeyError: 'not_a_role'` before the
fix, passes after):

```python
example = {
    "conversations": [
        {"from": "human", "value": "Solve the math problem.\n3 + 4"},
        {"from": "not_a_role", "value": "The answer is 7."},
    ]
}
get_dataset_converter("openai", dataset_attr, data_args)(example)
```

This is a sibling of #10601, which fixes the same `tag_mapping` `KeyError`
class on the ranking/pairwise `chosen`/`rejected` path. This one is the
regular (non-ranking) main message loop, a different code path; the diffs
don't overlap.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests? (`tests/data/test_converter.py::test_openai_converter_skips_invalid_role`)
