### PR TITLE
fix(data): clarify `_nothink` suffix warning for reasoning-only models

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -655,8 +655,10 @@ def get_template_and_fix_tokenizer(tokenizer: "PreTrainedTokenizer", data_args: 
 
     if isinstance(template, ReasoningTemplate):
         logger.warning_rank0(
-            "You are using reasoning template, "
-            "please add `_nothink` suffix if the model is not a reasoning model. "
+            "You are using reasoning template. "
+            "If the base model is NOT a reasoning model (i.e., it has a separate Instruct variant), "
+            "please add `_nothink` suffix to disable thinking. "
+            "For reasoning-only model families (e.g., Qwen3.6), the suffix is not needed. "
             "e.g., qwen3_vl_nothink"
         )
         template.enable_thinking = data_args.enable_thinking


### PR DESCRIPTION
Fixes #10566

---

`get_template_and_fix_tokenizer` 中的警告无条件建议添加 `_nothink` 后缀，对于仅发布推理模型（无 Instruct 版本）的模型系列（如 Qwen3.6）会产生误导。

修改警告文本，明确说明：
- 只有基础模型**不是**推理模型时需要加后缀
- 纯推理模型系列无需加后缀

This contribution was prepared with AI assistance.