### PR TITLE
fix: exclude broken transformers release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "torch>=2.4.0",
     "torchvision>=0.19.0",
     "torchaudio>=2.4.0",
-    "transformers>=4.55.0,<=5.6.0,!=4.57.0",
+    "transformers>=4.55.0,<=5.7.0,!=4.57.0,!=5.6.0",
     "datasets>=2.16.0,<=4.0.0",
     "accelerate>=1.3.0,<=1.11.0",
     "peft>=0.18.0,<=0.18.1",

--- a/src/llamafactory/extras/misc.py
+++ b/src/llamafactory/extras/misc.py
@@ -94,7 +94,9 @@ def check_version(requirement: str, mandatory: bool = False) -> None:
 
 def check_dependencies() -> None:
     r"""Check the version of the required packages."""
-    check_version("transformers>=4.55.0,<=5.7.0,!=4.57.0,!=5.6.0")
+    check_version("transformers>=4.55.0,<=5.7.0")
+    check_version("transformers!=4.57.0")
+    check_version("transformers!=5.6.0")
     check_version("datasets>=2.16.0,<=4.0.0")
     check_version("accelerate>=1.3.0,<=1.15.0")
     check_version("peft>=0.18.0,<=0.20.0")

--- a/src/llamafactory/extras/misc.py
+++ b/src/llamafactory/extras/misc.py
@@ -94,7 +94,7 @@ def check_version(requirement: str, mandatory: bool = False) -> None:
 
 def check_dependencies() -> None:
     r"""Check the version of the required packages."""
-    check_version("transformers>=4.55.0,<=5.6.0")
+    check_version("transformers>=4.55.0,<=5.7.0,!=4.57.0,!=5.6.0")
     check_version("datasets>=2.16.0,<=4.0.0")
     check_version("accelerate>=1.3.0,<=1.15.0")
     check_version("peft>=0.18.0,<=0.20.0")


### PR DESCRIPTION
Fixes #10610

The issue thread identifies `transformers==5.6.0` as the broken release for the FlashAttention path, and maintainers noted that upgrading Transformers avoids it.

This updates the supported Transformers spec in both install metadata and the runtime dependency check:
- allow `<=5.7.0`
- keep the existing `!=4.57.0` exclusion
- add `!=5.6.0` so existing broken environments fail the version gate instead of passing silently

Validation:
- `uvx ruff check pyproject.toml src\llamafactory\extras\misc.py`
- `py -m py_compile src\llamafactory\extras\misc.py`
- `git diff --check`