### PR TITLE
fix(data): read_cloud_json breaks on GCS directory listings

### DIFF
--- a/src/llamafactory/data/data_utils.py
+++ b/src/llamafactory/data/data_utils.py
@@ -195,7 +195,9 @@ def read_cloud_json(cloud_path: str) -> list[Any]:
         fs = setup_fs(cloud_path)  # try again with credentials
 
     # filter out non-JSON files
-    files = [x["Key"] for x in fs.listdir(cloud_path)] if fs.isdir(cloud_path) else [cloud_path]
+    # "name" is the fsspec-standard field populated by every backend's listdir() (s3fs sets both
+    # "Key" and "name"; gcsfs only sets "name"), unlike "Key" which is an S3-only convenience alias.
+    files = [x["name"] for x in fs.listdir(cloud_path)] if fs.isdir(cloud_path) else [cloud_path]
     files = list(filter(lambda file: file.endswith(".json") or file.endswith(".jsonl"), files))
     if not files:
         raise ValueError(f"No JSON/JSONL files found in the specified path: {cloud_path}.")

--- a/tests/data/test_data_utils.py
+++ b/tests/data/test_data_utils.py
@@ -1,0 +1,40 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llamafactory.data.data_utils import read_cloud_json
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_read_cloud_json_directory_listing_uses_fsspec_standard_name_field():
+    # Both s3fs and gcsfs populate "name" on every listdir() entry; only s3fs also sets the
+    # S3-specific "Key" alias. Using "Key" breaks GCS directory listings with a bare KeyError.
+    mock_fs = MagicMock()
+    mock_fs.isdir.return_value = True
+    mock_fs.listdir.return_value = [
+        {"name": "my-bucket/data/train.jsonl", "size": 123, "type": "file"},
+        {"name": "my-bucket/data/README.md", "size": 45, "type": "file"},
+    ]
+
+    with (
+        patch("llamafactory.data.data_utils.setup_fs", return_value=mock_fs),
+        patch("llamafactory.data.data_utils._read_json_with_fs", return_value=[{"text": "hello"}]) as mock_read,
+    ):
+        result = read_cloud_json("gs://my-bucket/data/")
+
+    mock_read.assert_called_once_with(mock_fs, "my-bucket/data/train.jsonl")
+    assert result == [{"text": "hello"}]


### PR DESCRIPTION
## What does this PR do?

`read_cloud_json()`'s directory-listing branch reads the `"Key"` field off each `fs.listdir()` entry:

```python
files = [x["Key"] for x in fs.listdir(cloud_path)] if fs.isdir(cloud_path) else [cloud_path]
```

`"Key"` is an s3fs-specific convenience alias (`s3fs/core.py`: `f["Key"] = "/".join([bucket, f["Key"]])`, then `f["name"] = f["Key"]`). `gcsfs`'s `_process_object()` only ever sets `"name"` (never `"Key"`). So a GCS **directory** path (`gs://`/`gcs://`) raises a bare `KeyError: 'Key'` — single-file GCS paths work fine since the `fs.isdir` ternary skips `listdir()` entirely, but the directory case, which the docstring explicitly advertises support for, is broken.

```python
# gcsfs directory listing entry (real shape, verified against installed gcsfs source):
# {'name': 'my-bucket/data/train.jsonl', 'size': 123, 'type': 'file'}  -- no "Key" key at all
read_cloud_json("gs://my-bucket/data/")  # before: KeyError: 'Key'
```

`"name"` is the fsspec cross-backend standard field present on **every** backend's `listdir()`/`ls()` output (s3fs sets both `"Key"` and `"name"`; gcsfs sets only `"name"`), so switching to `x["name"]` fixes GCS without touching S3 behavior.

Reachable via `data/loader.py:129` whenever a `dataset_info.json` entry sets `load_from: "cloud_file"` without a specific file name (a documented feature per `data/README.md`).

## Fix

One-line change: `x["Key"]` → `x["name"]`.

## Tests

Added `tests/data/test_data_utils.py` (new file — no existing test covered `read_cloud_json`) with a test that mocks `setup_fs` to return a filesystem whose `listdir()` output matches gcsfs's real shape (`"name"` only, no `"Key"`), and asserts the correct file gets picked up and read. Verified red on `main` (`git stash` the fix): `KeyError: 'Key'`, matching the bug exactly. Green after. `ruff check`/`ruff format --check` clean; `tests/check_license.py` clean (new file has the Apache-2.0 header).

## Duplicate-work check

Searched open PRs for `data_utils.py`/`read_cloud_json` — none found.

---
This PR was drafted with AI assistance (Claude); I independently reproduced the bug against the real, unmodified module (and verified both s3fs's and gcsfs's actual listdir field names against the installed library source) and verified the fix. I reviewed the change and take responsibility for it.