### PR TITLE
fix(data): correct keyword argument `sample_idx` to `batch_idx` in collator

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -261,7 +261,7 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                     "attention_mask": features["attention_mask"][sample_idx : sample_idx + 1],
                 }
                 mm_inputs_for_sample = _slice_mm_inputs_for_sample(
-                    mm_inputs, batch_imglens, batch_vidlens, sample_idx=sample_idx
+                    mm_inputs, batch_imglens, batch_vidlens, batch_idx=sample_idx
                 )
                 self._compute_rope_position_ids(sample_features, mm_inputs_for_sample)
                 all_position_ids.append(sample_features["position_ids"])


### PR DESCRIPTION
Fixes #10497

---

`_slice_mm_inputs_for_sample` 的第 4 个参数名为 `batch_idx`，但第 263 行调用时错用了 `sample_idx=sample_idx`，导致多模态训练在 `num_sub_seqs <= 1` 时抛出 `TypeError`。

修复：`sample_idx=sample_idx` → `batch_idx=sample_idx`

This contribution was prepared with AI assistance.