### PR TITLE
[data] fix: escape string arguments in LFM2 function_formatter

### DIFF
--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -798,10 +798,9 @@ class LFM2ToolUtils(ToolUtils):
             args = json.loads(args_json)
             kwargs_parts = []
             for key, value in args.items():
-                if isinstance(value, str):
-                    kwargs_parts.append(f'{key}="{value}"')
-                else:
-                    kwargs_parts.append(f"{key}={json.dumps(value, ensure_ascii=False)}")
+                # json.dumps produces a correctly-escaped, double-quoted literal for strings
+                # too; raw f'{key}="{value}"' interpolation broke on quotes/newlines/backslashes.
+                kwargs_parts.append(f"{key}={json.dumps(value, ensure_ascii=False)}")
 
             calls.append(f"{name}({', '.join(kwargs_parts)})")
 

--- a/tests/data/test_formatter.py
+++ b/tests/data/test_formatter.py
@@ -380,3 +380,17 @@ def test_lfm2_tool_round_trip():
     assert len(extracted) == 1
     assert extracted[0][0] == original["name"]
     assert json.loads(extracted[0][1]) == original["arguments"]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_lfm2_tool_round_trip_special_characters():
+    # String arguments with quotes/newlines/backslashes used to be interpolated raw,
+    # producing invalid Python that the extractor then failed to parse.
+    formatter = FunctionFormatter(slots=["{{content}}"], tool_format="lfm2")
+    tool_formatter = ToolFormatter(tool_format="lfm2")
+    original = {"name": "my_func", "arguments": {"text": 'he said "hi"\nnext line', "path": "C:\\tmp"}}
+    formatted = formatter.apply(content=json.dumps(original))
+    extracted = tool_formatter.extract(formatted[0])
+    assert len(extracted) == 1
+    assert extracted[0][0] == original["name"]
+    assert json.loads(extracted[0][1]) == original["arguments"]


### PR DESCRIPTION
## What does this PR do?

`LFM2ToolUtils.function_formatter` (`src/llamafactory/data/tool_utils.py`) interpolates string argument values **raw** into double quotes:

```python
if isinstance(value, str):
    kwargs_parts.append(f'{key}="{value}"')   # no escaping
```

Any legal string argument containing a `"`, a newline, or a backslash produces syntactically-invalid Python in the emitted `fn(key="value")` call:

```
he said "hi"      -> f(text="he said "hi"")   # unbalanced quotes
line1\nline2       -> f(text="line1<newline>")   # literal newline
C:\path            -> SyntaxWarning: invalid escape sequence
```

This corrupts SFT **training targets** built via the `lfm2` template's `FunctionFormatter`, and at inference the `tool_extractor` (`ast.parse`) then fails to parse the call and drops it entirely (returns raw content).

## Fix

`json.dumps` already produces a correctly-escaped, double-quoted Python-compatible literal for strings too — and matches the existing test output byte-for-byte (`foo="bar"`, `size=10`) — so use it for all values and drop the raw-string branch.

## Test

Added `test_lfm2_tool_round_trip_special_characters` (quotes / newline / backslash round-trip). It fails before the fix and passes after; all existing LFM2 formatter tests are unchanged.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

Prepared with AI assistance and reviewed before submission.