### PR TITLE
fix(webui): improve Windows compatibility for subprocess launch and data preprocessing

### DIFF
--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -487,7 +487,11 @@ class Runner:
                 else:
                     stderr = "No subprocess log file found."
 
-            print(stderr)
+            try:
+                print(stderr)
+            except UnicodeEncodeError:
+                sys.stdout.buffer.write(stderr.encode("utf-8", errors="replace"))
+                sys.stdout.buffer.flush()
             finish_info = ALERTS["err_failed"][lang]
             finish_log = ALERTS["err_failed"][lang] + f" Exit code: {return_code}\n\n```\n{stderr}\n```\n"
 

--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -17,7 +17,6 @@ import os
 import sys
 from collections.abc import Generator
 from copy import deepcopy
-from pathlib import Path
 from subprocess import Popen, TimeoutExpired
 from typing import TYPE_CHECKING, Any
 
@@ -41,6 +40,7 @@ from .common import (
 )
 from .control import get_trainer_info
 from .locales import ALERTS, LOCALES
+from .runner_paths import resolve_cli_executable
 
 
 if is_gradio_available():
@@ -382,12 +382,7 @@ class Runner:
             env = deepcopy(os.environ)
             env["LLAMABOARD_ENABLED"] = "1"
             env["LLAMABOARD_WORKDIR"] = args["output_dir"]
-            if os.name == "nt":
-                cli_exe = str(Path(sys.executable).parent / "llamafactory-cli.exe")
-            else:
-                cli_exe = str(Path(sys.executable).parent / "llamafactory-cli")
-                if not Path(cli_exe).exists():
-                    cli_exe = "llamafactory-cli"
+            cli_exe = resolve_cli_executable(sys.executable, os.name)
             if args.get("deepspeed", None) is not None:
                 env["FORCE_TORCHRUN"] = "1"
 

--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -14,8 +14,10 @@
 
 import json
 import os
+import sys
 from collections.abc import Generator
 from copy import deepcopy
+from pathlib import Path
 from subprocess import Popen, TimeoutExpired
 from typing import TYPE_CHECKING, Any
 
@@ -141,7 +143,7 @@ class Runner:
             do_train=True,
             model_name_or_path=get("top.model_path"),
             cache_dir=user_config.get("cache_dir", None),
-            preprocessing_num_workers=16,
+            preprocessing_num_workers=1 if os.name == "nt" else 16,
             finetuning_type=finetuning_type,
             template=get("top.template"),
             rope_scaling=get("top.rope_scaling") if get("top.rope_scaling") != "none" else None,
@@ -307,7 +309,7 @@ class Runner:
             stage="sft",
             model_name_or_path=get("top.model_path"),
             cache_dir=user_config.get("cache_dir", None),
-            preprocessing_num_workers=16,
+            preprocessing_num_workers=1 if os.name == "nt" else 16,
             finetuning_type=finetuning_type,
             quantization_method=get("top.quantization_method"),
             template=get("top.template"),
@@ -380,6 +382,12 @@ class Runner:
             env = deepcopy(os.environ)
             env["LLAMABOARD_ENABLED"] = "1"
             env["LLAMABOARD_WORKDIR"] = args["output_dir"]
+            if os.name == "nt":
+                cli_exe = str(Path(sys.executable).parent / "llamafactory-cli.exe")
+            else:
+                cli_exe = str(Path(sys.executable).parent / "llamafactory-cli")
+                if not Path(cli_exe).exists():
+                    cli_exe = "llamafactory-cli"
             if args.get("deepspeed", None) is not None:
                 env["FORCE_TORCHRUN"] = "1"
 
