### PR TITLE
fix(chat): validate messages is non-empty before accessing messages[0] in multimodal processing

### DIFF
--- a/src/llamafactory/chat/hf_engine.py
+++ b/src/llamafactory/chat/hf_engine.py
@@ -84,6 +84,9 @@ class HuggingfaceEngine(BaseEngine):
         audios: Optional[list["AudioInput"]] = None,
         input_kwargs: Optional[dict[str, Any]] = {},
     ) -> tuple[dict[str, Any], int]:
+        if not messages:
+            raise ValueError("Messages must not be empty")
+
         mm_input_dict = {"images": [], "videos": [], "audios": [], "imglens": [0], "vidlens": [0], "audlens": [0]}
         if images is not None:
             mm_input_dict.update({"images": images, "imglens": [len(images)]})


### PR DESCRIPTION
## Summary
- Fix IndexError when `messages` is empty in `_process_args()` method
- Add input validation to provide meaningful error messages
- Prevent mysterious crashes for programmatic API users

## Problem
In `src/llamafactory/chat/hf_engine.py`, the `_process_args()` method accesses `messages[0]` without checking if the messages list is empty. This can cause an `IndexError` when users pass an empty messages list through the API.

## Solution
Add validation at the beginning of `_process_args()` to check if messages is empty and raise a clear `ValueError` with a descriptive message.

## Changes
- Added validation: `if not messages: raise ValueError("Messages must not be empty")`
- This prevents `IndexError` at lines 90, 95, and 100 where `messages[0]` is accessed
- Provides clear error message for debugging

## Impact
- Low risk: Only adds validation, no changes to existing logic
- Improves user experience by providing clear error messages
- Prevents crashes when API is called with empty messages
