### PR TITLE
Fix v1 grad norm and lr log

### DIFF
--- a/src/llamafactory/v1/core/base_trainer.py
+++ b/src/llamafactory/v1/core/base_trainer.py
@@ -279,12 +279,34 @@ class BaseTrainer:
                     # deepspeed: engine.step() already ran inside backward at the sync boundary
                     grad_norm = self._deepspeed_engine.get_grad_norm()
                 else:
-                    grad_norm = torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.args.max_grad_norm).item()
+                    # FSDP2 shards params/grads as DTensors across the fsdp mesh, so each rank only
+                    # holds 1/shard_size of every parameter. `get_total_norm`/`clip_grad_norm_`
+                    # return a *per-rank local shard* norm and `.item()` reads only that local
+                    # partial (== global_norm / sqrt(shard_size)). Using it directly makes the
+                    # reported grad_norm scale as 1/sqrt(dp_size) (e.g. 8xdp mbs1 vs 4xdp mbs2
+                    # differ by sqrt(2)), and -- worse -- makes `clip_grad_norm_` apply the clip
+                    # coefficient per-shard, corrupting the update once clipping is actually on.
+                    # Fix: reduce to the true global norm first (full_tensor all-reduces across the
+                    # fsdp shard mesh), then clip with that scalar via clip_grads_with_norm_.
+                    from torch.distributed.tensor import DTensor
 
-                    if self.args.dist_config and self.args.dist_config.get("cp_size", 1) > 1:
-                        grad_norm = grad_norm**2
-                        grad_norm = DistributedInterface().all_reduce(grad_norm, op=ReduceOp.SUM, dim=Dim.CP)
-                        grad_norm = grad_norm**0.5
+                    grads = [p.grad for p in self.model.parameters() if p.grad is not None]
+                    total_norm = torch.nn.utils.get_total_norm(grads)
+                    if isinstance(total_norm, DTensor):
+                        # full_tensor already all-reduces across the whole fsdp shard mesh. With the
+                        # default mp_shard_size = world_size this mesh spans CP too, so FSDP's
+                        # reduce-scatter has already summed grads across CP -- no separate CP
+                        # reduction is wanted (it would over-count grad_norm by sqrt(cp_size) and
+                        # also skew the clip coefficient below). CP-on and CP-off both report the
+                        # true global norm this way.
+                        total_norm = total_norm.full_tensor()
+                    # pass the (replicated) global norm as a Tensor -- clip_grads_with_norm_ does
+                    # torch.clamp(max_norm / (total_norm + 1e-6), max=1.0), which rejects a bare
+                    # python float. .item() for reporting only, after clipping.
+                    torch.nn.utils.clip_grads_with_norm_(
+                        self.model.parameters(), self.args.max_grad_norm, total_norm
+                    )
+                    grad_norm = total_norm.item()
 
                     if not torch.isfinite(torch.tensor(grad_norm)):  # type: ignore # pyright: ignore [reportUnknownReturnType]
                         logger.warning_rank0(f"Gradient norm is not finite: {grad_norm}")

--- a/src/llamafactory/v1/core/base_trainer.py
+++ b/src/llamafactory/v1/core/base_trainer.py
@@ -31,6 +31,7 @@ from abc import abstractmethod
 
 import torch
 import torch.nn.functional as F
+from torch.distributed.tensor import DTensor
 
 from ..accelerator.helper import ReduceOp
 from ..accelerator.interface import Dim, DistributedInterface
@@ -283,8 +284,6 @@ class BaseTrainer:
                     # per-rank local shard norm (global / sqrt(shard_size)): reported grad_norm then
                     # scales as 1/sqrt(dp_size) and the clip coefficient is applied per-shard. Reduce
                     # to the true global norm first, then clip with it.
-                    from torch.distributed.tensor import DTensor
-
                     grads = [p.grad for p in self.model.parameters() if p.grad is not None]
                     total_norm = torch.nn.utils.get_total_norm(grads)
                     if isinstance(total_norm, DTensor):

