### PR TITLE
feat: add MTP support for SFT

### DIFF
--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -540,6 +540,14 @@ class FinetuningArguments(
         default=False,
         metadata={"help": "Whether or not to freeze the language model in MLLM training."},
     )
+    num_mtp_layers: int = field(
+        default=0,
+        metadata={"help": "Number of Multi-Token Prediction (MTP) layers to train externally."},
+    )
+    mtp_loss_weight: float = field(
+        default=0.0,
+        metadata={"help": "Weight of the external MTP auxiliary loss. 0 disables MTP training."},
+    )
     compute_accuracy: bool = field(
         default=False,
         metadata={"help": "Whether or not to compute the token-level accuracy at evaluation."},

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -15,6 +15,8 @@
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 
+from ..extras.packages import is_transformers_version_greater_than
+
 
 @dataclass
 class FreezeArguments:
@@ -555,6 +557,14 @@ class FinetuningArguments(
         default=False,
         metadata={"help": "Whether or not to freeze the language model in MLLM training."},
     )
+    num_mtp_layers: int = field(
+        default=0,
+        metadata={"help": "Number of Multi-Token Prediction (MTP) layers to train externally."},
+    )
+    mtp_loss_weight: float = field(
+        default=0.0,
+        metadata={"help": "Weight of the external MTP auxiliary loss. 0 disables MTP training."},
+    )
     compute_accuracy: bool = field(
         default=False,
         metadata={"help": "Whether or not to compute the token-level accuracy at evaluation."},
@@ -633,6 +643,12 @@ class FinetuningArguments(
 
             if self.pissa_init:
                 raise ValueError("`pissa_init` is only valid for LoRA training.")
+
+        if self.num_mtp_layers > 0 and not is_transformers_version_greater_than("5.14.0"):
+            raise ValueError(
+                "MTP training requires `transformers>=5.14.0`, "
+                'please install it via `pip install "transformers>=5.14.0"`.'
+            )
 
     def to_dict(self) -> dict[str, Any]:
         args = asdict(self)

--- a/src/llamafactory/train/sft/mtp_utils.py
+++ b/src/llamafactory/train/sft/mtp_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 """Non-intrusive Multi-Token Prediction (MTP) helpers for SFT.
 
 These utilities allow training MTP layers without modifying transformers model
@@ -23,7 +25,12 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 from transformers.masking_utils import create_causal_mask
-from transformers.modeling_layers import MtpModel
+
+try:
+    from transformers.modeling_layers import MtpModel
+except ImportError as e:
+    MtpModel = None  # type: ignore[misc,assignment]
+    _MTP_IMPORT_ERROR = e
 
 
 def extend_layer_types(config: Any, num_mtp_layers: int) -> Any:
@@ -65,7 +72,7 @@ def _is_mrope_config(config: Any) -> bool:
 
 
 def compute_mtp_loss(
-    mtp_model: MtpModel,
+    mtp_model: "MtpModel",
     input_ids: torch.Tensor,
     main_hidden_states: torch.Tensor,
     labels: torch.Tensor,
@@ -79,6 +86,12 @@ def compute_mtp_loss(
     This function works for both standard 2D RoPE models (Deepseek-V3,
     GLM-4-MoE) and MRoPE models (Qwen3.5).
     """
+    if MtpModel is None:
+        raise ImportError(
+            "MTP training requires a transformers version that provides "
+            "`transformers.modeling_layers.MtpModel` (merged via huggingface/transformers#46229). "
+            "Please install a compatible transformers build from source."
+        ) from _MTP_IMPORT_ERROR
     batch_size, seq_len = main_hidden_states.shape[:2]
     device = main_hidden_states.device
 

--- a/src/llamafactory/train/sft/mtp_utils.py
+++ b/src/llamafactory/train/sft/mtp_utils.py
@@ -14,23 +14,23 @@
 
 from __future__ import annotations
 
-"""Non-intrusive Multi-Token Prediction (MTP) helpers for SFT.
-
-These utilities allow training MTP layers without modifying transformers model
-files. They are used by `CustomSeq2SeqTrainer` when `num_mtp_layers > 0`.
-"""
-
 from typing import Any
 
 import torch
 import torch.nn.functional as F
 from transformers.masking_utils import create_causal_mask
 
+
 try:
     from transformers.modeling_layers import MtpModel
 except ImportError as e:
     MtpModel = None  # type: ignore[misc,assignment]
     _MTP_IMPORT_ERROR = e
+
+
+# Non-intrusive Multi-Token Prediction (MTP) helpers for SFT.
+# These utilities allow training MTP layers without modifying transformers model
+# files. They are used by `CustomSeq2SeqTrainer` when `num_mtp_layers > 0`.
 
 
 def extend_layer_types(config: Any, num_mtp_layers: int) -> Any:
@@ -72,7 +72,7 @@ def _is_mrope_config(config: Any) -> bool:
 
 
 def compute_mtp_loss(
-    mtp_model: "MtpModel",
+    mtp_model: MtpModel,
     input_ids: torch.Tensor,
     main_hidden_states: torch.Tensor,
     labels: torch.Tensor,

--- a/src/llamafactory/train/sft/mtp_utils.py
+++ b/src/llamafactory/train/sft/mtp_utils.py
@@ -57,7 +57,14 @@ def get_base_lm_model(model: torch.nn.Module) -> torch.nn.Module:
     return getattr(base, "language_model", base)
 
 
-def compute_mtp_loss_tf(
+def _is_mrope_config(config: Any) -> bool:
+    r"""Detect whether a model uses Multimodal RoPE (e.g. Qwen3.5)."""
+    text_config = config.get_text_config() if hasattr(config, "get_text_config") else config
+    rope_params = getattr(text_config, "rope_parameters", None)
+    return isinstance(rope_params, dict) and "mrope_section" in rope_params
+
+
+def compute_mtp_loss(
     mtp_model: MtpModel,
     input_ids: torch.Tensor,
     main_hidden_states: torch.Tensor,
@@ -68,13 +75,21 @@ def compute_mtp_loss_tf(
 
     Layer i consumes the embedding of token ``t+i+1`` and the previous hidden
     state at position ``t`` to predict token ``t+i+2``.
+
+    This function works for both standard 2D RoPE models (Deepseek-V3,
+    GLM-4-MoE) and MRoPE models (Qwen3.5).
     """
     batch_size, seq_len = main_hidden_states.shape[:2]
     device = main_hidden_states.device
 
     base_embeds = mtp_model.embed_tokens(input_ids)
-    pos = torch.arange(seq_len, device=device).view(1, 1, -1)
-    base_position_ids = pos.expand(4, batch_size, -1).clone()
+    pos = torch.arange(seq_len, device=device)
+    if _is_mrope_config(mtp_model.config):
+        # MRoPE: [4, batch_size, seq_len] where the first component is text positions
+        base_position_ids = pos.view(1, 1, -1).expand(4, batch_size, -1).clone()
+    else:
+        # Standard RoPE: [batch_size, seq_len]
+        base_position_ids = pos.unsqueeze(0).expand(batch_size, -1).clone()
 
     total_loss = torch.tensor(0.0, device=device, dtype=torch.float32)
     current_hidden = main_hidden_states
@@ -87,8 +102,16 @@ def compute_mtp_loss_tf(
         shifted_position_ids = torch.roll(base_position_ids, -shift, dims=-1).clone()
         shifted_position_ids[..., -shift:] = base_position_ids[..., -shift:]
 
-        # Qwen3.5 rotary_emb expects mrope (3D) for temporal/height/width.
-        position_embeddings = mtp_model.rotary_emb(shifted_embeds, position_ids=shifted_position_ids[1:])
+        # Split position ids: text positions go to the causal mask, rope positions
+        # go to the rotary embedding. For 2D RoPE these are the same tensor.
+        if shifted_position_ids.ndim == 2:
+            text_position_ids = shifted_position_ids
+            rope_position_ids = shifted_position_ids
+        else:
+            text_position_ids = shifted_position_ids[0]
+            rope_position_ids = shifted_position_ids[1:]
+
+        position_embeddings = mtp_model.rotary_emb(shifted_embeds, position_ids=rope_position_ids)
 
         # Only shift 2D attention masks; for 4D or None fall back to a pure causal mask.
         # Labels are -100 for padded positions so the loss ignores them.
@@ -103,7 +126,7 @@ def compute_mtp_loss_tf(
             inputs_embeds=shifted_embeds,
             attention_mask=shifted_attention_mask,
             past_key_values=None,
-            position_ids=shifted_position_ids[0],
+            position_ids=text_position_ids,
         )
 
         current_hidden = mtp_model.layers[i](
@@ -111,7 +134,7 @@ def compute_mtp_loss_tf(
             previous_hidden_state=current_hidden,
             position_embeddings=position_embeddings,
             attention_mask=causal_mask,
-            position_ids=shifted_position_ids[0],
+            position_ids=text_position_ids,
             past_key_values=None,
         )
 

--- a/src/llamafactory/train/sft/mtp_utils.py
+++ b/src/llamafactory/train/sft/mtp_utils.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from typing import Any
 
 import torch
-import torch.nn.functional as F
 from transformers.masking_utils import create_causal_mask
 
 
@@ -104,16 +103,18 @@ def compute_mtp_loss(
         # Standard RoPE: [batch_size, seq_len]
         base_position_ids = pos.unsqueeze(0).expand(batch_size, -1).clone()
 
-    total_loss = torch.tensor(0.0, device=device, dtype=torch.float32)
+    total_loss = 0.0
     current_hidden = main_hidden_states
 
     for i in range(len(mtp_model.layers)):
         shift = i + 1
-        shifted_embeds = base_embeds[:, shift:, :]
-        shifted_embeds = F.pad(shifted_embeds, (0, 0, 0, shift), value=0.0)
+        shifted_embeds = torch.zeros_like(base_embeds)
+        if shift < seq_len:
+            shifted_embeds[:, :-shift, :] = base_embeds[:, shift:, :]
 
-        shifted_position_ids = torch.roll(base_position_ids, -shift, dims=-1).clone()
-        shifted_position_ids[..., -shift:] = base_position_ids[..., -shift:]
+        shifted_position_ids = base_position_ids.clone()
+        if shift < seq_len:
+            shifted_position_ids[..., :-shift] = base_position_ids[..., shift:]
 
         # Split position ids: text positions go to the causal mask, rope positions
         # go to the rotary embedding. For 2D RoPE these are the same tensor.
@@ -129,8 +130,9 @@ def compute_mtp_loss(
         # Only shift 2D attention masks; for 4D or None fall back to a pure causal mask.
         # Labels are -100 for padded positions so the loss ignores them.
         if attention_mask is not None and attention_mask.dim() == 2:
-            shifted_attention_mask = attention_mask[:, shift:]
-            shifted_attention_mask = F.pad(shifted_attention_mask, (0, shift), value=0)
+            shifted_attention_mask = torch.zeros_like(attention_mask)
+            if shift < seq_len:
+                shifted_attention_mask[:, :-shift] = attention_mask[:, shift:]
         else:
             shifted_attention_mask = None
 
@@ -154,8 +156,9 @@ def compute_mtp_loss(
         mtp_logits = mtp_model.shared_head(current_hidden)
 
         target_shift = i + 2
-        shifted_labels = torch.roll(labels, -target_shift, dims=1).clone()
-        shifted_labels[:, -target_shift:] = -100
+        shifted_labels = torch.full_like(labels, -100)
+        if target_shift < seq_len:
+            shifted_labels[:, :-target_shift] = labels[:, target_shift:]
 
         layer_loss = mtp_model.loss_function(
             mtp_logits,

--- a/src/llamafactory/train/sft/mtp_utils.py
+++ b/src/llamafactory/train/sft/mtp_utils.py
@@ -1,0 +1,146 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Non-intrusive Multi-Token Prediction (MTP) helpers for SFT.
+
+These utilities allow training MTP layers without modifying transformers model
+files. They are used by `CustomSeq2SeqTrainer` when `num_mtp_layers > 0`.
+"""
+
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from transformers.masking_utils import create_causal_mask
+from transformers.modeling_layers import MtpModel
+
+
+def extend_layer_types(config: Any, num_mtp_layers: int) -> Any:
+    r"""Extend `layer_types` so that MTP layers can be instantiated.
+
+    Models such as Qwen3.5 read `config.layer_types[layer_idx]` in their decoder
+    layer. MTP layers have `layer_idx = num_hidden_layers + k`, so we append
+    extra `"full_attention"` entries at runtime without touching any file.
+    """
+    text_config = config.get_text_config() if hasattr(config, "get_text_config") else config
+    current = list(getattr(text_config, "layer_types", []))
+    needed = text_config.num_hidden_layers + num_mtp_layers
+    if len(current) < needed:
+        current.extend(["full_attention"] * (needed - len(current)))
+        text_config.layer_types = current
+    return text_config
+
+
+def get_base_lm_model(model: torch.nn.Module) -> torch.nn.Module:
+    r"""Return the underlying language model (text tower).
+
+    This handles PeftModel wrapping and multimodal models:
+      - PeftModel -> get_base_model()
+      - Conditional generation -> base_model.language_model
+      - Causal LM -> base_model
+    """
+    if hasattr(model, "get_base_model"):
+        model = model.get_base_model()
+
+    base = getattr(model, "base_model", model)
+    return getattr(base, "language_model", base)
+
+
+def compute_mtp_loss_tf(
+    mtp_model: MtpModel,
+    input_ids: torch.Tensor,
+    main_hidden_states: torch.Tensor,
+    labels: torch.Tensor,
+    attention_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    r"""Teacher-forcing MTP loss computed entirely outside the base model.
+
+    Layer i consumes the embedding of token ``t+i+1`` and the previous hidden
+    state at position ``t`` to predict token ``t+i+2``.
+    """
+    batch_size, seq_len = main_hidden_states.shape[:2]
+    device = main_hidden_states.device
+
+    base_embeds = mtp_model.embed_tokens(input_ids)
+    pos = torch.arange(seq_len, device=device).view(1, 1, -1)
+    base_position_ids = pos.expand(4, batch_size, -1).clone()
+
+    total_loss = torch.tensor(0.0, device=device, dtype=torch.float32)
+    current_hidden = main_hidden_states
+
+    for i in range(len(mtp_model.layers)):
+        shift = i + 1
+        shifted_embeds = base_embeds[:, shift:, :]
+        shifted_embeds = F.pad(shifted_embeds, (0, 0, 0, shift), value=0.0)
+
+        shifted_position_ids = torch.roll(base_position_ids, -shift, dims=-1).clone()
+        shifted_position_ids[..., -shift:] = base_position_ids[..., -shift:]
+
+        # Qwen3.5 rotary_emb expects mrope (3D) for temporal/height/width.
+        position_embeddings = mtp_model.rotary_emb(shifted_embeds, position_ids=shifted_position_ids[1:])
+
+        # Only shift 2D attention masks; for 4D or None fall back to a pure causal mask.
+        # Labels are -100 for padded positions so the loss ignores them.
+        if attention_mask is not None and attention_mask.dim() == 2:
+            shifted_attention_mask = attention_mask[:, shift:]
+            shifted_attention_mask = F.pad(shifted_attention_mask, (0, shift), value=0)
+        else:
+            shifted_attention_mask = None
+
+        causal_mask = create_causal_mask(
+            config=mtp_model.config,
+            inputs_embeds=shifted_embeds,
+            attention_mask=shifted_attention_mask,
+            past_key_values=None,
+            position_ids=shifted_position_ids[0],
+        )
+
+        current_hidden = mtp_model.layers[i](
+            inputs_embeds=shifted_embeds,
+            previous_hidden_state=current_hidden,
+            position_embeddings=position_embeddings,
+            attention_mask=causal_mask,
+            position_ids=shifted_position_ids[0],
+            past_key_values=None,
+        )
+
+        mtp_logits = mtp_model.shared_head(current_hidden)
+
+        target_shift = i + 2
+        shifted_labels = torch.roll(labels, -target_shift, dims=1).clone()
+        shifted_labels[:, -target_shift:] = -100
+
+        layer_loss = mtp_model.loss_function(
+            mtp_logits,
+            labels,
+            vocab_size=mtp_model.config.vocab_size,
+            shift_labels=shifted_labels,
+        )
+        total_loss = total_loss + layer_loss
+
+    return total_loss / len(mtp_model.layers)
+
+
+class MtpHiddenStateHook:
+    r"""Forward hook that captures the output of the base model's final norm."""
+
+    def __init__(self, module: torch.nn.Module):
+        self.hidden: torch.Tensor | None = None
+        self.handle = module.register_forward_hook(self._hook)
+
+    def _hook(self, module, input, output):
+        self.hidden = output if isinstance(output, torch.Tensor) else output[0]
+
+    def remove(self):
+        self.handle.remove()

--- a/src/llamafactory/train/sft/mtp_utils.py
+++ b/src/llamafactory/train/sft/mtp_utils.py
@@ -1,0 +1,183 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from transformers.masking_utils import create_causal_mask
+
+
+try:
+    from transformers.modeling_layers import MtpModel
+except ImportError as e:
+    MtpModel = None  # type: ignore[misc,assignment]
+    _MTP_IMPORT_ERROR = e
+
+
+# Non-intrusive Multi-Token Prediction (MTP) helpers for SFT.
+# These utilities allow training MTP layers without modifying transformers model
+# files. They are used by `CustomSeq2SeqTrainer` when `num_mtp_layers > 0`.
+
+
+def extend_layer_types(config: Any, num_mtp_layers: int) -> Any:
+    r"""Extend `layer_types` so that MTP layers can be instantiated.
+
+    Models such as Qwen3.5 read `config.layer_types[layer_idx]` in their decoder
+    layer. MTP layers have `layer_idx = num_hidden_layers + k`, so we append
+    extra `"full_attention"` entries at runtime without touching any file.
+    """
+    text_config = config.get_text_config() if hasattr(config, "get_text_config") else config
+    current = list(getattr(text_config, "layer_types", []))
+    needed = text_config.num_hidden_layers + num_mtp_layers
+    if len(current) < needed:
+        current.extend(["full_attention"] * (needed - len(current)))
+        text_config.layer_types = current
+    return text_config
+
+
+def get_base_lm_model(model: torch.nn.Module) -> torch.nn.Module:
+    r"""Return the underlying language model (text tower).
+
+    This handles PeftModel wrapping and multimodal models:
+      - PeftModel -> get_base_model()
+      - Conditional generation -> base_model.language_model
+      - Causal LM -> base_model
+    """
+    if hasattr(model, "get_base_model"):
+        model = model.get_base_model()
+
+    base = getattr(model, "base_model", model)
+    return getattr(base, "language_model", base)
+
+
+def _is_mrope_config(config: Any) -> bool:
+    r"""Detect whether a model uses Multimodal RoPE (e.g. Qwen3.5)."""
+    text_config = config.get_text_config() if hasattr(config, "get_text_config") else config
+    rope_params = getattr(text_config, "rope_parameters", None)
+    return isinstance(rope_params, dict) and "mrope_section" in rope_params
+
+
+def compute_mtp_loss(
+    mtp_model: MtpModel,
+    input_ids: torch.Tensor,
+    main_hidden_states: torch.Tensor,
+    labels: torch.Tensor,
+    attention_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    r"""Teacher-forcing MTP loss computed entirely outside the base model.
+
+    Layer i consumes the embedding of token ``t+i+1`` and the previous hidden
+    state at position ``t`` to predict token ``t+i+2``.
+
+    This function works for both standard 2D RoPE models (Deepseek-V3,
+    GLM-4-MoE) and MRoPE models (Qwen3.5).
+    """
+    if MtpModel is None:
+        raise ImportError(
+            'MTP training requires `transformers>=5.14.0`, please install it via `pip install "transformers>=5.14.0"`.'
+        ) from _MTP_IMPORT_ERROR
+    batch_size, seq_len = main_hidden_states.shape[:2]
+    device = main_hidden_states.device
+
+    base_embeds = mtp_model.embed_tokens(input_ids)
+    pos = torch.arange(seq_len, device=device)
+    if _is_mrope_config(mtp_model.config):
+        # MRoPE: [4, batch_size, seq_len] where the first component is text positions
+        base_position_ids = pos.view(1, 1, -1).expand(4, batch_size, -1).clone()
+    else:
+        # Standard RoPE: [batch_size, seq_len]
+        base_position_ids = pos.unsqueeze(0).expand(batch_size, -1).clone()
+
+    total_loss = 0.0
+    current_hidden = main_hidden_states
+
+    for i in range(len(mtp_model.layers)):
+        shift = i + 1
+        shifted_embeds = torch.zeros_like(base_embeds)
+        if shift < seq_len:
+            shifted_embeds[:, :-shift, :] = base_embeds[:, shift:, :]
+
+        shifted_position_ids = base_position_ids.clone()
+        if shift < seq_len:
+            shifted_position_ids[..., :-shift] = base_position_ids[..., shift:]
+
+        # Split position ids: text positions go to the causal mask, rope positions
+        # go to the rotary embedding. For 2D RoPE these are the same tensor.
+        if shifted_position_ids.ndim == 2:
+            text_position_ids = shifted_position_ids
+            rope_position_ids = shifted_position_ids
+        else:
+            text_position_ids = shifted_position_ids[0]
+            rope_position_ids = shifted_position_ids[1:]
+
+        position_embeddings = mtp_model.rotary_emb(shifted_embeds, position_ids=rope_position_ids)
+
+        # Only shift 2D attention masks; for 4D or None fall back to a pure causal mask.
+        # Labels are -100 for padded positions so the loss ignores them.
+        if attention_mask is not None and attention_mask.dim() == 2:
+            shifted_attention_mask = torch.zeros_like(attention_mask)
+            if shift < seq_len:
+                shifted_attention_mask[:, :-shift] = attention_mask[:, shift:]
+        else:
+            shifted_attention_mask = None
+
+        causal_mask = create_causal_mask(
+            config=mtp_model.config,
+            inputs_embeds=shifted_embeds,
+            attention_mask=shifted_attention_mask,
+            past_key_values=None,
+            position_ids=text_position_ids,
+        )
+
+        current_hidden = mtp_model.layers[i](
+            inputs_embeds=shifted_embeds,
+            previous_hidden_state=current_hidden,
+            position_embeddings=position_embeddings,
+            attention_mask=causal_mask,
+            position_ids=text_position_ids,
+            past_key_values=None,
+        )
+
+        mtp_logits = mtp_model.shared_head(current_hidden)
+
+        target_shift = i + 2
+        shifted_labels = torch.full_like(labels, -100)
+        if target_shift < seq_len:
+            shifted_labels[:, :-target_shift] = labels[:, target_shift:]
+
+        layer_loss = mtp_model.loss_function(
+            mtp_logits,
+            labels,
+            vocab_size=mtp_model.config.vocab_size,
+            shift_labels=shifted_labels,
+        )
+        total_loss = total_loss + layer_loss
+
+    return total_loss / len(mtp_model.layers)
+
+
+class MtpHiddenStateHook:
+    r"""Forward hook that captures the output of the base model's final norm."""
+
+    def __init__(self, module: torch.nn.Module):
+        self.hidden: torch.Tensor | None = None
+        self.handle = module.register_forward_hook(self._hook)
+
+    def _hook(self, module, input, output):
+        self.hidden = output if isinstance(output, torch.Tensor) else output[0]
+
+    def remove(self):
+        self.handle.remove()

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -194,6 +194,7 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
 
         if self.mtp_hook is not None and "labels" in inputs:
             hidden = self.mtp_hook.hidden
+            self.mtp_hook.hidden = None
             if hidden is not None:
                 unwrapped_model = self.accelerator.unwrap_model(model)
                 mtp_model = getattr(unwrapped_model, "mtp", None)
@@ -245,10 +246,12 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
 
         unwrapped_model = self.accelerator.unwrap_model(self.model)
         mtp_model = getattr(unwrapped_model, "mtp", None)
-        if mtp_model is not None and self.is_world_process_zero():
-            mtp_dir = os.path.join(output_dir, "mtp")
-            mtp_model.save_pretrained(mtp_dir)
-            logger.info_rank0(f"Saved external MTP weights to {mtp_dir}")
+        if mtp_model is not None:
+            state_dict = self.accelerator.get_state_dict(mtp_model)
+            if self.is_world_process_zero():
+                mtp_dir = os.path.join(output_dir, "mtp")
+                mtp_model.save_pretrained(mtp_dir, state_dict=state_dict)
+                logger.info_rank0(f"Saved external MTP weights to {mtp_dir}")
 
     def save_predictions(
         self, dataset: "Dataset", predict_results: "PredictionOutput", skip_special_tokens: bool = True

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -32,7 +32,7 @@ from ...extras.constants import IGNORE_INDEX
 from ..callbacks import SaveProcessorCallback
 from ..fp8_utils import configure_fp8_environment, patch_accelerator_for_fp8, verify_fp8_status
 from ..trainer_utils import create_custom_optimizer, create_custom_scheduler
-from .mtp_utils import MtpHiddenStateHook, compute_mtp_loss_tf, extend_layer_types, get_base_lm_model
+from .mtp_utils import MtpHiddenStateHook, compute_mtp_loss, extend_layer_types, get_base_lm_model
 
 
 if TYPE_CHECKING:
@@ -190,7 +190,7 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
                 unwrapped_model = self.accelerator.unwrap_model(model)
                 mtp_model = getattr(unwrapped_model, "mtp", None)
                 if mtp_model is not None:
-                    mtp_loss = compute_mtp_loss_tf(
+                    mtp_loss = compute_mtp_loss(
                         mtp_model,
                         input_ids=inputs["input_ids"],
                         main_hidden_states=hidden,

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 import numpy as np
 import torch
 from transformers import Seq2SeqTrainer
+from transformers.modeling_layers import MtpModel
 from typing_extensions import override
 
 from ...extras import logging
@@ -31,6 +32,7 @@ from ...extras.constants import IGNORE_INDEX
 from ..callbacks import SaveProcessorCallback
 from ..fp8_utils import configure_fp8_environment, patch_accelerator_for_fp8, verify_fp8_status
 from ..trainer_utils import create_custom_optimizer, create_custom_scheduler
+from .mtp_utils import MtpHiddenStateHook, compute_mtp_loss_tf, extend_layer_types, get_base_lm_model
 
 
 if TYPE_CHECKING:
@@ -105,6 +107,27 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
                 self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
                 self.ref_model.eval()
 
+        # ------------------------------------------------------------------
+        # Non-intrusive Multi-Token Prediction (MTP) setup.
+        # Attach MtpModel to the base model before any distributed wrapping.
+        # ------------------------------------------------------------------
+        self.mtp_hook = None
+        self.mtp_loss_weight = 0.0
+        if finetuning_args.num_mtp_layers > 0:
+            if finetuning_args.use_asft_loss:
+                raise ValueError("MTP training is currently incompatible with ASFT loss.")
+
+            base_model_for_mtp = self.model.get_base_model() if hasattr(self.model, "get_base_model") else self.model
+            extend_layer_types(base_model_for_mtp.config, finetuning_args.num_mtp_layers)
+            self.model.mtp = MtpModel(base_model_for_mtp, finetuning_args.num_mtp_layers)
+            self.mtp_loss_weight = finetuning_args.mtp_loss_weight
+            text_model = get_base_lm_model(base_model_for_mtp)
+            self.mtp_hook = MtpHiddenStateHook(text_model.norm)
+            logger.info_rank0(
+                f"Attached external MtpModel with {finetuning_args.num_mtp_layers} layers, "
+                f"loss weight {self.mtp_loss_weight}."
+            )
+
         if finetuning_args.use_dft_loss:
             from ..trainer_utils import dft_loss_func
 
@@ -158,8 +181,25 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
                 ref_logits = ref_outputs.logits
             outputs = model(**inputs)
             return self.compute_loss_func(outputs, inputs["labels"], ref_logits)
-        else:
-            return super().compute_loss(model, inputs, *args, **kwargs)
+
+        base_loss = super().compute_loss(model, inputs, *args, **kwargs)
+
+        if self.mtp_hook is not None and "labels" in inputs:
+            hidden = self.mtp_hook.hidden
+            if hidden is not None:
+                unwrapped_model = self.accelerator.unwrap_model(model)
+                mtp_model = getattr(unwrapped_model, "mtp", None)
+                if mtp_model is not None:
+                    mtp_loss = compute_mtp_loss_tf(
+                        mtp_model,
+                        input_ids=inputs["input_ids"],
+                        main_hidden_states=hidden,
+                        labels=inputs["labels"],
+                        attention_mask=inputs.get("attention_mask"),
+                    )
+                    return base_loss + self.mtp_loss_weight * mtp_loss
+
+        return base_loss
 
     @override
     def prediction_step(
@@ -187,6 +227,20 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
             generated_tokens = generated_tokens.contiguous()
 
         return loss, generated_tokens, labels
+
+    @override
+    def save_model(self, output_dir: Optional[str] = None, _internal_call: bool = False):
+        r"""Save the base model as usual, plus an `mtp/` sub-directory if MTP is enabled."""
+        super().save_model(output_dir, _internal_call)
+        if output_dir is None:
+            return
+
+        unwrapped_model = self.accelerator.unwrap_model(self.model)
+        mtp_model = getattr(unwrapped_model, "mtp", None)
+        if mtp_model is not None and self.is_world_process_zero():
+            mtp_dir = os.path.join(output_dir, "mtp")
+            mtp_model.save_pretrained(mtp_dir)
+            logger.info_rank0(f"Saved external MTP weights to {mtp_dir}")
 
     def save_predictions(
         self, dataset: "Dataset", predict_results: "PredictionOutput", skip_special_tokens: bool = True

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 import numpy as np
 import torch
 from transformers import Seq2SeqTrainer
-from transformers.modeling_layers import MtpModel
 from typing_extensions import override
 
 from ...extras import logging
@@ -116,6 +115,15 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
         if finetuning_args.num_mtp_layers > 0:
             if finetuning_args.use_asft_loss:
                 raise ValueError("MTP training is currently incompatible with ASFT loss.")
+
+            try:
+                from transformers.modeling_layers import MtpModel
+            except ImportError as e:
+                raise ImportError(
+                    "MTP training requires a transformers version that provides "
+                    "`transformers.modeling_layers.MtpModel` (merged via huggingface/transformers#46229). "
+                    "Please install a compatible transformers build from source."
+                ) from e
 
             base_model_for_mtp = self.model.get_base_model() if hasattr(self.model, "get_base_model") else self.model
             extend_layer_types(base_model_for_mtp.config, finetuning_args.num_mtp_layers)

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -31,6 +31,7 @@ from ...extras.constants import IGNORE_INDEX
 from ..callbacks import SaveProcessorCallback
 from ..fp8_utils import configure_fp8_environment, patch_accelerator_for_fp8, verify_fp8_status
 from ..trainer_utils import create_custom_optimizer, create_custom_scheduler
+from .mtp_utils import MtpHiddenStateHook, compute_mtp_loss, extend_layer_types, get_base_lm_model
 
 
 if TYPE_CHECKING:
@@ -105,6 +106,35 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
                 self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
                 self.ref_model.eval()
 
+        # ------------------------------------------------------------------
+        # Non-intrusive Multi-Token Prediction (MTP) setup.
+        # Attach MtpModel to the base model before any distributed wrapping.
+        # ------------------------------------------------------------------
+        self.mtp_hook = None
+        self.mtp_loss_weight = 0.0
+        if finetuning_args.num_mtp_layers > 0:
+            if finetuning_args.use_asft_loss:
+                raise ValueError("MTP training is currently incompatible with ASFT loss.")
+
+            try:
+                from transformers.modeling_layers import MtpModel
+            except ImportError as e:
+                raise ImportError(
+                    "MTP training requires `transformers>=5.14.0`, "
+                    'please install it via `pip install "transformers>=5.14.0"`.'
+                ) from e
+
+            base_model_for_mtp = self.model.get_base_model() if hasattr(self.model, "get_base_model") else self.model
+            extend_layer_types(base_model_for_mtp.config, finetuning_args.num_mtp_layers)
+            self.model.mtp = MtpModel(base_model_for_mtp, finetuning_args.num_mtp_layers)
+            self.mtp_loss_weight = finetuning_args.mtp_loss_weight
+            text_model = get_base_lm_model(base_model_for_mtp)
+            self.mtp_hook = MtpHiddenStateHook(text_model.norm)
+            logger.info_rank0(
+                f"Attached external MtpModel with {finetuning_args.num_mtp_layers} layers, "
+                f"loss weight {self.mtp_loss_weight}."
+            )
+
         if finetuning_args.use_dft_loss:
             from ..trainer_utils import dft_loss_func
 
@@ -158,8 +188,26 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
                 ref_logits = ref_outputs.logits
             outputs = model(**inputs)
             return self.compute_loss_func(outputs, inputs["labels"], ref_logits)
-        else:
-            return super().compute_loss(model, inputs, *args, **kwargs)
+
+        base_loss = super().compute_loss(model, inputs, *args, **kwargs)
+
+        if self.mtp_hook is not None and "labels" in inputs:
+            hidden = self.mtp_hook.hidden
+            self.mtp_hook.hidden = None
+            if hidden is not None:
+                unwrapped_model = self.accelerator.unwrap_model(model)
+                mtp_model = getattr(unwrapped_model, "mtp", None)
+                if mtp_model is not None:
+                    mtp_loss = compute_mtp_loss(
+                        mtp_model,
+                        input_ids=inputs["input_ids"],
+                        main_hidden_states=hidden,
+                        labels=inputs["labels"],
+                        attention_mask=inputs.get("attention_mask"),
+                    )
+                    return base_loss + self.mtp_loss_weight * mtp_loss
+
+        return base_loss
 
     @override
     def prediction_step(
@@ -187,6 +235,22 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
             generated_tokens = generated_tokens.contiguous()
 
         return loss, generated_tokens, labels
+
+    @override
+    def save_model(self, output_dir: Optional[str] = None, _internal_call: bool = False):
+        r"""Save the base model as usual, plus an `mtp/` sub-directory if MTP is enabled."""
+        super().save_model(output_dir, _internal_call)
+        if output_dir is None:
+            return
+
+        unwrapped_model = self.accelerator.unwrap_model(self.model)
+        mtp_model = getattr(unwrapped_model, "mtp", None)
+        if mtp_model is not None:
+            state_dict = self.accelerator.get_state_dict(mtp_model)
+            if self.is_world_process_zero():
+                mtp_dir = os.path.join(output_dir, "mtp")
+                mtp_model.save_pretrained(mtp_dir, state_dict=state_dict)
+                logger.info_rank0(f"Saved external MTP weights to {mtp_dir}")
 
     def save_predictions(
         self, dataset: "Dataset", predict_results: "PredictionOutput", skip_special_tokens: bool = True


### PR DESCRIPTION
# What does this PR do?

Adds optional Multi-Token Prediction (MTP) training to the SFT trainer. When
`num_mtp_layers > 0`, an external `MtpModel` is attached to the base model and
trained with a teacher-forcing auxiliary loss. The implementation is
non-intrusive: no transformers modeling files are modified.

This works for both standard 2D RoPE models (e.g., DeepSeek-V3, GLM-4-MoE) and
MRoPE models (e.g., Qwen3.5 / Qwen3.6 dense).

## Requirements

- `transformers` must include `transformers.modeling_layers.MtpModel`, introduced
  in [huggingface/transformers#46229](https://github.com/huggingface/transformers/pull/46229).
  Until that PR is released, install from source:

  ```bash
  pip install git+https://github.com/huggingface/transformers.git
  ```
## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
