### PR TITLE
[xpu] extend runs_on markers to include Intel XPU for v1 tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,8 @@ def _get_visible_devices_env() -> str | None:
         return "CUDA_VISIBLE_DEVICES"
     elif CURRENT_DEVICE == "npu":
         return "ASCEND_RT_VISIBLE_DEVICES"
+    elif CURRENT_DEVICE == "xpu":
+        return "ZE_AFFINITY_MASK"
     else:
         return None
 
@@ -160,6 +162,8 @@ def _manage_distributed_env(request: FixtureRequest, monkeypatch: MonkeyPatch) -
             monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
         elif CURRENT_DEVICE == "npu":
             monkeypatch.setattr(torch.npu, "device_count", lambda: 1)
+        elif CURRENT_DEVICE == "xpu":
+            monkeypatch.setattr(torch.xpu, "device_count", lambda: 1)
 
 
 @pytest.fixture

--- a/tests_v1/accelerator/test_interface.py
+++ b/tests_v1/accelerator/test_interface.py
@@ -52,7 +52,7 @@ def test_all_device():
     assert DistributedInterface().get_local_world_size() == int(os.getenv("LOCAL_WORLD_SIZE", "1"))
 
 
-@pytest.mark.runs_on(["cuda", "npu"])
+@pytest.mark.runs_on(["cuda", "npu", "xpu"])
 @pytest.mark.require_distributed(2)
 def test_multi_device():
     master_port = find_available_port()

--- a/tests_v1/conftest.py
+++ b/tests_v1/conftest.py
@@ -79,6 +79,8 @@ def _get_visible_devices_env() -> str | None:
         return "CUDA_VISIBLE_DEVICES"
     elif CURRENT_DEVICE == "npu":
         return "ASCEND_RT_VISIBLE_DEVICES"
+    elif CURRENT_DEVICE == "xpu":
+        return "ZE_AFFINITY_MASK"
     else:
         return None
 
@@ -172,6 +174,8 @@ def _manage_distributed_env(request: FixtureRequest, monkeypatch: MonkeyPatch) -
             monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
         elif CURRENT_DEVICE == "npu":
             monkeypatch.setattr(torch.npu, "device_count", lambda: 1)
+        elif CURRENT_DEVICE == "xpu":
+            monkeypatch.setattr(torch.xpu, "device_count", lambda: 1)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests_v1/sampler/test_cli_sampler.py
+++ b/tests_v1/sampler/test_cli_sampler.py
@@ -19,7 +19,7 @@ from llamafactory.v1.core.model_engine import ModelEngine
 from llamafactory.v1.samplers.cli_sampler import SyncSampler
 
 
-@pytest.mark.runs_on(["cuda", "npu"])
+@pytest.mark.runs_on(["cuda", "npu", "xpu"])
 def test_sync_sampler():
     model_args = ModelArguments(model="Qwen/Qwen3-4B-Instruct-2507")
     sample_args = SampleArguments()

--- a/tests_v1/trainers/test_fsdp2_dpo_trainer.py
+++ b/tests_v1/trainers/test_fsdp2_dpo_trainer.py
@@ -21,7 +21,7 @@ import pytest
 
 
 @pytest.mark.xfail(reason="CI machines may OOM when heavily loaded.")
-@pytest.mark.runs_on(["cuda", "npu"])
+@pytest.mark.runs_on(["cuda", "npu", "xpu"])
 def test_fsdp2_dpo_trainer(tmp_path: Path):
     """Test FSDP2 DPO trainer with sigmoid loss by simulating `llamafactory-cli dpo config.yaml`."""
     config_yaml = """\

--- a/tests_v1/trainers/test_fsdp2_sft_trainer.py
+++ b/tests_v1/trainers/test_fsdp2_sft_trainer.py
@@ -20,7 +20,7 @@ import pytest
 
 
 @pytest.mark.xfail(reason="CI machines may OOM when heavily loaded.")
-@pytest.mark.runs_on(["cuda", "npu"])
+@pytest.mark.runs_on(["cuda", "npu", "xpu"])
 def test_fsdp2_sft_trainer(tmp_path: Path):
     """Test FSDP2 SFT trainer by simulating `llamafactory-cli sft config.yaml` behavior."""
     config_yaml = """\


### PR DESCRIPTION
## Summary

Add Intel XPU (`xpu`) as a first-class device target across the v1 test suite, alongside the existing `cuda` and `npu` support.

### Problem

On Intel XPU hardware, several v1 tests are unconditionally skipped with:
```
test requires one of ['cuda', 'npu'] (current: xpu)
```

### Changes

**`tests/conftest.py` and `tests_v1/conftest.py`** — two additions each:
- `_get_visible_devices_env`: return `ZE_AFFINITY_MASK` for `xpu` (Intel's device-visibility env var), enabling correct device-count checks for `@pytest.mark.require_distributed` skip logic
- `_manage_distributed_env`: patch `torch.xpu.device_count` to 1 for single-device test isolation, matching the existing `cuda`/`npu` handling

**Test files** — add `"xpu"` to `@pytest.mark.runs_on`:
- `tests_v1/accelerator/test_interface.py` — `test_multi_device`
- `tests_v1/sampler/test_cli_sampler.py` — `test_sync_sampler`
- `tests_v1/trainers/test_fsdp2_sft_trainer.py` — `test_fsdp2_sft_trainer`
- `tests_v1/trainers/test_fsdp2_dpo_trainer.py` — `test_fsdp2_dpo_trainer`
