### PR TITLE
Fix Qwen3.5 Unsloth forward conflict

### DIFF
--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -483,8 +483,10 @@ def patch_model(
         if getattr(model.config, "model_type", None) in ["qwen3_5", "qwen3_5_moe"]:
             if is_torch_npu_available():
                 patch_qwen3_5_forward_npu(model)
-            elif is_torch_cuda_available() and model_args.flash_attn == "fa2":
+            elif is_torch_cuda_available() and model_args.flash_attn == "fa2" and not model_args.use_unsloth:
                 # this is the patch for packing/neat_packing for GPU GDN. And when setting packing, flash_attn must be fa2.
+                # Unsloth compiles its own Qwen3.5 forward methods before this point; replacing them here breaks its
+                # optimized forward path and can produce incorrect training loss.
                 patch_qwen3_5_forward_gpu(model)
 
     if not model_args.use_unsloth:


### PR DESCRIPTION
## Summary

- skip the LLaMA-Factory Qwen3.5 FA2/GDN forward patch when Unsloth is enabled
- preserve the existing cu-seqlens patch for the standard Transformers training path

## Root cause

Unsloth compiles and installs its own Qwen3.5 forward methods while loading the model. LLaMA-Factory then applied its class-level Qwen3.5 decoder/GDN monkey patch unconditionally for FA2 training, overwriting the Unsloth forward path and potentially producing an abnormally low initial training loss.

## Impact

Qwen3.5 training with `use_unsloth: true` now keeps Unsloth's forward implementation. Non-Unsloth Qwen3.5 FA2 packing and neat-packing behavior is unchanged.

Fixes #10637

## Validation

- `ruff check src/llamafactory/model/patcher.py`
- `ruff format --check src/llamafactory/model/patcher.py`
- local routing regression check: 2 passed
