### PR TITLE
fix(mm_plugin): regularize images before processor in MiniCPMV4_6Plugin

### DIFF
--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -1458,6 +1458,14 @@ class MiniCPMV4_6Plugin(BasePlugin):
         mm_inputs = {}
 
         if len(images) != 0:
+            # Pre-load images into PIL objects so the (torchvision-backed) image_processor passes
+            # them through unchanged, instead of decoding paths via torchvision (which is built
+            # without libjpeg on ROCm). See _regularize_images.
+            images = self._regularize_images(
+                images,
+                image_max_pixels=getattr(processor, "image_max_pixels", 1024 * 1024),
+                image_min_pixels=getattr(processor, "image_min_pixels", 32 * 32),
+            )["images"]
             # The image_processor ignores downsample_mode; target_sizes are always based on patch_size.
             # downsample_mode only affects the token divisor in _build_v4_6_placeholder and model forward.
             mm_inputs.update(image_processor(images, return_tensors="pt"))


### PR DESCRIPTION
# What does this PR do?

`MiniCPMV4_6Plugin._get_mm_inputs` feeds raw image inputs (file paths / bytes / dicts)
directly into `image_processor`, unlike every other plugin — including the older
`MiniCPMVPlugin` — which first calls `_regularize_images()` to load them into PIL
objects and apply `image_max_pixels` / `image_min_pixels` resizing.

This has two consequences for MiniCPM-V-4.6:

1. **`image_max_pixels` / `image_min_pixels` are silently ignored**, so images are
   never resized according to the configured pixel bounds.
2. **Training/inference crashes on torchvision builds without libjpeg.** With
   `transformers>=5.7`, the (torchvision-backed) image processor decodes path inputs
   through torchvision. On wheels built without libjpeg (e.g. the ROCm torchvision
   builds) this fails during preprocessing with:
   ```
   RuntimeError: decode_jpeg: torchvision not compiled with libjpeg support
   ```

Pre-loading the images to PIL via `_regularize_images()` makes the processor pass
them through unchanged, which both restores the resize behavior and avoids the
torchvision decode path. The video branch is intentionally left untouched, since
videos are decoded via PyAV (`_regularize_videos`), not torchvision.

## How was this tested?

Reproduced while LoRA fine-tuning **MiniCPM-V-4.6** (`template: minicpm_v_4_6`) on an
AMD ROCm setup (`transformers==5.7.0`, ROCm torchvision without libjpeg). Before this
change, `llamafactory-cli train` crashed in dataset preprocessing with the
`decode_jpeg` error above. After the change, SFT runs to completion and the trained
adapter produces correct image-grounded answers.

Fixes # (no issue)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
