### PR TITLE
[v1] set flash_attn to flash_attention_2 for ulysses CP example

### DIFF
--- a/examples/v1/train_full/train_full_ulysses_cp.yaml
+++ b/examples/v1/train_full/train_full_ulysses_cp.yaml
@@ -3,6 +3,7 @@ trust_remote_code: true
 model_class: llm
 
 template: qwen3_nothink
+flash_attn: flash_attention_2
 
 # FSDP Config
 dist_config:


### PR DESCRIPTION
# What does this PR do?

---
Title:

[v1] add `flash_attn: flash_attention_2` to ulysses CP example

Body:

## What

Add the missing `flash_attn: flash_attention_2` line to
`examples/v1/train_full/train_full_ulysses_cp.yaml`.

## Why

Sequence parallelism requires flash attention. The trainer raises
`ValueError: Sequence parallelism requires flash attention. Please set
flash_attn: flash_attention_2.` when `_attn_implementation != "flash_attention_2"`
(see `src/llamafactory/v1/core/base_trainer.py`).

The current example config does not set `flash_attn`, so running it as-is
fails immediately at trainer init. Setting it to `flash_attention_2` matches
the SP requirement and makes the example runnable out-of-the-box.

## Change

One line added (no other changes):

```diff
 template: qwen3_nothink
+flash_attn: flash_attention_2
```
 # FSDP Config

---

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
