### PR TITLE
[fix] Respect Qwen video temporal patch size in metadata

### DIFF
--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -2103,8 +2103,6 @@ class Qwen2VLPlugin(BasePlugin):
                 metadata["width"], metadata["height"], image_max_pixels, image_min_pixels
             )
             num_frames = len(metadata["sample_indices"])
-            if num_frames % 2 != 0:
-                num_frames += 1
 
             resized_size = self._get_qwen_video_resize(
                 num_frames,

--- a/tests/data/test_mm_plugin.py
+++ b/tests/data/test_mm_plugin.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -451,6 +452,47 @@ def test_qwen3_vl_plugin():
     ]
 
 
+@pytest.mark.parametrize(
+    ("temporal_patch_size", "expected_grid_t"),
+    [(1, 5), (2, 3), (3, 2)],
+)
+def test_qwen3_vl_plugin_video_grid_metadata(monkeypatch, temporal_patch_size: int, expected_grid_t: int):
+    qwen3_vl_plugin = get_mm_plugin(name="qwen3_vl", video_token="<|video_pad|>")
+    processor = SimpleNamespace(
+        image_processor=SimpleNamespace(),
+        video_processor=SimpleNamespace(
+            patch_size=16,
+            temporal_patch_size=temporal_patch_size,
+            merge_size=2,
+            size={"shortest_edge": 16 * 16, "longest_edge": 256 * 256},
+        ),
+        video_fps=2.0,
+        video_maxlen=128,
+    )
+    metadata = {
+        "width": 64,
+        "height": 32,
+        "average_fps": 2.0,
+        "sample_indices": list(range(5)),
+    }
+    resize_num_frames = []
+
+    monkeypatch.setattr(qwen3_vl_plugin, "_get_qwen_video_stream_metadata", lambda *args: metadata)
+    monkeypatch.setattr(qwen3_vl_plugin, "_get_qwen_video_size_after_regularization", lambda *args: (64, 32))
+
+    def mock_video_resize(num_frames: int, *args) -> tuple[int, int]:
+        resize_num_frames.append(num_frames)
+        return 32, 64
+
+    monkeypatch.setattr(qwen3_vl_plugin, "_get_qwen_video_resize", mock_video_resize)
+
+    video_metadata = qwen3_vl_plugin._get_qwen_video_grid_metadata(["video.mp4"], processor)
+
+    assert video_metadata is not None
+    assert resize_num_frames == [5]
+    assert video_metadata["video_grid_thw"].tolist() == [[expected_grid_t, 2, 4]]
+
+
 @pytest.mark.runs_on(["cpu", "mps"])
 @pytest.mark.skipif(not is_transformers_version_greater_than("4.57.0"), reason="Requires transformers>=4.57.0")
 @pytest.mark.skipif(not is_pyav_available(), reason="Requires pyav")
@@ -479,7 +521,7 @@ def test_qwen3_vl_plugin_video_path():
     )
     result = qwen3_vl_plugin.process_messages(VIDEO_MESSAGES, [], videos, [], processor)
     # This demo video duration is 9.72s, with video_fps=2, we extract 19 frames
-    # 19 + 1 => temperoal compress => 10 video_sequence
+    # ceil(19 / temporal_patch_size) => 10 video sequences
     assert result[0]["content"].count("<|vision_start|>") == 10, (
         f"Expected 10 video tokens, got {result[0]['content'].count('<|vision_start|>')}"
     )


### PR DESCRIPTION
## What does this PR do?

- Keep the original sampled frame count when deriving Qwen video token metadata.
- Let the temporal grid dimension use the existing `ceil(num_frames / temporal_patch_size)` calculation.
- Add regression coverage for `temporal_patch_size` values 1, 2, and 3.

## Motivation

The metadata-only Qwen video path hard-coded odd-frame padding to a multiple of 2 before calling the Qwen3-VL resize helper. This only matched the default `temporal_patch_size=2`. With custom configurations such as `temporal_patch_size=1`, it over-counted frames and could make the fast metadata path disagree with full video preprocessing.

The upstream Qwen3-VL processor computes spatial resizing from the original sampled frame count, then pads the temporal dimension while building patches. Keeping the original count here mirrors that order. Timestamp grouping already uses `video_processor.temporal_patch_size` on the current main branch.

Closes #10675

## Validation

- `pytest tests/data/test_mm_plugin.py -k 'video_grid_metadata' -q` — 3 passed
- `pytest tests/data/test_mm_plugin.py -k 'qwen3_vl_plugin' -q` (CPU) — 4 passed, 1 skipped because the optional video fixture is absent
- `ruff check src/llamafactory/data/mm_plugin.py tests/data/test_mm_plugin.py`
- `ruff format --check src/llamafactory/data/mm_plugin.py tests/data/test_mm_plugin.py`
