### PR TITLE
[docs] update trend badge and promote PenguinHarness in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <div align="center" markdown="1">
 
-### Check our new open-source project: 🐧 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness): Your desktop agent that automatically builds agents for just $0.02 of tokens!
+### Check our new open-source project —<br>🐧 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness): Your desktop agent that automatically builds agents for just $0.02 of tokens!
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ### Check our new open-source project —<br>🐧 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness): Your desktop agent that automatically builds agents for just $0.02 of tokens!
 
-Click to follow the project: https://github.com/Prism-Shadow/penguin-harness
+Follow our project: https://github.com/Prism-Shadow/penguin-harness
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 
 ### Check our new open-source project —<br>🐧 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness): Your desktop agent that automatically builds agents for just $0.02 of tokens!
 
+Click to follow the project: https://github.com/Prism-Shadow/penguin-harness
+
 </div>
 
 https://github.com/user-attachments/assets/9b7033e8-f08a-4c3f-bd33-547896664e6e

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <div align="center" markdown="1">
 
-### 🐧 Meet [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness): our new agent harness — let Agents autonomously build better Agents for just $0.02 of tokens!
+### Check our new open-source project: 🐧 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness): Your desktop agent that automatically builds agents for just $0.02 of tokens!
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 [![Open in Studios](https://img.shields.io/badge/ModelScope-Open%20in%20Studios-blue)](https://modelscope.cn/studios/hiyouga/LLaMA-Board)
 [![Open in Novita](https://img.shields.io/badge/Novita-Deploy%20Template-blue)](https://novita.ai/templates-library/105981?sharer=88115474-394e-4bda-968e-b88e123d0c47)
 
+----
+
 <div align="center" markdown="1">
 
 ### 🐧 Meet [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness): our new agent harness — let Agents autonomously build better Agents for just $0.02 of tokens!
@@ -26,6 +28,8 @@
 </div>
 
 https://github.com/user-attachments/assets/9b7033e8-f08a-4c3f-bd33-547896664e6e
+
+----
 
 ### Used by [Amazon](https://aws.amazon.com/cn/blogs/machine-learning/how-apoidea-group-enhances-visual-information-extraction-from-banking-documents-with-multimodal-models-using-llama-factory-on-amazon-sagemaker-hyperpod/), [NVIDIA](https://developer.nvidia.com/rtx/ai-toolkit), [Aliyun](https://help.aliyun.com/zh/pai/use-cases/fine-tune-a-llama-3-model-with-llama-factory), etc.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@
 [![Open in Studios](https://img.shields.io/badge/ModelScope-Open%20in%20Studios-blue)](https://modelscope.cn/studios/hiyouga/LLaMA-Board)
 [![Open in Novita](https://img.shields.io/badge/Novita-Deploy%20Template-blue)](https://novita.ai/templates-library/105981?sharer=88115474-394e-4bda-968e-b88e123d0c47)
 
+<div align="center" markdown="1">
+
+### 🐧 Meet [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness): our new agent harness — let Agents autonomously build better Agents for just $0.02 of tokens!
+
+</div>
+
+https://github.com/user-attachments/assets/9b7033e8-f08a-4c3f-bd33-547896664e6e
+
 ### Used by [Amazon](https://aws.amazon.com/cn/blogs/machine-learning/how-apoidea-group-enhances-visual-information-extraction-from-banking-documents-with-multimodal-models-using-llama-factory-on-amazon-sagemaker-hyperpod/), [NVIDIA](https://developer.nvidia.com/rtx/ai-toolkit), [Aliyun](https://help.aliyun.com/zh/pai/use-cases/fine-tune-a-llama-3-model-with-llama-factory), etc.
 
 <div align="center" markdown="1">
@@ -32,7 +40,7 @@
 
 ### Easily fine-tune 100+ large language models with zero-code [CLI](#quickstart) and [Web UI](#fine-tuning-with-llama-board-gui-powered-by-gradio)
 
-![GitHub Trend](https://trendshift.io/api/badge/repositories/4535)
+![GitHub Trend](https://trendshift.io/api/badge/repositories/17371)
 
 </div>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -23,7 +23,7 @@
 
 <div align="center" markdown="1">
 
-### 欢迎关注我们全新的开源项目：🐧 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness)：只需 0.02 美元的 Token，即可自动构建 Agent 的桌面级 Agent！
+### 欢迎关注我们全新的开源项目——<br>🐧 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness)：只需 0.02 美元的 Token，即可自动构建 Agent 的桌面级 Agent！
 
 </div>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -25,6 +25,8 @@
 
 ### 欢迎关注我们全新的开源项目——<br>🐧 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness)：只需 0.02 美元的 Token，即可自动构建 Agent 的桌面级 Agent！
 
+点击关注项目：https://github.com/Prism-Shadow/penguin-harness
+
 </div>
 
 https://github.com/user-attachments/assets/9b7033e8-f08a-4c3f-bd33-547896664e6e

--- a/README_zh.md
+++ b/README_zh.md
@@ -19,6 +19,14 @@
 [![Open in Studios](https://img.shields.io/badge/ModelScope-Open%20in%20Studios-blue)](https://modelscope.cn/studios/hiyouga/LLaMA-Board)
 [![Open in Novita](https://img.shields.io/badge/Novita-Deploy%20Template-blue)](https://novita.ai/templates-library/105981?sharer=88115474-394e-4bda-968e-b88e123d0c47)
 
+<div align="center" markdown="1">
+
+### 🐧 来认识 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness)：我们全新的 Agent 框架——只需 0.02 美元的 Token，让 Agent 自主构建更强的 Agent！
+
+</div>
+
+https://github.com/user-attachments/assets/9b7033e8-f08a-4c3f-bd33-547896664e6e
+
 ### 获得[亚马逊](https://aws.amazon.com/cn/blogs/china/a-one-stop-code-free-model-fine-tuning-deployment-platform-based-on-sagemaker-and-llama-factory/)、[英伟达](https://developer.nvidia.cn/rtx/ai-toolkit)、[阿里云](https://help.aliyun.com/zh/pai/use-cases/fine-tune-a-llama-3-model-with-llama-factory)等的应用。
 
 <div align="center" markdown="1">
@@ -32,7 +40,7 @@
 
 ### 使用零代码[命令行](#快速开始)与 [Web UI](#llama-board-可视化微调由-gradio-驱动) 轻松微调百余种大模型
 
-![GitHub Trend](https://trendshift.io/api/badge/repositories/4535)
+![GitHub Trend](https://trendshift.io/api/badge/repositories/17371)
 
 </div>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -23,7 +23,7 @@
 
 <div align="center" markdown="1">
 
-### 🐧 来认识 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness)：我们全新的 Agent 框架——只需 0.02 美元的 Token，让 Agent 自主构建更强的 Agent！
+### 欢迎关注我们全新的开源项目：🐧 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness)：只需 0.02 美元的 Token，即可自动构建 Agent 的桌面级 Agent！
 
 </div>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -23,7 +23,7 @@
 
 <div align="center" markdown="1">
 
-### 欢迎关注我们全新的开源项目——<br>🐧 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness)：只需 0.02 美元的 Token，即可自动构建 Agent 的桌面级 Agent！
+### 欢迎关注我们全新的开源项目——<br>🐧 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness)：只需 0.2 元的 Token，即可自动构建 Agent 的桌面级 Agent！
 
 点击关注项目：https://github.com/Prism-Shadow/penguin-harness
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -19,6 +19,8 @@
 [![Open in Studios](https://img.shields.io/badge/ModelScope-Open%20in%20Studios-blue)](https://modelscope.cn/studios/hiyouga/LLaMA-Board)
 [![Open in Novita](https://img.shields.io/badge/Novita-Deploy%20Template-blue)](https://novita.ai/templates-library/105981?sharer=88115474-394e-4bda-968e-b88e123d0c47)
 
+----
+
 <div align="center" markdown="1">
 
 ### 🐧 来认识 [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness)：我们全新的 Agent 框架——只需 0.02 美元的 Token，让 Agent 自主构建更强的 Agent！
@@ -26,6 +28,8 @@
 </div>
 
 https://github.com/user-attachments/assets/9b7033e8-f08a-4c3f-bd33-547896664e6e
+
+----
 
 ### 获得[亚马逊](https://aws.amazon.com/cn/blogs/china/a-one-stop-code-free-model-fine-tuning-deployment-platform-based-on-sagemaker-and-llama-factory/)、[英伟达](https://developer.nvidia.cn/rtx/ai-toolkit)、[阿里云](https://help.aliyun.com/zh/pai/use-cases/fine-tune-a-llama-3-model-with-llama-factory)等的应用。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -29,7 +29,7 @@
 
 </div>
 
-https://github.com/user-attachments/assets/9b7033e8-f08a-4c3f-bd33-547896664e6e
+https://github.com/user-attachments/assets/604eb626-0a5d-4a62-87e3-14ebade1cd5f
 
 ----
 


### PR DESCRIPTION
## What does this PR do?

- Updates the GitHub Trend badge to the new trendshift entry for the renamed repo (`4535` → `17371`, which now points to `hiyouga/LlamaFactory`).
- Adds a PenguinHarness promotion section near the top of both `README.md` and `README_zh.md`, embedding the official demo video showing an Agent building a complete Agent app for just $0.02 of tokens.

🐧 PenguinHarness: https://github.com/Prism-Shadow/penguin-harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)