### PR TITLE
fix(api): cancel sweeper task on shutdown

### DIFF
--- a/src/llamafactory/api/app.py
+++ b/src/llamafactory/api/app.py
@@ -14,7 +14,7 @@
 
 import asyncio
 import os
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from functools import partial
 from typing import Annotated
 
@@ -59,11 +59,19 @@ async def sweeper() -> None:
 
 @asynccontextmanager
 async def lifespan(app: "FastAPI", chat_model: "ChatModel"):  # collects GPU memory
+    sweeper_task = None
     if chat_model.engine.name == EngineName.HF:
-        asyncio.create_task(sweeper())
+        sweeper_task = asyncio.create_task(sweeper())
 
-    yield
-    torch_gc()
+    try:
+        yield
+    finally:
+        if sweeper_task is not None:
+            sweeper_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await sweeper_task
+
+        torch_gc()
 
 
 def create_app(chat_model: "ChatModel") -> "FastAPI":

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -1,0 +1,58 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import llamafactory.api.app as api_app
+from llamafactory.extras.constants import EngineName
+
+
+def test_lifespan_cancels_sweeper(monkeypatch):
+    created_tasks = []
+    create_task = asyncio.create_task
+
+    def track_task(coroutine):
+        task = create_task(coroutine)
+        created_tasks.append(task)
+        return task
+
+    async def exercise_lifespan():
+        started = asyncio.Event()
+        stopped = asyncio.Event()
+
+        async def fake_sweeper():
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                stopped.set()
+
+        monkeypatch.setattr(api_app, "sweeper", fake_sweeper)
+        monkeypatch.setattr(api_app.asyncio, "create_task", track_task)
+        torch_gc = Mock()
+        monkeypatch.setattr(api_app, "torch_gc", torch_gc)
+        chat_model = SimpleNamespace(engine=SimpleNamespace(name=EngineName.HF))
+
+        async with api_app.lifespan(None, chat_model):
+            await started.wait()
+
+        assert len(created_tasks) == 1
+        assert created_tasks[0].done()
+        assert created_tasks[0].cancelled()
+        assert stopped.is_set()
+        torch_gc.assert_called_once_with()
+
+    asyncio.run(exercise_lifespan())


### PR DESCRIPTION
# What does this PR do?

This PR ensures the Hugging Face API memory sweeper is stopped when the FastAPI application lifespan exits.

## Background

The API lifespan started `sweeper()` with `asyncio.create_task()` but discarded the task handle. When the application shut down or its lifespan restarted in the same event loop, the periodic background task remained pending and could outlive the app instance.

## Changes

- Keep the sweeper task handle for Hugging Face engine instances.
- Cancel and await the task in the lifespan `finally` block.
- Preserve the existing final `torch_gc()` call.
- Add a regression test that verifies the task reaches the cancelled state before lifespan shutdown completes.

## Verification

- Before the fix: `WANDB_DISABLED=true .venv/bin/pytest -q tests/api/test_app.py` failed because the sweeper task was still pending.
- After the fix: the same command passes (`1 passed`).
- Full suite: `make test` (`306 passed, 22 skipped, 3 xfailed, 4 xpassed`).
- Quality: Ruff 0.15.5 checks and changed-files pre-commit hooks pass.
- Packaging: `make license` and `make build` pass.

## Impact

- Scope: `src/llamafactory/api/app.py`
- Breaking change: No
- Training and inference behavior: Unchanged

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