--- a/src/llamafactory/v1/core/base_trainer.py
+++ b/src/llamafactory/v1/core/base_trainer.py
@@ -279,30 +279,19 @@ class BaseTrainer:
                     # deepspeed: engine.step() already ran inside backward at the sync boundary
                     grad_norm = self._deepspeed_engine.get_grad_norm()
                 else:
-                    # FSDP2 shards params/grads as DTensors across the fsdp mesh, so each rank only
-                    # holds 1/shard_size of every parameter. `get_total_norm`/`clip_grad_norm_`
-                    # return a *per-rank local shard* norm and `.item()` reads only that local
-                    # partial (== global_norm / sqrt(shard_size)). Using it directly makes the
-                    # reported grad_norm scale as 1/sqrt(dp_size) (e.g. 8xdp mbs1 vs 4xdp mbs2
-                    # differ by sqrt(2)), and -- worse -- makes `clip_grad_norm_` apply the clip
-                    # coefficient per-shard, corrupting the update once clipping is actually on.
-                    # Fix: reduce to the true global norm first (full_tensor all-reduces across the
-                    # fsdp shard mesh), then clip with that scalar via clip_grads_with_norm_.
+                    # FSDP2 shards params/grads across the fsdp mesh, so clip_grad_norm_ returns a
+                    # per-rank local shard norm (global / sqrt(shard_size)): reported grad_norm then
+                    # scales as 1/sqrt(dp_size) and the clip coefficient is applied per-shard. Reduce
+                    # to the true global norm first, then clip with it.
                     from torch.distributed.tensor import DTensor
 
                     grads = [p.grad for p in self.model.parameters() if p.grad is not None]
                     total_norm = torch.nn.utils.get_total_norm(grads)
                     if isinstance(total_norm, DTensor):
-                        # full_tensor already all-reduces across the whole fsdp shard mesh. With the
-                        # default mp_shard_size = world_size this mesh spans CP too, so FSDP's
-                        # reduce-scatter has already summed grads across CP -- no separate CP
-                        # reduction is wanted (it would over-count grad_norm by sqrt(cp_size) and
-                        # also skew the clip coefficient below). CP-on and CP-off both report the
-                        # true global norm this way.
+                        # full_tensor all-reduces across the fsdp mesh (spans CP under default
+                        # mp_shard=world); a separate CP reduce would over-count by sqrt(cp_size).
                         total_norm = total_norm.full_tensor()
-                    # pass the (replicated) global norm as a Tensor -- clip_grads_with_norm_ does
-                    # torch.clamp(max_norm / (total_norm + 1e-6), max=1.0), which rejects a bare
-                    # python float. .item() for reporting only, after clipping.
+                    # pass a Tensor: clip_grads_with_norm_ clamps max_norm / (total_norm + 1e-6).
                     torch.nn.utils.clip_grads_with_norm_(
                         self.model.parameters(), self.args.max_grad_norm, total_norm
                     )

--- a/src/llamafactory/v1/plugins/model_plugins/parallelization/sequence_parallel.py
+++ b/src/llamafactory/v1/plugins/model_plugins/parallelization/sequence_parallel.py
@@ -90,7 +90,10 @@ def apply_sequence_parallel(model, model_args):
     set_ulysses_sequence_parallel_group(DistributedInterface().get_group(Dim.CP))
 
     try:
-        num_attention_heads, num_key_value_heads = model.config.num_attention_heads, model.config.num_attention_heads
+        num_attention_heads, num_key_value_heads = (
+            model.config.num_attention_heads,
+            model.config.num_key_value_heads,
+        )
     except AttributeError:
         num_attention_heads, num_key_value_heads = (
             model.config.text_config.num_attention_heads,

--- a/src/llamafactory/v1/utils/callbacks/logging_callback.py
+++ b/src/llamafactory/v1/utils/callbacks/logging_callback.py
@@ -54,7 +54,17 @@ class LoggingCallback(TrainerCallback):
 
         # Human-readable output to stdout
         display_logs = {**logs, "step": state.global_step, "total_steps": state.num_training_steps}
-        parts = ", ".join(f"{k}: {v:.4f}" if isinstance(v, float) else f"{k}: {v}" for k, v in display_logs.items())
+
+        def _fmt(k: str, v) -> str:
+            if not isinstance(v, float):
+                return f"{k}: {v}"
+            # learning_rate is often < 1e-4 (e.g. 1e-5); :.4f would print "0.0000".
+            # Use :.4g so small values show as "1e-05" while 1e-4 still shows "0.0001".
+            if k == "learning_rate":
+                return f"{k}: {v:.4g}"
+            return f"{k}: {v:.4f}"
+
+        parts = ", ".join(_fmt(k, v) for k, v in display_logs.items())
         logger.info_rank0(parts)
 
         # Append to JSONL log file in output_dir


### PR DESCRIPTION
---
# What does this PR do?

Fixes three small bugs in the v1 trainer, all found while debugging cross-layout (different `dp_size` / `cp_size`) precision alignment.

## 1. `grad_norm` mis-reported (and mis-clipped) under FSDP2 sharded params

**File**: `src/llamafactory/v1/core/base_trainer.py`

Under FSDP2, parameters/gradients are sharded `DTensor`s across the fsdp mesh, so each rank holds only `1/shard_size` of every parameter. `torch.nn.utils.clip_grad_norm_` internally calls `_get_total_norm`, which computes the norm over the **local shard only** and does **not** all-reduce squared norms across the mesh. `.item()` therefore reads the local partial, which equals `global_norm / sqrt(shard_size)`.

Consequences:
- Reported `grad_norm` scales as `1/sqGPU `mbs1` vs 4-GPU `mbs2` (same global batch, `cp_size=1`) differ by exactly `sqrt(2)` (= `sqrt(dp8/dp4)`), while `loss` is identical.
- Worse: the clip coefficient `max_norm / total_norm` is also computed from the local shard norm, so once `max_grad_norm` is actually enabled the gradient is clipped **per-shard** (different coefficient per rank), corrupting the update.

**Fix**: compute the local norm via `get_total_norm`, reduce it to the true global norm with `.full_tensor()` (which all-reduces across the fsdp shard mesh), then clip with that scalar via
`clip_grads_with_norm_`. `.item()` is r clipping.

The previous `cp_size > 1` cross-CP all-reduce of `grad_norm` is removed: under the default `mp_shard_size
= world_size` the fsdp mesh already spter has already summed gradientsacross CP — the extra reduce would over-count `grad_norm` by `sqrt(cp_size)` and skew the clip coefficient.

Verification: a 2-process DTensor test confirms `get_total_norm(...).item()` returns the local shard nowhile `.full_tensor().item()` returns he fix, 8-GPU-`mbs1` and 4-GPU-`mbs2`report the same `grad_norm`.

## 2. `learning_rate` log truncation for small values

**File**: `src/llamafactory/v1/utils/callbacks/logging_callback.py`                                    
`learning_rate` was formatted with `:.4f`, so values below `1e-4` (e.g. `1e-5`, `2e-5`) printed as `0.0000`. Use `:.4g` for `learning_rate` so `1e-5` shows as `1e-05` while `1e-4` still shows `0.0001`. Other floats (`loss`, `grad_norm`) kee

## 3. `num_key_value_heads` typo in ulysses sequence-parallel setup
**File**: `src/llamafactory/v1/pluginsn/sequence_parallel.py`

In `apply_sequence_parallel`, the `try` branch assigned both `num_attention_heads` and `num_key_value_heads` from `model.conf — the second should be`num_key_value_heads`). As a result the `cp_size` divisibility assertion for KV heads validated the wrong value. The `except` branch (the `text_config` path) was already correct.

Fixes #N/A (no linked issue; found during internal precision debugging)

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