@@ -387,7 +395,7 @@ class Runner:
             webui_log_path = os.path.join(args["output_dir"], "webui_subprocess.log")
             webui_log = open(webui_log_path, "a", encoding="utf-8")
             self.trainer = Popen(
-                ["llamafactory-cli", "train", save_cmd(args)],
+                [cli_exe, "train", save_cmd(args)],
                 env=env,
                 stdout=webui_log,
                 stderr=webui_log,

--- a/src/llamafactory/webui/runner_paths.py
+++ b/src/llamafactory/webui/runner_paths.py
@@ -1,0 +1,35 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+
+def resolve_cli_executable(python_executable: str | Path, platform: str) -> str:
+    r"""Resolve the LlamaFactory CLI executable next to the active Python installation."""
+    python_dir = Path(python_executable).parent
+    if platform == "nt":
+        environment_cli = python_dir / "llamafactory-cli.exe"
+        if environment_cli.exists():
+            return str(environment_cli)
+
+        scripts_cli = python_dir / "Scripts" / "llamafactory-cli.exe"
+        if scripts_cli.exists():
+            return str(scripts_cli)
+
+    else:
+        environment_cli = python_dir / "llamafactory-cli"
+        if environment_cli.exists():
+            return str(environment_cli)
+
+    return "llamafactory-cli"

--- a/tests/webui/test_runner_paths.py
+++ b/tests/webui/test_runner_paths.py
@@ -1,0 +1,49 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from llamafactory.webui.runner_paths import resolve_cli_executable
+
+
+def test_resolve_cli_executable_prefers_active_environment(tmp_path: Path) -> None:
+    python_executable = tmp_path / "python.exe"
+    cli_executable = tmp_path / "llamafactory-cli.exe"
+    cli_executable.touch()
+
+    assert resolve_cli_executable(python_executable, platform="nt") == str(cli_executable)
+
+
+def test_resolve_cli_executable_finds_windows_scripts_directory(tmp_path: Path) -> None:
+    python_executable = tmp_path / "python.exe"
+    cli_executable = tmp_path / "Scripts" / "llamafactory-cli.exe"
+    cli_executable.parent.mkdir()
+    cli_executable.touch()
+
+    assert resolve_cli_executable(python_executable, platform="nt") == str(cli_executable)
+
+
+def test_resolve_cli_executable_prefers_active_unix_environment(tmp_path: Path) -> None:
+    python_executable = tmp_path / "bin" / "python"
+    cli_executable = python_executable.parent / "llamafactory-cli"
+    cli_executable.parent.mkdir()
+    cli_executable.touch()
+
+    assert resolve_cli_executable(python_executable, platform="posix") == str(cli_executable)
+
+
+def test_resolve_cli_executable_falls_back_to_path(tmp_path: Path) -> None:
+    python_executable = tmp_path / "python.exe"
+
+    assert resolve_cli_executable(python_executable, platform="nt") == "llamafactory-cli"


### PR DESCRIPTION
## What

This PR fixes three Windows-specific failures in LlamaBoard:

- resolve `llamafactory-cli` from the active environment, including standard Windows `Scripts/` installs, before falling back to `PATH`
- use a single preprocessing worker on Windows to avoid `spawn`-based dataset worker crashes
- preserve subprocess diagnostics when the Windows console cannot encode a log character

## Why

When LlamaBoard is launched with `python -m llamafactory.cli webui`, the UI can start successfully while training fails later:

1. `Popen(["llamafactory-cli", ...])` relies on `PATH`, which may not contain the active Python installation's script directory.
2. Windows uses `spawn` for multiprocessing, so dataset preprocessing can terminate workers while repeatedly importing the ML stack.
3. Printing a subprocess log can itself raise `UnicodeEncodeError` on legacy Windows console encodings, hiding the original failure.

The CLI lookup now checks both layouts used by supported Python installations: next to an active virtual-environment interpreter and under a global interpreter's `Scripts/` directory. If neither executable exists, it preserves the existing `PATH` lookup behavior. POSIX environments continue to prefer the executable next to the active interpreter and otherwise use `PATH`.

## Validation

- `PYTHONPATH=src python -m pytest -q --confcutdir=tests/webui tests/webui/test_runner_paths.py` (4 passed)
- `ruff format --check src/llamafactory/webui/runner.py src/llamafactory/webui/runner_paths.py tests/webui/test_runner_paths.py`
- `ruff check src/llamafactory/webui/runner.py src/llamafactory/webui/runner_paths.py tests/webui/test_runner_paths.py`
- repository license-header check
- `python -m compileall` for the changed Python modules

The focused tests cover Windows virtual-environment and global `Scripts/` layouts, a POSIX virtual environment, and the `PATH` fallback.

## Environment used for the original Windows reproduction

- Windows 11
- Python 3.11.15
- uv 0.10.9-managed environment
- LlamaFactory 0.9.6.dev0
- RTX 5060 Laptop (CUDA 12.8)

## Scope

The changes are limited to the LlamaBoard runner, a small side-effect-free executable resolver, and its focused regression tests. Linux and macOS retain the existing preprocessing worker count and CLI fallback behavior.
