### PR TITLE
[data] fix: OpenAIDatasetConverter drops trailing tool responses

### DIFF
--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -282,6 +282,18 @@ class OpenAIDatasetConverter(DatasetConverter):
                 }
             )
 
+        # Flush trailing tool responses (a conversation that ends on observation messages)
+        # which the in-loop flush above only handles when a later non-observation message follows.
+        if len(tool_responses) > 0:
+            _content = "\n</tool_response>\n<tool_response>\n".join(tool_responses)
+            aligned_messages.append(
+                {
+                    "role": Role.OBSERVATION.value,
+                    "content": _content,
+                }
+            )
+            tool_responses = []
+
         odd_tags = (Role.USER.value, Role.OBSERVATION.value)
         even_tags = (Role.ASSISTANT.value, Role.FUNCTION.value)
         accept_tags = (odd_tags, even_tags)

--- a/tests/data/test_converter.py
+++ b/tests/data/test_converter.py
@@ -62,3 +62,58 @@ def test_sharegpt_converter():
         "_videos": None,
         "_audios": None,
     }
+
+
+def _openai_dataset_attr() -> DatasetAttr:
+    dataset_attr = DatasetAttr("hf_hub", "x", formatting="openai")
+    dataset_attr.messages = "messages"
+    dataset_attr.role_tag = "role"
+    dataset_attr.content_tag = "content"
+    dataset_attr.user_tag = "user"
+    dataset_attr.assistant_tag = "assistant"
+    dataset_attr.observation_tag = "tool"
+    dataset_attr.function_tag = "function"
+    dataset_attr.system_tag = "system"
+    return dataset_attr
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_openai_converter_skips_conversation_ending_on_tool_response():
+    converter = get_dataset_converter("openai", _openai_dataset_attr(), DataArguments())
+    example = {
+        "messages": [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"function": {"name": "get_weather", "arguments": "{}"}}],
+            },
+            {"role": "tool", "content": "Sunny, 25C"},
+        ]
+    }
+    result = converter(example)
+    # The trailing tool response makes this an incomplete tool cycle; it must be skipped,
+    # not silently truncated into [user] -> [tool_call] (which dropped the tool response).
+    assert result["_prompt"] == []
+    assert result["_response"] == []
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_openai_converter_keeps_completed_tool_cycle():
+    converter = get_dataset_converter("openai", _openai_dataset_attr(), DataArguments())
+    example = {
+        "messages": [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"function": {"name": "get_weather", "arguments": "{}"}}],
+            },
+            {"role": "tool", "content": "Sunny, 25C"},
+            {"role": "assistant", "content": "It is sunny, 25C."},
+        ]
+    }
+    result = converter(example)
+    all_content = str(result["_prompt"]) + str(result["_response"])
+    assert "Sunny, 25C" in all_content
+    assert result["_response"][-1] == {"role": Role.ASSISTANT.value, "content": "It is sunny, 25C."}


### PR DESCRIPTION
## What does this PR do?

In `OpenAIDatasetConverter` (`src/llamafactory/data/converter.py`), accumulated `tool_responses` are only flushed into `aligned_messages` when a **non-observation** message follows (the in-loop `elif len(tool_responses) > 0` branch). A conversation that **ends on** observation message(s) never flushes them:

```
[user, assistant(tool_call), tool]   # ends on a tool response
# before: aligned = [user, function]         -> even count passes -> trained as a truncated example
#         (the tool response 'Sunny, 25C' is silently dropped)
# after:  aligned = [user, function, tool]   -> odd count -> flagged incomplete -> skipped
```

So the tool response is silently discarded, and the truncated list can pass the even-count check and be **trained on** instead of being flagged as incomplete and skipped. The ShareGPT converter already skips such odd-length cases; this makes OpenAI consistent.

## Fix

Add a post-loop flush mirroring the in-loop one.

## Test

Added `test_openai_converter_skips_conversation_ending_on_tool_response` (incomplete cycle → skipped, was silently truncated) and `test_openai_converter_keeps_completed_tool_cycle` (a completed cycle still keeps the tool response + final answer). The first fails before the fix and passes after.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

Note: open PR #10578 (ShareGPT tool-observation merge) adopts the same accumulation pattern and would benefit from the same post-loop flush.

Prepared with AI assistance and reviewed before submission.