### PR TITLE
docs: fix typos in comments and help text

### DIFF
--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -929,7 +929,7 @@ class InternVLPlugin(BasePlugin):
         messages = deepcopy(messages)
         mm_inputs = self._get_mm_inputs(images, videos, audios, processor)
 
-        image_pixel_patch_list = mm_inputs.get("image_num_patches")  # pathes of images
+        image_pixel_patch_list = mm_inputs.get("image_num_patches")  # patches of images
         video_num_patches = mm_inputs.get("video_num_patches")  # all patches for frames of videos
         video_patch_indices = mm_inputs.get("video_patch_indices")  # num frames of per video
 
@@ -2667,7 +2667,7 @@ class Qwen2OmniPlugin(Qwen2VLPlugin):
 
             if (
                 use_audio_in_video and len(audios) and len(videos)
-            ):  # if use the audio of video # deal video token and audio token togather
+            ):  # if use the audio of video # deal video token and audio token together
                 if len(videos) != len(audios):
                     raise ValueError(
                         f"Number of videos ({len(videos)}) must match number of audios ({len(audios)}) when using audio in video."

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1035,7 +1035,7 @@ register_template(
     format_assistant=StringFormatter(slots=["{{content}}<turn|>\n"]),
     format_system=StringFormatter(
         slots=["<|turn>system\n<|think|>{{content}}<turn|>\n"]
-    ),  #  default thought singal contained
+    ),  #  default thought signal contained
     format_observation=StringFormatter(
         slots=["<|turn>tool\n{{content}}<turn|>\n<|turn>model\n"]
     ),  # seem not consistent with the chattemplate
@@ -1061,7 +1061,7 @@ register_template(
     format_assistant=StringFormatter(slots=["{{content}}<turn|>\n"]),
     format_system=StringFormatter(
         slots=["<|turn>system\n<|think|>{{content}}<turn|>\n"]
-    ),  #  default thought singal contained
+    ),  #  default thought signal contained
     format_observation=StringFormatter(slots=["<|turn>tool\n{{content}}<turn|>\n<|turn>model\n"]),
     format_tools=ToolFormatter(tool_format="gemma4"),
     format_function=FunctionFormatter(slots=["<|tool>{{content}}<tool|>"], tool_format="gemma4"),

--- a/src/llamafactory/hparams/evaluation_args.py
+++ b/src/llamafactory/hparams/evaluation_args.py
@@ -44,7 +44,7 @@ class EvaluationArguments:
     )
     n_shot: int = field(
         default=5,
-        metadata={"help": "Number of examplars for few-shot learning."},
+        metadata={"help": "Number of exemplars for few-shot learning."},
     )
     save_dir: str | None = field(
         default=None,

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -385,7 +385,7 @@ class BAdamArgument:
             "help": (
                 "The mode of the mask for BAdam optimizer. "
                 "`adjacent` means that the trainable parameters are adjacent to each other, "
-                "`scatter` means that trainable parameters are randomly choosed from the weight."
+                "`scatter` means that trainable parameters are randomly chosen from the weight."
             )
         },
     )
@@ -530,7 +530,7 @@ class FinetuningArguments(
     )
     freeze_vision_tower: bool = field(
         default=True,
-        metadata={"help": "Whether ot not to freeze the vision tower in MLLM training."},
+        metadata={"help": "Whether or not to freeze the vision tower in MLLM training."},
     )
     freeze_multi_modal_projector: bool = field(
         default=True,

--- a/src/llamafactory/webui/control.py
+++ b/src/llamafactory/webui/control.py
@@ -105,7 +105,7 @@ def check_template(lang: str, template: str) -> None:
 
 
 def get_trainer_info(lang: str, output_path: os.PathLike, do_train: bool) -> tuple[str, "gr.Slider", dict[str, Any]]:
-    r"""Get training infomation for monitor.
+    r"""Get training information for monitor.
 
     If do_train is True:
         Inputs: top.lang, train.output_path


### PR DESCRIPTION
## Summary

- fix several spelling errors in comments and user-facing help text
- keep the change limited to wording only; no runtime logic changes

## Validation

- `git diff --check origin/main...HEAD`
- `uv run --no-project --with ruff -- ruff check src/llamafactory/data/mm_plugin.py src/llamafactory/data/template.py src/llamafactory/hparams/evaluation_args.py src/llamafactory/hparams/finetuning_args.py src/llamafactory/webui/control.py`
- `uv run --no-project --with codespell -- codespell src/llamafactory/data/mm_plugin.py src/llamafactory/data/template.py src/llamafactory/hparams/evaluation_args.py src/llamafactory/hparams/finetuning_args.py src/llamafactory/webui/control.py --ignore-words-list ROUGE,rouge,ploting`