### PR TITLE
Surface warning instead of swallowing profiler activity errors (TorchProfilerCallback)

### DIFF
--- a/src/llamafactory/train/callbacks.py
+++ b/src/llamafactory/train/callbacks.py
@@ -390,9 +390,16 @@ class TorchProfilerCallback(TrainerCallback):
             if is_torch_cuda_available():
                 activities.append(torch.profiler.ProfilerActivity.CUDA)
             if is_torch_npu_available():
-                activities.append(torch.profiler.ProfilerActivity.NPU)
-        except Exception:
-            pass
+                npu_activity = getattr(torch.profiler.ProfilerActivity, "NPU", None)
+                if npu_activity is not None:
+                    activities.append(npu_activity)
+                else:
+                    logger.warning_rank0(
+                        "NPU device detected but current torch build has no `ProfilerActivity.NPU`; "
+                        "NPU profiling disabled. Upgrade torch to enable NPU traces."
+                    )
+        except Exception as e:
+            logger.warning_rank0(f"Failed to add device profiler activities: {e}.")
 
         self.profiler = torch.profiler.profile(
             activities=activities,

--- a/tests/train/test_torch_profiler_callback.py
+++ b/tests/train/test_torch_profiler_callback.py
@@ -9,7 +9,7 @@
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and,
+# See the License for the specific language governing permissions and
 # limitations under the License.
 
 from dataclasses import dataclass
@@ -32,8 +32,13 @@ class _FakeArgs:
     profiler_with_stack: bool = False
 
 
+@dataclass
+class _FakeTrainArgs:
+    output_dir: str = ""
+
+
 @pytest.mark.runs_on(["cpu", "mps"])
-def test_profiler_callback_warns_missing_npu_activity(monkeypatch, caplog):
+def test_profiler_callback_warns_missing_npu_activity(monkeypatch, caplog, tmp_path):
     r"""``TorchProfilerCallback.on_train_begin`` should not crash if the installed
     torch build lacks ``ProfilerActivity.NPU`` (older torch shipped without NPU).
 
@@ -45,8 +50,6 @@ def test_profiler_callback_warns_missing_npu_activity(monkeypatch, caplog):
     """
     from llamafactory.train import callbacks as cb_mod
 
-    # Force the code path that thinks NPU is available, then attempt to access the
-    # enum value — which we make missing via a fake ProfilerActivity class.
     monkeypatch.setattr(cb_mod, "is_torch_npu_available", lambda: True)
     monkeypatch.setattr(cb_mod, "is_torch_cuda_available", lambda: False)
 
@@ -63,11 +66,7 @@ def test_profiler_callback_warns_missing_npu_activity(monkeypatch, caplog):
 
     with caplog.at_level(logging.WARNING, logger="llamafactory"):
         try:
-            callback.on_train_begin(
-                args=type("A", (), {"output_dir": "/tmp/opencode_test_prof_no_npu"})(),
-                state=type("S", (), {})(),
-                control=None,
-            )
+            callback.on_train_begin(args=_FakeTrainArgs(output_dir=str(tmp_path)), state=type("S", (), {})(), control=None)
         finally:
             if getattr(callback, "profiler", None) is not None:
                 callback.profiler.stop()
@@ -77,19 +76,26 @@ def test_profiler_callback_warns_missing_npu_activity(monkeypatch, caplog):
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
-def test_profiler_callback_handles_failed_activity(monkeypatch, caplog):
-    r"""If appending a profiler activity raises for any reason, the callback must
-    log a warning instead of silently swallowing the error.
+def test_profiler_callback_handles_failed_activity(monkeypatch, caplog, tmp_path):
+    r"""If accessing a ``ProfilerActivity`` member raises for any reason, the
+    callback must log a warning instead of silently swallowing the error.
+
+    Uses a metaclass with ``__getattribute__`` so that *accessing* ``CUDA`` or
+    ``NPU`` raises — a plain function-valued class attribute would just return
+    the function object without invoking it, masking the very code path we want
+    to exercise (the broad ``except Exception``).
     """
 
-    def boom():
-        raise RuntimeError("simulated torch issue")
+    class _BoomMeta(type):
+        def __getattribute__(cls, name):
+            if name in ("CUDA", "NPU"):
+                raise RuntimeError("simulated torch issue")
+            return super().__getattribute__(name)
 
-    monkeypatch.setattr(
-        torch.profiler,
-        "ProfilerActivity",
-        type("Boom", (), {"CPU": torch.profiler.ProfilerActivity.CPU, "CUDA": boom, "NPU": boom}),
-    )
+    class _Boom(metaclass=_BoomMeta):
+        CPU = torch.profiler.ProfilerActivity.CPU
+
+    monkeypatch.setattr(torch.profiler, "ProfilerActivity", _Boom)
 
     from llamafactory.train import callbacks as cb_mod
 
@@ -102,11 +108,7 @@ def test_profiler_callback_handles_failed_activity(monkeypatch, caplog):
 
     with caplog.at_level(logging.WARNING, logger="llamafactory"):
         try:
-            callback.on_train_begin(
-                args=type("A", (), {"output_dir": "/tmp/opencode_test_prof_boom"})(),
-                state=type("S", (), {})(),
-                control=None,
-            )
+            callback.on_train_begin(args=_FakeTrainArgs(output_dir=str(tmp_path)), state=type("S", (), {})(), control=None)
         finally:
             if getattr(callback, "profiler", None) is not None:
                 callback.profiler.stop()

--- a/tests/train/test_torch_profiler_callback.py
+++ b/tests/train/test_torch_profiler_callback.py
@@ -1,0 +1,119 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and,
+# limitations under the License.
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from llamafactory.train.callbacks import TorchProfilerCallback
+
+
+@dataclass
+class _FakeArgs:
+    profiler_output_dir: str = None
+    profiler_wait_steps: int = 0
+    profiler_warmup_steps: int = 0
+    profiler_active_steps: int = 1
+    profiler_repeat: int = 1
+    profiler_record_shapes: bool = False
+    profiler_profile_memory: bool = False
+    profiler_with_stack: bool = False
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_profiler_callback_warns_missing_npu_activity(monkeypatch, caplog):
+    r"""``TorchProfilerCallback.on_train_begin`` should not crash if the installed
+    torch build lacks ``ProfilerActivity.NPU`` (older torch shipped without NPU).
+
+    Before the fix, the broad ``except Exception: pass`` silently swallowed the
+    ``AttributeError``, leaving the user with no NPU traces and no warning.
+
+    After the fix, the warning ``"... ProfilerActivity.NPU" ...`` is surfaced so
+    the user can see why NPU tracing is disabled.
+    """
+    from llamafactory.train import callbacks as cb_mod
+
+    # Force the code path that thinks NPU is available, then attempt to access the
+    # enum value — which we make missing via a fake ProfilerActivity class.
+    monkeypatch.setattr(cb_mod, "is_torch_npu_available", lambda: True)
+    monkeypatch.setattr(cb_mod, "is_torch_cuda_available", lambda: False)
+
+    class _NoNPUActivity:
+        CPU = torch.profiler.ProfilerActivity.CPU
+        CUDA = torch.profiler.ProfilerActivity.CUDA
+        # deliberately omit NPU
+
+    monkeypatch.setattr(torch.profiler, "ProfilerActivity", _NoNPUActivity())
+
+    callback = TorchProfilerCallback(_FakeArgs())
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="llamafactory"):
+        try:
+            callback.on_train_begin(
+                args=type("A", (), {"output_dir": "/tmp/opencode_test_prof_no_npu"})(),
+                state=type("S", (), {})(),
+                control=None,
+            )
+        finally:
+            if getattr(callback, "profiler", None) is not None:
+                callback.profiler.stop()
+
+    messages = " ".join(record.message for record in caplog.records)
+    assert "ProfilerActivity.NPU" in messages
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_profiler_callback_handles_failed_activity(monkeypatch, caplog):
+    r"""If appending a profiler activity raises for any reason, the callback must
+    log a warning instead of silently swallowing the error.
+    """
+
+    def boom():
+        raise RuntimeError("simulated torch issue")
+
+    monkeypatch.setattr(
+        torch.profiler,
+        "ProfilerActivity",
+        type("Boom", (), {"CPU": torch.profiler.ProfilerActivity.CPU, "CUDA": boom, "NPU": boom}),
+    )
+
+    from llamafactory.train import callbacks as cb_mod
+
+    monkeypatch.setattr(cb_mod, "is_torch_cuda_available", lambda: True)
+    monkeypatch.setattr(cb_mod, "is_torch_npu_available", lambda: False)
+
+    callback = TorchProfilerCallback(_FakeArgs())
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="llamafactory"):
+        try:
+            callback.on_train_begin(
+                args=type("A", (), {"output_dir": "/tmp/opencode_test_prof_boom"})(),
+                state=type("S", (), {})(),
+                control=None,
+            )
+        finally:
+            if getattr(callback, "profiler", None) is not None:
+                callback.profiler.stop()
+
+    messages = " ".join(record.message for record in caplog.records)
+    assert "Failed to add device profiler activities" in messages
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

`TorchProfilerCallback.on_train_begin` built the list of profiler activities with
a broad `try / except Exception: pass` that silently swallowed any error:

```python
activities = [torch.profiler.ProfilerActivity.CPU]
try:
    if is_torch_cuda_available():
        activities.append(torch.profiler.ProfilerActivity.CUDA)
    if is_torch_npu_available():
        activities.append(torch.profiler.ProfilerActivity.NPU)
except Exception:
    pass
```

This had two real consequences:

1. **Older torch builds ship without `ProfilerActivity.NPU`** (e.g. CUDA-only
   wheels, torch < 2.1). When `is_torch_npu_available()` returns `True` but the
   enum member is missing, the previous code raised `AttributeError` and
   silently caught it — leaving the user with only CPU traces and *no warning*
   that NPU profiling wasn't actually collected.
2. **Any future failure** (e.g. an upcoming `ProfilerActivity` name change, an
   import-time torch regression on ROCm/MPS) would be silently hidden, making
   "why is my profiler empty?" very hard to debug.

## Fix

1. **Detect the missing enum attribute explicitly** via
   `getattr(torch.profiler.ProfilerActivity, "NPU", None)`. If the attribute is
   missing, surface a `logger.warning_rank0` so the user knows NPU traces won't
   be collected.
2. **Replace the bare `except Exception: pass`** with
   `except Exception as e: logger.warning_rank0(...)`. The catch is kept (so the
   profiler still launches with whatever activities succeeded) but the error
   message is visible so users can diagnose rather than staring at empty traces.

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| NPU detected, torch has `ProfilerActivity.NPU` | NPU traces added | NPU traces added (unchanged) |
| NPU detected, torch lacks `ProfilerActivity.NPU` | `AttributeError` swallowed, only CPU traces, no message | Warning logged, CPU traces only |
| Any other exception inside the try block | Silently swallowed | Warning logged with exception text |
| CUDA/NPU both unavailable (CPU torch) | No try block entered | No try block entered (unchanged) |

## Tests

Added `tests/train/test_torch_profiler_callback.py` with two CPU-only tests
that monkeypatch `torch.profiler.ProfilerActivity`:

- `test_profiler_callback_warns_missing_npu_activity`: forces
  `is_torch_npu_available()` to return `True` while replacing `ProfilerActivity`
  with a class that has no `NPU` member. Asserts the warning mentioning
  `ProfilerActivity.NPU` is logged and the callback does not raise.
- `test_profiler_callback_handles_failed_activity`: forces
  `ProfilerActivity.CUDA` / `.NPU` access to raise `RuntimeError`. Asserts the
  warning `Failed to add device profiler activities` is logged.

Both tests use `@pytest.mark.runs_on(["cpu", "mps"])` and require no model
download (matching the existing test style).

## Files Changed

| File | Lines +/− | Risk |
|------|-----------|------|
| `src/llamafactory/train/callbacks.py` | +10 / -3 | Additive, only surfaces warnings — no behavior change for working configs |
| `tests/train/test_torch_profiler_callback.py` | +129 / 0 | New file, CPU-only |

## Verification

- `python3 -m py_compile` passes for both files.
- The missing-NPU-enum scenario is reproducible on this machine (CUDA-only
  torch build, `ProfilerActivity.NPU` does not exist) — the fix path runs and
  emits the expected warning.

## Backward Compatibility

No public API surface change. Configs that previously silently fell back to
CPU-only profiling now log a warning — the actual profiling output is
unchanged. Users who relied on silent CPU-only fallback are unaffected.
