### PR TITLE
Fix packed position IDs in multimodal collator

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -321,6 +321,23 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                 f"got {features['position_ids'].shape}, expected {expected_position_ids_shape}."
             )
 
+    def _align_position_ids_with_input_ids(self, features: dict[str, "torch.Tensor"]) -> None:
+        r"""Pad position ids to the input length after the tokenizer collator runs."""
+        if "position_ids" not in features:
+            return
+
+        input_seq_len = features["input_ids"].size(-1)
+        position_seq_len = features["position_ids"].size(-1)
+        if position_seq_len > input_seq_len:
+            raise ValueError(f"position_ids length ({position_seq_len}) exceeds input_ids length ({input_seq_len}).")
+
+        pad_len = input_seq_len - position_seq_len
+        if pad_len == 0:
+            return
+
+        padding = (0, pad_len) if self.tokenizer.padding_side == "right" else (pad_len, 0)
+        features["position_ids"] = F.pad(features["position_ids"], padding, value=0)
+
     def __call__(self, features: list[dict[str, Any]]) -> dict[str, "torch.Tensor"]:
         batch_images, batch_videos, batch_audios = [], [], []
         batch_imglens, batch_vidlens, batch_audlens, batch_input_ids = [], [], [], []
@@ -378,10 +395,14 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                 features[0]["input_ids"] = features[0]["input_ids"] + fake_input_ids
                 features[0]["attention_mask"] = features[0]["attention_mask"] + [0] * len(fake_input_ids)
                 features[0]["labels"] = features[0]["labels"] + [IGNORE_INDEX] * len(fake_input_ids)
+                if "position_ids" in features[0]:
+                    features[0]["position_ids"] = features[0]["position_ids"] + [0] * len(fake_input_ids)
             else:
                 features[0]["input_ids"] = fake_input_ids + features[0]["input_ids"]
                 features[0]["attention_mask"] = [0] * len(fake_input_ids) + features[0]["attention_mask"]
                 features[0]["labels"] = [IGNORE_INDEX] * len(fake_input_ids) + features[0]["labels"]
+                if "position_ids" in features[0]:
+                    features[0]["position_ids"] = [0] * len(fake_input_ids) + features[0]["position_ids"]
 
             batch_input_ids[0] = features[0]["input_ids"]
 
@@ -414,6 +435,7 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
             mm_inputs["mm_token_type_ids"] = torch.tensor(padded, dtype=torch.long)
 
         features: dict[str, torch.Tensor] = super().__call__(features)
+        self._align_position_ids_with_input_ids(features)
 
         bsz, seq_len = features["input_ids"].shape[:2]
         model_type = getattr(self.model.config, "model_type", None) if self.model is not None else None

--- a/tests/data/test_collator.py
+++ b/tests/data/test_collator.py
@@ -137,6 +137,100 @@ def test_multimodal_collator():
         assert batch_input[k].eq(torch.tensor(expected_input[k])).all()
 
 
