### PR TITLE
fix(data): GLM4-MOE tool_extractor never overridden, round-trip fails

### DIFF
--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -708,9 +708,30 @@ class GLM4MOEToolUtils(QwenToolUtils):
                 if not isinstance(value, str):
                     value = json.dumps(value, ensure_ascii=False)
                 prompt += "\n<arg_value>" + value + "</arg_value>"
+            prompt += "\n</tool_call>"
             function_texts.append(prompt)
 
         return "\n".join(function_texts)
+
+    @override
+    @staticmethod
+    def tool_extractor(content: str) -> Union[str, list["FunctionCall"]]:
+        regex = re.compile(r"<tool_call>\s*([^\s<>]+)\s*(.*?)\s*</tool_call>", re.DOTALL)
+        results = []
+        for func_name, params_block in re.findall(regex, content):
+            args_dict = {}
+            param_pattern = re.compile(r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>", re.DOTALL)
+            for key, raw_value in re.findall(param_pattern, params_block):
+                value = raw_value.strip()
+                try:
+                    parsed_value = json.loads(value)
+                except json.JSONDecodeError:
+                    parsed_value = raw_value.strip()
+                args_dict[key.strip()] = parsed_value
+
+            results.append(FunctionCall(func_name.strip(), json.dumps(args_dict, ensure_ascii=False)))
+
+        return results if results else content
 
 
 class SeedToolUtils(ToolUtils):

--- a/tests/data/test_formatter.py
+++ b/tests/data/test_formatter.py
@@ -380,3 +380,39 @@ def test_lfm2_tool_round_trip():
     assert len(extracted) == 1
     assert extracted[0][0] == original["name"]
     assert json.loads(extracted[0][1]) == original["arguments"]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_glm4_moe_tool_extractor_no_match():
+    formatter = ToolFormatter(tool_format="glm4_moe")
+    result = "This is a regular response without tool calls."
+    extracted = formatter.extract(result)
+    assert extracted == result
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_glm4_moe_tool_round_trip():
+    formatter = FunctionFormatter(slots=["{{content}}"], tool_format="glm4_moe")
+    tool_formatter = ToolFormatter(tool_format="glm4_moe")
+    original = {"name": "my_func", "arguments": {"arg1": "hello", "arg2": 42, "arg3": True}}
+    formatted = formatter.apply(content=json.dumps(original))
+    extracted = tool_formatter.extract(formatted[0])
+    assert len(extracted) == 1
+    assert extracted[0][0] == original["name"]
+    assert json.loads(extracted[0][1]) == original["arguments"]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_glm4_moe_multi_tool_round_trip():
+    formatter = FunctionFormatter(slots=["{{content}}"], tool_format="glm4_moe")
+    tool_formatter = ToolFormatter(tool_format="glm4_moe")
+    originals = [
+        {"name": "my_func", "arguments": {"arg1": "hello", "arg2": 42}},
+        {"name": "other_func", "arguments": {"arg3": "world"}},
+    ]
+    formatted = formatter.apply(content=json.dumps(originals))
+    extracted = tool_formatter.extract(formatted[0])
+    assert len(extracted) == 2
+    for (name, arguments), original in zip(extracted, originals):
+        assert name == original["name"]
+        assert json.loads(arguments) == original["arguments"]


### PR DESCRIPTION
## What does this PR do?

`GLM4MOEToolUtils` overrides `tool_formatter`/`function_formatter` to produce its own XML-ish format (`<tool_call>{name}\n<arg_key>...</arg_key>\n<arg_value>...</arg_value>...`, matching `GLM4_MOE_TOOL_PROMPT`), but never overrides `tool_extractor` — it inherits `QwenToolUtils.tool_extractor`, which does `json.loads()` on the `<tool_call>...</tool_call>` body. That body is never valid JSON for this format, so extraction always fails and falls through to returning the raw, unparsed string instead of `list[FunctionCall]`.

Separately, `function_formatter` never emitted the closing `</tool_call>` tag that `GLM4_MOE_TOOL_PROMPT` itself documents (`"\n...\n</tool_call>\n"`), which the new extractor needs to delimit consecutive tool calls when the model emits more than one.

```python
tu = get_tool_utils("glm4_moe")
formatted = tu.function_formatter([FunctionCall("get_weather", '{"city": "Paris"}')])
tu.tool_extractor(formatted)
# before: returns the same raw string unchanged (not parsed)
# after:  [FunctionCall(name='get_weather', arguments='{"city": "Paris"}')]
```

Confirmed this is live, registered code: `"glm4_moe"` is in the `TOOLS` registry and wired into multiple real templates in `src/llamafactory/data/template.py` — not experimental/dead code. Any chat inference using a glm4_moe-family template with tool calling currently cannot parse the model's own generated tool calls back into structured `FunctionCall`s.

## Fix

- Add a `tool_extractor` override to `GLM4MOEToolUtils`, mirroring the regex-based extraction pattern already used by sibling classes (`MiniMaxM2ToolUtils`/`Qwen35ToolUtils`) for their own XML-ish formats: match `<tool_call>NAME ... </tool_call>` blocks, then pull `<arg_key>/<arg_value>` pairs out of each block (with a `json.loads` attempt per value, falling back to the raw string — same convention as the sibling extractors).
- Add the missing closing `</tool_call>` tag in `function_formatter`.

## Tests

Added to `tests/data/test_formatter.py` (mirroring the existing `test_lfm2_tool_*` pattern):
- `test_glm4_moe_tool_extractor_no_match` — plain content without a tool call still passes through unchanged.
- `test_glm4_moe_tool_round_trip` — single tool call round-trips through `function_formatter` → `tool_extractor`.
- `test_glm4_moe_multi_tool_round_trip` — two consecutive tool calls both extract correctly (exercises the closing-tag fix, since without it the regex over-greedily spans both calls).

Verified red on `main` (`git stash` the `tool_utils.py` change): both round-trip tests fail with the exact symptom above (`assert len(extracted) == 1` sees a raw string's length instead). Green after the fix. Full `tests/data/test_formatter.py` + `tests/data/test_template.py` (65 passed, 3 skipped, 3 xpassed) — no regressions. `ruff check` and `ruff format --check` clean on both touched files.

## Duplicate-work check

Searched open/closed PRs and issues for `GLM4MOEToolUtils`/`glm4_moe tool_call` — no overlap found. (Note: while investigating I found this repo already has several excellent open PRs from @he-yufeng fixing closely related tool-call round-trip bugs in sibling classes, e.g. #10586 for MiniMax-M2 — I cross-checked all of those diffs and none touch `GLM4MOEToolUtils`.)

---
This PR was drafted with AI assistance (Claude); I independently reproduced the bug against the real, unmodified module and verified the fix. I reviewed the change and take responsibility for it.