### PR TITLE
[model] add Qwen-AgentWorld-35B-A3B support

### DIFF
--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -3372,6 +3372,19 @@ register_model_group(
 )
 
 
+# Qwen-AgentWorld: language world model based on Qwen3.5-35B-A3B (MoE).
+# Reference: https://github.com/QwenLM/Qwen-AgentWorld
+register_model_group(
+    models={
+        "Qwen-AgentWorld-35B-A3B-Thinking": {
+            DownloadSource.DEFAULT: "Qwen/Qwen-AgentWorld-35B-A3B",
+            DownloadSource.MODELSCOPE: "Qwen/Qwen-AgentWorld-35B-A3B",
+        },
+    },
+    template="qwen3",
+)
+
+
 register_model_group(
     models={
         "Vicuna-v1.5-7B-Chat": {


### PR DESCRIPTION
# What does this PR do?

Add built-in support for **Qwen-AgentWorld-35B-A3B**, a native language world model released by the Qwen team, based on Qwen3.5-35B-A3B (MoE, 35B total / 3B active, 256K context).

- Register `Qwen-AgentWorld-35B-A3B-Thinking` in `src/llamafactory/extras/constants.py`, with both Hugging Face (`Qwen/Qwen-AgentWorld-35B-A3B`) and ModelScope (`Qwen/Qwen-AgentWorld-35B-A3B`) download sources.
- Bind it to the existing `qwen3` chat template — the model shares the standard Qwen3 chat format and its inference uses `--reasoning-parser qwen3`, so no new template is required.
- The `-Thinking` suffix is used so the `register_model_group` helper automatically populates `DEFAULT_TEMPLATE`.

Reference:
- Repo: https://github.com/QwenLM/Qwen-AgentWorld (the README explicitly recommends LLaMA-Factory for fine-tuning)
- HF: https://huggingface.co/Qwen/Qwen-AgentWorld-35B-A3B

Fixes #10614

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?  *(No new tests added: this PR only adds an entry to the model registry that reuses the existing `qwen3` template; verified locally with `ruff check / format` and a runtime registry smoke check.)*