### PR TITLE
fix: coerce unsloth target_modules for composite VLMs

### DIFF
--- a/src/llamafactory/model/model_utils/unsloth.py
+++ b/src/llamafactory/model/model_utils/unsloth.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from ...extras import logging
 from ...extras.misc import get_current_device
+from .visual import COMPOSITE_MODELS
 
 
 if TYPE_CHECKING:
@@ -65,11 +66,38 @@ def load_unsloth_pretrained_model(
     return model
 
 
+def _coerce_unsloth_target_modules(model: "PreTrainedModel", target_modules: list[str]) -> list[str]:
+    r"""Convert expanded VLM target modules back to leaf names for unsloth.
+
+    For composite VLMs, `patch_target_modules` expands short target names (e.g. `out_proj`) into
+    full module paths (e.g. `model.language_model.layers.0.linear_attn.out_proj`) so that standard
+    PEFT can exclude frozen submodules like the vision tower. Unsloth's `get_peft_regex`, however,
+    treats every entry in `target_modules` as a leaf name and matches modules ending in it, so a full
+    path never matches and no layers get adapters. Reduce back to unique leaf names in that case.
+    """
+    if isinstance(target_modules, str):
+        target_modules = [target_modules]
+    elif isinstance(target_modules, set):
+        target_modules = list(target_modules)
+
+    model_type = getattr(model.config, "model_type", None)
+    if model_type not in COMPOSITE_MODELS or not target_modules:
+        return target_modules
+
+    if all("." not in name for name in target_modules):
+        return target_modules
+
+    return sorted({name.rsplit(".", 1)[-1] for name in target_modules})
+
+
 def get_unsloth_peft_model(
     model: "PreTrainedModel", model_args: "ModelArguments", peft_kwargs: dict[str, Any]
 ) -> "PreTrainedModel":
     r"""Get the peft model for the pretrained model with unsloth. Used in training."""
     from unsloth import FastLanguageModel  # type: ignore
+
+    if "target_modules" in peft_kwargs:
+        peft_kwargs["target_modules"] = _coerce_unsloth_target_modules(model, peft_kwargs["target_modules"])
 
     unsloth_peft_kwargs = {
         "model": model,

--- a/src/llamafactory/model/model_utils/unsloth.py
+++ b/src/llamafactory/model/model_utils/unsloth.py
@@ -66,14 +66,15 @@ def load_unsloth_pretrained_model(
     return model
 
 
-def _coerce_unsloth_target_modules(model: "PreTrainedModel", target_modules: list[str]) -> list[str]:
-    r"""Convert expanded VLM target modules back to leaf names for unsloth.
+def _coerce_unsloth_target_modules(model: "PreTrainedModel", target_modules: list[str] | set[str] | str) -> list[str]:
+    r"""Convert expanded language-model target paths back to leaf names for unsloth.
 
     For composite VLMs, `patch_target_modules` expands short target names (e.g. `out_proj`) into
     full module paths (e.g. `model.language_model.layers.0.linear_attn.out_proj`) so that standard
     PEFT can exclude frozen submodules like the vision tower. Unsloth's `get_peft_regex`, however,
     treats every entry in `target_modules` as a leaf name and matches modules ending in it, so a full
-    path never matches and no layers get adapters. Reduce back to unique leaf names in that case.
+    path never matches and no layers get adapters. Keep only language-model paths before reducing
+    them to unique leaf names, preserving already-leaf target names such as `lm_head`.
     """
     if isinstance(target_modules, str):
         target_modules = [target_modules]
@@ -87,6 +88,16 @@ def _coerce_unsloth_target_modules(model: "PreTrainedModel", target_modules: lis
     if all("." not in name for name in target_modules):
         return target_modules
 
+    language_model_keys = COMPOSITE_MODELS[model_type].language_model_keys
+    target_modules = [
+        name
+        for name in target_modules
+        if "." not in name
+        or any(
+            name == key or name.startswith(f"{key}.") or f".{key}." in name or name.endswith(f".{key}")
+            for key in language_model_keys
+        )
+    ]
     return sorted({name.rsplit(".", 1)[-1] for name in target_modules})
 
 

--- a/tests/model/model_utils/test_unsloth.py
+++ b/tests/model/model_utils/test_unsloth.py
@@ -1,0 +1,42 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+from llamafactory.model.model_utils.unsloth import _coerce_unsloth_target_modules
+
+
+def test_coerce_unsloth_target_modules_composite_model():
+    model = MagicMock()
+    model.config.model_type = "qwen2_vl"
+    target_modules = [
+        "model.language_model.layers.0.self_attn.q_proj",
+        "model.language_model.layers.1.self_attn.q_proj",
+        "model.language_model.layers.0.self_attn.k_proj",
+    ]
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["k_proj", "q_proj"]
+
+
+def test_coerce_unsloth_target_modules_non_composite_model():
+    model = MagicMock()
+    model.config.model_type = "qwen2"
+    target_modules = ["model.layers.0.self_attn.q_proj"]
+    assert _coerce_unsloth_target_modules(model, target_modules) == target_modules
+
+
+def test_coerce_unsloth_target_modules_already_leaf_names():
+    model = MagicMock()
+    model.config.model_type = "qwen2_vl"
+    target_modules = ["q_proj", "k_proj"]
+    assert _coerce_unsloth_target_modules(model, target_modules) == target_modules

--- a/tests/model/model_utils/test_unsloth.py
+++ b/tests/model/model_utils/test_unsloth.py
@@ -28,6 +28,44 @@ def test_coerce_unsloth_target_modules_composite_model():
     assert _coerce_unsloth_target_modules(model, target_modules) == ["k_proj", "q_proj"]
 
 
+def test_coerce_unsloth_target_modules_excludes_vision_leaves():
+    model = MagicMock()
+    model.config.model_type = "qwen2_vl"
+    target_modules = [
+        "model.language_model.layers.0.self_attn.q_proj",
+        "lm_head",
+        "model.visual.blocks.0.attn.vision_only_proj",
+    ]
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["lm_head", "q_proj"]
+
+
+def test_coerce_unsloth_target_modules_uses_model_specific_language_root():
+    model = MagicMock()
+    model.config.model_type = "dots_ocr"
+    target_modules = [
+        "model.layers.0.self_attn.q_proj",
+        "vision_tower.blocks.0.attn.vision_only_proj",
+    ]
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["q_proj"]
+
+
+def test_coerce_unsloth_target_modules_coerces_string():
+    model = MagicMock()
+    model.config.model_type = "qwen2_vl"
+    target_modules = "model.language_model.layers.0.self_attn.q_proj"
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["q_proj"]
+
+
+def test_coerce_unsloth_target_modules_coerces_set():
+    model = MagicMock()
+    model.config.model_type = "qwen2_vl"
+    target_modules = {
+        "model.language_model.layers.0.self_attn.q_proj",
+        "model.language_model.layers.0.self_attn.k_proj",
+    }
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["k_proj", "q_proj"]
+
+
 def test_coerce_unsloth_target_modules_non_composite_model():
     model = MagicMock()
     model.config.model_type = "qwen2"


### PR DESCRIPTION
## Summary
- `patch_target_modules` expands short LoRA target names (e.g. `out_proj`) into full module paths for composite VLMs, so standard PEFT can skip frozen submodules like the vision tower.
- Unsloth's `get_peft_regex` treats every `target_modules` entry as a leaf name and matches modules ending in it, so a full path never matches and no adapters get applied when training a VLM with `use_unsloth: true`.
- Added `_coerce_unsloth_target_modules` in `src/llamafactory/model/model_utils/unsloth.py` to reduce expanded paths back to unique leaf names before handing `target_modules` to unsloth, only for composite VLM model types.

Fixes #10662

## Test plan
- [x] Added unit tests in `tests/model/model_utils/test_unsloth.py` covering leaf-name passthrough, path coercion for composite VLMs, and non-composite models being left untouched.
- [x] `pytest -vv --import-mode=importlib tests/model/model_utils/test_unsloth.py`