### PR TITLE
docs: fix ray initialization comment typo

### DIFF
--- a/src/llamafactory/train/tuner.py
+++ b/src/llamafactory/train/tuner.py
@@ -134,7 +134,7 @@ def _training_function(config: dict[str, Any]) -> None:
         raise ValueError(f"Unknown task: {finetuning_args.stage}.")
 
     if is_ray_available() and ray.is_initialized():
-        return  # if ray is intialized it will destroy the process group on return
+        return  # if ray is initialized it will destroy the process group on return
 
     try:
         if dist.is_initialized():


### PR DESCRIPTION
﻿## What does this PR do?

Fixes a typo in a Ray cleanup comment in `src/llamafactory/train/tuner.py`.

This is a docs/comment-only cleanup; runtime behavior is unchanged.

## Before submitting

- [x] Did you read the contributor guideline?
- [x] Did you write any new necessary tests? N/A, comment-only typo fix.

## Validation

- `uvx --from codespell codespell src\\llamafactory\\train\\tuner.py`
- `uvx ruff check src\\llamafactory\\train\\tuner.py`
- `git diff --check`
