### PR TITLE
[data] wrap MiniMax-M2 tool calls in <minimax:tool_call>

### DIFF
--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -521,7 +521,7 @@ class MiniMaxM2ToolUtils(ToolUtils):
             prompt += "\n</invoke>"
             function_texts.append(prompt)
 
-        return "\n".join(function_texts)
+        return "<minimax:tool_call>\n" + "\n".join(function_texts) + "\n</minimax:tool_call>"
 
     @override
     @staticmethod

--- a/tests/data/test_formatter.py
+++ b/tests/data/test_formatter.py
@@ -380,3 +380,26 @@ def test_lfm2_tool_round_trip():
     assert len(extracted) == 1
     assert extracted[0][0] == original["name"]
     assert json.loads(extracted[0][1]) == original["arguments"]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_minimax2_function_formatter():
+    formatter = FunctionFormatter(slots=["{{content}}"], tool_format="minimax2")
+    result = formatter.apply(content=json.dumps(FUNCTION))[0]
+    # the assistant tool call must be wrapped in <minimax:tool_call>, matching the
+    # format the model is instructed to use in MINIMAX_M2_TOOL_PROMPT
+    assert result.startswith("<minimax:tool_call>")
+    assert result.endswith("</minimax:tool_call>")
+    assert '<invoke name="tool_name">' in result
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_minimax2_tool_round_trip():
+    formatter = FunctionFormatter(slots=["{{content}}"], tool_format="minimax2")
+    tool_formatter = ToolFormatter(tool_format="minimax2")
+    original = {"name": "my_func", "arguments": {"arg1": "hello", "arg2": 42, "arg3": True}}
+    formatted = formatter.apply(content=json.dumps(original))
+    extracted = tool_formatter.extract(formatted[0])
+    assert len(extracted) == 1
+    assert extracted[0][0] == original["name"]
+    assert json.loads(extracted[0][1]) == original["arguments"]


### PR DESCRIPTION
# What does this PR do?

`MiniMaxM2ToolUtils.function_formatter` builds the assistant tool-call text as bare `<invoke>...</invoke>` blocks, with no `<minimax:tool_call>` wrapper. That contradicts two things in the same file:

- `MINIMAX_M2_TOOL_PROMPT` tells the model to emit tool calls as `<minimax:tool_call>\n<invoke ...>...</invoke>\n</minimax:tool_call>`.
- `MiniMaxM2ToolUtils.tool_extractor` only matches content wrapped in `<minimax:tool_call>...</minimax:tool_call>`; without the wrapper it returns the raw string and the tool call is dropped.

So fine-tuning with `template=minimax2` on tool-call data teaches the model the wrong output format: the training target omits the wrapper the system prompt asks for, and the framework's own extractor can't parse it back. The encode/decode round trip silently loses every tool call.

Fix: wrap the joined `<invoke>` blocks in `<minimax:tool_call>...</minimax:tool_call>`, matching both the prompt and the extractor.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

Added `test_minimax2_function_formatter` (asserts the wrapper is present) and `test_minimax2_tool_round_trip` (asserts a formatted call parses back to the original) in `tests/data/test_formatter.py`. Both fail on `main` and pass with this change; the full `test_formatter.py` suite stays green (36 passed).
