### PR TITLE
[ci] pin ruff version and fix lint errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         args: [--py39-plus]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.2
+    rev: v0.15.5
     hooks:
     -   id: ruff
         args: [--fix]

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@
 
 check_dirs := scripts src tests tests_v1
 
+ruff_version := 0.15.5
+
 RUN := $(shell command -v uv >/dev/null 2>&1 && echo "uv run" || echo "")
 BUILD := $(shell command -v uv >/dev/null 2>&1 && echo "uv build" || echo "python -m build")
 TOOL := $(shell command -v uv >/dev/null 2>&1 && echo "uvx" || echo "")
+RUFF := $(shell command -v uv >/dev/null 2>&1 && echo "uvx ruff@$(ruff_version)" || echo "ruff")
 
 build:
 	$(BUILD)
@@ -17,12 +20,12 @@ license:
 	$(RUN) python3 tests/check_license.py $(check_dirs)
 
 quality:
-	$(TOOL) ruff check $(check_dirs)
-	$(TOOL) ruff format --check $(check_dirs)
+	$(RUFF) check $(check_dirs)
+	$(RUFF) format --check $(check_dirs)
 
 style:
-	$(TOOL) ruff check $(check_dirs) --fix
-	$(TOOL) ruff format $(check_dirs)
+	$(RUFF) check $(check_dirs) --fix
+	$(RUFF) format $(check_dirs)
 
 test:
 	WANDB_DISABLED=true $(RUN) pytest -vv --import-mode=importlib tests/ tests_v1/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ ignore = [
     "D105",  # no doc magic method
     "D107",  # no doc __init__
 ]
