### PR TITLE
Fix hyper parallel tail accumulation loss scaling

### DIFF
--- a/src/llamafactory/train/hyper_parallel/trainer.py
+++ b/src/llamafactory/train/hyper_parallel/trainer.py
@@ -361,7 +361,12 @@ class HyperParallelTrainer(CustomSeq2SeqTrainer):
             loss = loss.mean()
 
         if not getattr(self, "model_accepts_loss_kwargs", False) and getattr(self, "compute_loss_func", None) is None:
-            loss = loss / self.args.gradient_accumulation_steps
+            accumulation_steps = getattr(
+                self,
+                "current_gradient_accumulation_steps",
+                self.args.gradient_accumulation_steps,
+            )
+            loss = loss / accumulation_steps
 
         self.accelerator.backward(loss)
 


### PR DESCRIPTION
# What does this PR do?

## Summary

Fix loss scaling in `HyperParallelTrainer` when the last gradient accumulation window in an epoch is shorter than `gradient_accumulation_steps`.

## Background

`HyperParallelTrainer.training_step` previously scaled the loss with the configured gradient accumulation value:

```python
loss = loss / self.args.gradient_accumulation_steps
```

This is incorrect when the dataloader length is not divisible by gradient_accumulation_steps. In that case, the final optimizer step of an epoch may contain fewer microbatches than configured.
For example, with gradient_accumulation_steps=4, the last optimizer step may only accumulate 2 microbatches. Dividing by 4 would scale the loss and gradients down by an extra factor of 2.
Changes
Use the actual accumulation steps tracked by the Transformers training loop:
```
accumulation_steps = getattr(
    self,
    "current_gradient_accumulation_steps",
    self.args.gradient_accumulation_steps,
)
loss = loss / accumulation_steps
```
The configured gradient_accumulation_steps is kept as a fallback for compatibility.
Impact
No behavior change for full gradient accumulation windows.
Corrects loss and gradient scaling for tail accumulation windows.
Aligns HyperParallelTrainer behavior with the standard Transformers Trainer.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
