### PR TITLE
fix(unsloth): rewrite expanded VLM target_modules to leaf names

### DIFF
--- a/src/llamafactory/model/model_utils/unsloth.py
+++ b/src/llamafactory/model/model_utils/unsloth.py
@@ -65,11 +65,45 @@ def load_unsloth_pretrained_model(
     return model
 
 
+def _leaf_target_modules(target_modules: list[str] | set[str] | str | None) -> list[str] | str | None:
+    r"""Convert expanded module paths to unique leaf names for Unsloth.
+
+    For composite VLMs, ``patch_target_modules`` may expand short targets like
+    ``out_proj`` into full paths such as
+    ``model.language_model.layers.0.linear_attn.out_proj`` (correct for PEFT).
+    Unsloth's ``get_peft_regex`` treats each entry as a leaf name and builds
+    end-anchored regexes, so full paths match nothing and training crashes with
+    "No layers to finetune?".
+    """
+    if target_modules is None or isinstance(target_modules, str):
+        return target_modules
+
+    leaves: list[str] = []
+    seen: set[str] = set()
+    for module in target_modules:
+        leaf = module.rsplit(".", 1)[-1]
+        if leaf not in seen:
+            seen.add(leaf)
+            leaves.append(leaf)
+    return leaves
+
+
 def get_unsloth_peft_model(
     model: "PreTrainedModel", model_args: "ModelArguments", peft_kwargs: dict[str, Any]
 ) -> "PreTrainedModel":
     r"""Get the peft model for the pretrained model with unsloth. Used in training."""
     from unsloth import FastLanguageModel  # type: ignore
+
+    peft_kwargs = dict(peft_kwargs)
+    if "target_modules" in peft_kwargs:
+        original = peft_kwargs["target_modules"]
+        peft_kwargs["target_modules"] = _leaf_target_modules(original)
+        if peft_kwargs["target_modules"] != original:
+            logger.info_rank0(
+                "Unsloth expects leaf module names; rewrote target_modules from expanded paths: {} -> {}.".format(
+                    original, peft_kwargs["target_modules"]
+                )
+            )
 
     unsloth_peft_kwargs = {
         "model": model,

--- a/tests/model/model_utils/test_unsloth_targets.py
+++ b/tests/model/model_utils/test_unsloth_targets.py
@@ -1,0 +1,71 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_unsloth_module():
+    """Load unsloth.py without importing the full llamafactory package (torch)."""
+    extras = types.ModuleType("llamafactory.extras")
+    logging = types.ModuleType("llamafactory.extras.logging")
+
+    class _Logger:
+        def info_rank0(self, *args, **kwargs):
+            return None
+
+        def warning_rank0(self, *args, **kwargs):
+            return None
+
+    logging.get_logger = lambda name: _Logger()
+    extras.logging = logging
+    misc = types.ModuleType("llamafactory.extras.misc")
+    misc.get_current_device = lambda: "cpu"
+    extras.misc = misc
+    sys.modules.setdefault("llamafactory", types.ModuleType("llamafactory"))
+    sys.modules["llamafactory.extras"] = extras
+    sys.modules["llamafactory.extras.logging"] = logging
+    sys.modules["llamafactory.extras.misc"] = misc
+    sys.modules.setdefault("llamafactory.hparams", types.ModuleType("llamafactory.hparams"))
+
+    path = Path(__file__).resolve().parents[3] / "src/llamafactory/model/model_utils/unsloth.py"
+    # parents: test_unsloth_targets -> model_utils -> model -> tests -> repo root? 
+    # __file__ = tests/model/model_utils/test_unsloth_targets.py
+    # parents[0]=model_utils, [1]=model, [2]=tests, [3]=repo root. Yes.
+    src = path.read_text(encoding="utf-8")
+    src = src.replace("from ...extras import logging", "from llamafactory.extras import logging")
+    src = src.replace("from ...extras.misc import get_current_device", "from llamafactory.extras.misc import get_current_device")
+    ns: dict = {}
+    exec(compile(src, str(path), "exec"), ns)
+    return ns
+
+
+def test_leaf_target_modules_collapses_expanded_vlm_paths() -> None:
+    leaf = _load_unsloth_module()["_leaf_target_modules"]
+    expanded = [
+        "model.language_model.layers.0.linear_attn.out_proj",
+        "model.language_model.layers.0.self_attn.q_proj",
+        "model.language_model.layers.1.self_attn.q_proj",
+        "out_proj",
+    ]
+    assert leaf(expanded) == ["out_proj", "q_proj"]
+
+
+def test_leaf_target_modules_preserves_plain_names_and_strings() -> None:
+    leaf = _load_unsloth_module()["_leaf_target_modules"]
+    assert leaf(["q_proj", "v_proj"]) == ["q_proj", "v_proj"]
+    assert leaf("all-linear") == "all-linear"
+    assert leaf(None) is None


### PR DESCRIPTION
# What does this PR do?

Fixes #10662

When **Booster = unsloth** is used for LoRA SFT on composite / vision-language models (e.g. `qwen3_5`, Qwen2-VL, LLaVA, …), `patch_target_modules()` expands short targets like `out_proj` into full paths such as:

```text
model.language_model.layers.0.linear_attn.out_proj
```

That is correct for HuggingFace PEFT. Unsloth's `get_peft_regex()` treats each `target_modules` entry as a **leaf name** and builds end-anchored regexes, so full paths match nothing → **0 trainable layers** → `"No layers to finetune?"`.

The same config works with Booster `auto` (standard PEFT).

## Fix

In the Unsloth integration path only (`get_unsloth_peft_model`), rewrite `target_modules` to unique leaf names before calling `FastLanguageModel.get_peft_model()`. Standard PEFT path is unchanged.

## Before submitting

- [x] Did you read the contributor guideline?
- [x] Did you write any new necessary tests?

## Test plan

```bash
pytest tests/model/model_utils/test_unsloth_targets.py -q --noconftest
# 2 passed
```