-extend-select = [
+select = [
     "C",      # complexity
     "E",      # error
     "F",      # pyflakes

--- a/src/llamafactory/model/adapter.py
+++ b/src/llamafactory/model/adapter.py
@@ -198,12 +198,16 @@ def _setup_lora_tuning(
                 pass  # already loaded via load_unsloth_peft_model in loader.py
             else:
                 if model_args.use_unsloth:
-                    peft_model = load_unsloth_peft_model(config, model_args, finetuning_args, is_trainable=is_trainable)
+                    peft_model = load_unsloth_peft_model(
+                        config, model_args, finetuning_args, is_trainable=is_trainable
+                    )
                     if peft_model is not None:
                         model = peft_model
 
                 if not model_args.use_unsloth:  # unsloth was disabled or fell back
-                    model = PeftModel.from_pretrained(model, adapter_to_resume, is_trainable=is_trainable, **init_kwargs)
+                    model = PeftModel.from_pretrained(
+                        model, adapter_to_resume, is_trainable=is_trainable, **init_kwargs
+                    )
 
         logger.info_rank0("Loaded adapter(s): {}".format(",".join(model_args.adapter_name_or_path)))
 

--- a/src/llamafactory/model/model_utils/embedding.py
+++ b/src/llamafactory/model/model_utils/embedding.py
@@ -120,9 +120,7 @@ def _noisy_mean_initialization(
     avg_weight = _existing_embeddings(embed_weight, num_new_tokens, token_ids).mean(dim=0, keepdim=True)
 
     if token_ids:
-        noise_weight = torch.empty(
-            len(token_ids), embedding_dim, device=embed_weight.device, dtype=embed_weight.dtype
-        )
+        noise_weight = torch.empty(len(token_ids), embedding_dim, device=embed_weight.device, dtype=embed_weight.dtype)
         noise_weight.normal_(mean=0, std=(1.0 / math.sqrt(embedding_dim)))
         embed_weight[token_ids] = avg_weight + noise_weight
     else:
@@ -202,8 +200,7 @@ def _description_based_initialization(
             if len(valid_token_ids) == 0:
                 # Fallback: use mean of all existing embeddings
                 logger.warning_rank0(
-                    f"Description for token '{token_str}' contains no valid tokens. "
-                    "Using mean of existing embeddings."
+                    f"Description for token '{token_str}' contains no valid tokens. Using mean of existing embeddings."
                 )
                 base_embedding = fallback_embedding
             else:

--- a/src/llamafactory/train/hyper_parallel/trainer.py
+++ b/src/llamafactory/train/hyper_parallel/trainer.py
@@ -278,7 +278,9 @@ class HyperParallelTrainer(CustomSeq2SeqTrainer):
         )
         logical_batches = len(batch_sampler) // self._cp_size
         dp_size = max(1, get_platform().get_world_size() // self._cp_size)
-        logical_length = logical_batches // dp_size if self.args.dataloader_drop_last else _ceil_div(logical_batches, dp_size)
+        logical_length = (
+            logical_batches // dp_size if self.args.dataloader_drop_last else _ceil_div(logical_batches, dp_size)
+        )
 
         dataloader_params = {
             "batch_sampler": batch_sampler,

--- a/src/llamafactory/train/tuner.py
+++ b/src/llamafactory/train/tuner.py
@@ -90,9 +90,7 @@ def _training_function(config: dict[str, Any]) -> None:
 
     if finetuning_args.stage in ["pt", "sft"] and finetuning_args.use_hyper_parallel:
         if not is_hyper_parallel_available():
-            raise ImportError(
-                "hyper_parallel is not installed. Please install it with `pip install hyper_parallel`."
-            )
+            raise ImportError("hyper_parallel is not installed. Please install it with `pip install hyper_parallel`.")
         if finetuning_args.stage == "pt":
             from .hyper_parallel import run_pt as run_pt_hp
 

--- a/src/llamafactory/v1/core/base_trainer.py
+++ b/src/llamafactory/v1/core/base_trainer.py
@@ -294,9 +294,7 @@ class BaseTrainer:
                         # mp_shard=world); a separate CP reduce would over-count by sqrt(cp_size).
                         total_norm = total_norm.full_tensor()
                     # pass a Tensor: clip_grads_with_norm_ clamps max_norm / (total_norm + 1e-6).
-                    torch.nn.utils.clip_grads_with_norm_(
-                        self.model.parameters(), self.args.max_grad_norm, total_norm
-                    )
+                    torch.nn.utils.clip_grads_with_norm_(self.model.parameters(), self.args.max_grad_norm, total_norm)
                     grad_norm = total_norm.item()
 
                     if not torch.isfinite(torch.tensor(grad_norm)):  # type: ignore # pyright: ignore [reportUnknownReturnType]

--- a/src/llamafactory/v1/plugins/trainer_plugins/optimizers/optimizer.py
+++ b/src/llamafactory/v1/plugins/trainer_plugins/optimizers/optimizer.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 from ....utils import logging
 from ....utils.plugin import BasePlugin
 
+
 if TYPE_CHECKING:
     from ....config.arg_utils import PluginConfig
     from ....utils.types import HFModel

--- a/src/llamafactory/webui/components/eval.py
+++ b/src/llamafactory/webui/components/eval.py
@@ -60,7 +60,13 @@ def create_eval_tab(engine: "Engine") -> dict[str, "Component"]:
 
     input_elems.update({max_new_tokens, top_p, temperature, eval_seed, output_dir})
     elem_dict.update(
-        dict(max_new_tokens=max_new_tokens, top_p=top_p, temperature=temperature, eval_seed=eval_seed, output_dir=output_dir)
+        dict(
+            max_new_tokens=max_new_tokens,
+            top_p=top_p,
+            temperature=temperature,
+            eval_seed=eval_seed,
+            output_dir=output_dir,
+        )
     )
 
     with gr.Row():


### PR DESCRIPTION
## What does this PR do?

Fixes the `tests` workflow failing on main since today (e.g. run [30075299843](https://github.com/hiyouga/LlamaFactory/actions/runs/30075299843), `Check quality` step reporting 366 errors).

**Root cause:** the Makefile invokes ruff via `uvx ruff` with no version pin, so CI always resolves the latest release. ruff 0.16.0 (released this week) expanded its default rule set, and since `pyproject.toml` used `extend-select` (which builds on the defaults), a large number of previously unselected rule families (BLE, SIM, B, S, TRY, PL, DTZ, ...) were silently enabled — 370 errors on an unchanged codebase, 191 of them not auto-fixable.

**Changes:**

1. **Pin ruff to 0.15.5** in the Makefile (`RUFF := uvx ruff@$(ruff_version)`), used by both `make style` and `make quality`, so new ruff releases can no longer break CI. Bump the version deliberately via the `ruff_version` variable.
2. **Replace `extend-select` with an explicit `select`** in `pyproject.toml` — same effective rule set as before, but decoupled from ruff's default set, so future default expansions have no effect. Verified: ruff 0.16.0 now also passes with this config.
3. **Align the pre-commit ruff hook** to the same version (v0.13.2 → v0.15.5), so local hooks and CI format identically.
4. **Apply the outstanding auto-fixes** under the pinned version: one import-order fix (I001 in `v1/plugins/trainer_plugins/optimizers/optimizer.py`, slipped in via a PR whose checks did not run) and 6 files reformatted for line-length wrapping. `make style && make quality` and `make license` are green locally on 0.15.5, and `ruff check` also passes on 0.16.0.

Note: there is a Copilot-generated branch `copilot/fix-failing-github-actions-job` addressing the same failure; whichever lands first, the other can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)