### PR TITLE
[fix] reject invalid top_p values

### DIFF
--- a/scripts/vllm_infer.py
+++ b/scripts/vllm_infer.py
@@ -131,7 +131,7 @@ def vllm_infer(
     sampling_params = SamplingParams(
         repetition_penalty=generating_args.repetition_penalty or 1.0,  # repetition_penalty must > 0
         temperature=generating_args.temperature,
-        top_p=generating_args.top_p or 1.0,  # top_p must > 0
+        top_p=generating_args.top_p,
         top_k=generating_args.top_k or -1,  # top_k must > 0
         stop_token_ids=template_obj.get_stop_token_ids(tokenizer),
         max_tokens=generating_args.max_new_tokens,

--- a/src/llamafactory/chat/sglang_engine.py
+++ b/src/llamafactory/chat/sglang_engine.py
@@ -193,7 +193,7 @@ class SGLangEngine(BaseEngine):
 
         sampling_params = {
             "temperature": temperature if temperature is not None else self.generating_args["temperature"],
-            "top_p": (top_p if top_p is not None else self.generating_args["top_p"]) or 1.0,  # top_p must > 0
+            "top_p": top_p if top_p is not None else self.generating_args["top_p"],
             "top_k": (top_k if top_k is not None else self.generating_args["top_k"]) or -1,  # top_k must > 0
             "stop": stop,
             "stop_token_ids": self.template.get_stop_token_ids(self.tokenizer),

--- a/src/llamafactory/chat/vllm_engine.py
+++ b/src/llamafactory/chat/vllm_engine.py
@@ -171,7 +171,7 @@ class VllmEngine(BaseEngine):
             )
             or 1.0,  # repetition_penalty must > 0
             temperature=temperature if temperature is not None else self.generating_args["temperature"],
-            top_p=(top_p if top_p is not None else self.generating_args["top_p"]) or 1.0,  # top_p must > 0
+            top_p=top_p if top_p is not None else self.generating_args["top_p"],
             top_k=(top_k if top_k is not None else self.generating_args["top_k"]) or -1,  # top_k must > 0
             stop=stop,
             stop_token_ids=self.template.get_stop_token_ids(self.tokenizer),

--- a/src/llamafactory/hparams/generating_args.py
+++ b/src/llamafactory/hparams/generating_args.py
@@ -67,6 +67,10 @@ class GeneratingArguments:
         metadata={"help": "Whether or not to remove special tokens in the decoding."},
     )
 
+    def __post_init__(self):
+        if not 0.0 < self.top_p <= 1.0:
+            raise ValueError("`top_p` must be in the range (0.0, 1.0].")
+
     def to_dict(self, obey_generation_config: bool = False) -> dict[str, Any]:
         args = asdict(self)
         if args.get("max_new_tokens", -1) > 0:

--- a/tests/hparams/test_generating_args.py
+++ b/tests/hparams/test_generating_args.py
@@ -1,0 +1,29 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from llamafactory.hparams import GeneratingArguments
+
+
+@pytest.mark.parametrize("top_p", [0.0, -0.1, 1.1, float("nan")])
+def test_invalid_top_p(top_p: float):
+    with pytest.raises(ValueError, match=r"`top_p` must be in the range \(0\.0, 1\.0\]\."):
+        GeneratingArguments(top_p=top_p)
+
+
+@pytest.mark.parametrize("top_p", [1e-6, 0.7, 1.0])
+def test_valid_top_p(top_p: float):
+    generating_args = GeneratingArguments(top_p=top_p)
+    assert generating_args.top_p == top_p


### PR DESCRIPTION
## Summary

- validate that `GeneratingArguments.top_p` is in the supported `(0, 1]` range
- stop vLLM inference paths from silently rewriting `top_p=0.0` to `1.0`
- apply the same fix to the equivalent SGLang request path
- add regression coverage for valid values and invalid boundaries

## Root cause

The vLLM and SGLang plumbing used `top_p or 1.0`. Because `0.0` is falsy, an invalid zero value was treated as missing and replaced with the opposite end of the sampling range. `GeneratingArguments` also accepted the invalid value without validation.

## Impact

Invalid `top_p` values now fail during argument construction instead of silently changing sampling behavior. Per-request values are forwarded unchanged so the inference backend can reject invalid overrides rather than substituting them.

## Validation

- `python -m pytest -q tests/hparams/test_generating_args.py` (`7 passed`)
- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files

Closes #10709
