### PR TITLE
fix(ci): align workflow Python version with requires-python

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Why
Package metadata declares `requires-python` / `.python-version` as `>=3.11.0`, but CI workflows still pin `python-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `python-version` pins so they satisfy `>=3.11.0` (using `3.11` where a concrete pin is needed).

- `.github/workflows/docs.yml`
  - `python-version: '3.10'` → `python-version: '3.11'`

## Test plan
- [ ] Package `requires-python` / `.python-version` is still `>=3.11.0`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