+@pytest.mark.parametrize(
+    ("padding_side", "expected_position_ids"),
+    [
+        ("right", [[0, 1, 2, 0, 0]]),
+        ("left", [[0, 0, 0, 1, 2]]),
+    ],
+)
+def test_align_position_ids_with_input_ids(padding_side, expected_position_ids):
+    data_collator = object.__new__(MultiModalDataCollatorForSeq2Seq)
+    data_collator.tokenizer = type("Tokenizer", (), {"padding_side": padding_side})()
+    features = {
+        "input_ids": torch.tensor([[10, 11, 12, 13, 14]]),
+        "position_ids": torch.tensor([[0, 1, 2]]),
+    }
+
+    data_collator._align_position_ids_with_input_ids(features)
+
+    assert features["position_ids"].eq(torch.tensor(expected_position_ids)).all()
+
+
+def test_align_position_ids_rejects_longer_sequence():
+    data_collator = object.__new__(MultiModalDataCollatorForSeq2Seq)
+    data_collator.tokenizer = type("Tokenizer", (), {"padding_side": "right"})()
+    features = {
+        "input_ids": torch.tensor([[10, 11]]),
+        "position_ids": torch.tensor([[0, 1, 2]]),
+    }
+
+    with pytest.raises(ValueError, match="position_ids length .* exceeds input_ids length"):
+        data_collator._align_position_ids_with_input_ids(features)
+
+
+def test_multimodal_collator_aligns_packed_position_ids_after_fake_image():
+    class DummyTokenizer:
+        padding_side = "right"
+        pad_token_id = 0
+
+        def encode(self, text, add_special_tokens=False):
+            return [20, 21]
+
+        def pad(self, features, padding, max_length, pad_to_multiple_of, return_tensors):
+            target_length = max(len(feature["input_ids"]) for feature in features)
+            target_length = ((target_length + pad_to_multiple_of - 1) // pad_to_multiple_of) * pad_to_multiple_of
+            batch = {}
+            for key in features[0]:
+                values = []
+                for feature in features:
+                    value = feature[key]
+                    if key == "input_ids":
+                        value = value + [self.pad_token_id] * (target_length - len(value))
+                    elif key == "attention_mask":
+                        value = value + [0] * (target_length - len(value))
+
+                    values.append(value)
+
+                batch[key] = torch.tensor(values)
+
+            return batch
+
+    class DummyMMPlugin:
+        image_token = "<image>"
+        audio_token = None
+
+        def process_messages(self, messages, images, videos, audios, processor):
+            return messages
+
+        def process_token_ids(self, input_ids, labels, images, videos, audios, tokenizer, processor):
+            return input_ids, labels
+
+        def get_mm_inputs(self, images, videos, audios, imglens, vidlens, audlens, input_ids, processor):
+            return {}
+
+    template = type("Template", (), {"mm_plugin": DummyMMPlugin()})()
+    data_collator = MultiModalDataCollatorForSeq2Seq(
+        tokenizer=DummyTokenizer(),
+        template=template,
+        pad_to_multiple_of=8,
+        label_pad_token_id=IGNORE_INDEX,
+    )
+    features = [
+        {
+            "input_ids": [10, 11, 12],
+            "attention_mask": [1, 1, 1],
+            "position_ids": [0, 1, 2],
+            "labels": [10, 11, 12],
+        }
+    ]
+
+    batch = data_collator(features)
+
+    assert batch["input_ids"].shape == batch["position_ids"].shape == (1, 8)
+    assert batch["position_ids"].eq(torch.tensor([[0, 1, 2, 0, 0, 0, 0, 0]])).all()
+
+
 def _make_packed_feature(
     *,
     packing_params: dict,


### PR DESCRIPTION
## Summary

- extend packed `position_ids` when the multimodal collator injects fake image/audio tokens
- align `position_ids` with the tokenizer-padded `input_ids` length, respecting left/right padding
- reject unexpectedly longer `position_ids` instead of silently truncating them

Fixes #10659.

## Why

With `packing: true`, the supervised processor supplies `position_ids`. For text-only batches using a multimodal template, fake multimodal tokens extend `input_ids`, and `pad_to_multiple_of` can extend them again. Neither operation previously extended the supplied `position_ids`, producing the Llama-4 rotary embedding length mismatch.

## Tests

- `ruff check src/llamafactory/data/collator.py tests/data/test_collator.py`
- `ruff format --check src/llamafactory/data/collator.py tests/data/test_collator.py`
- `pytest -q --import-mode=importlib tests/data/test_collator.py -k "align_position_ids or aligns_packed_position_ids_after_fake_image or 4d_attention_mask"` (`5 passed, 3 deselected`)

Full model training was not run because it requires the gated Llama-4 checkpoint and multi-GPU setup from the report.

## AI assistance

Codex assisted with issue analysis, implementation, and regression-test drafting. I reviewed the diff and ran the checks listed above.