### PR TITLE
fix(webui): tolerate partial trainer log writes

### DIFF
--- a/src/llamafactory/webui/control.py
+++ b/src/llamafactory/webui/control.py
@@ -128,7 +128,13 @@ def get_trainer_info(lang: str, output_path: os.PathLike, do_train: bool) -> tup
         trainer_log: list[dict[str, Any]] = []
         with open(trainer_log_path, encoding="utf-8") as f:
             for line in f:
-                trainer_log.append(json.loads(line))
+                try:
+                    trainer_log.append(json.loads(line))
+                except json.JSONDecodeError:
+                    if line.endswith("\n"):
+                        raise
+
+                    break
 
         if len(trainer_log) != 0:
             latest_log = trainer_log[-1]

--- a/tests/webui/test_control.py
+++ b/tests/webui/test_control.py
@@ -1,0 +1,49 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from llamafactory.extras.constants import TRAINER_LOG
+from llamafactory.webui import control
+
+
+COMPLETE_LOG = {
+    "current_steps": 1,
+    "total_steps": 2,
+    "percentage": 50,
+    "elapsed_time": "1s",
+    "remaining_time": "1s",
+}
+
+
+def test_get_trainer_info_ignores_incomplete_trailing_log(tmp_path, monkeypatch):
+    trainer_log = tmp_path / TRAINER_LOG
+    trainer_log.write_text(json.dumps(COMPLETE_LOG) + '\n{"current_steps":', encoding="utf-8")
+    monkeypatch.setattr(control.gr, "Slider", lambda **kwargs: kwargs)
+
+    _, progress, _ = control.get_trainer_info("en", tmp_path, do_train=False)
+
+    assert progress["value"] == 50
+    assert progress["visible"] is True
+
+
+def test_get_trainer_info_rejects_complete_invalid_log(tmp_path, monkeypatch):
+    trainer_log = tmp_path / TRAINER_LOG
+    trainer_log.write_text(json.dumps(COMPLETE_LOG) + "\nnot-json\n", encoding="utf-8")
+    monkeypatch.setattr(control.gr, "Slider", lambda **kwargs: kwargs)
+
+    with pytest.raises(json.JSONDecodeError):
+        control.get_trainer_info("en", tmp_path, do_train=False)


### PR DESCRIPTION
# What does this PR do?

This PR keeps LlamaBoard monitoring responsive when it reads `trainer_log.jsonl` while the trainer is still writing the final line.

## Production race

`LogCallback` appends progress records to:

```text
<output_dir>/trainer_log.jsonl
```

At the same time, `Runner.monitor()` repeatedly calls `get_trainer_info()`, which opens that file and parses every line to update the progress bar and loss plot.

There is no synchronization between those processes. If the monitor opens the file after the writer has made only part of its final JSON object visible, the last line is not valid JSON yet. The previous implementation raised `JSONDecodeError`, interrupting that LlamaBoard refresh instead of continuing from the latest complete record.

## Concurrent-write reproduction

Environment:

- LLaMA Factory `0.9.6.dev0`
- Python `3.11.15`
- Gradio `5.50.0`

I reproduced the file race with the production `get_trainer_info()` function and a real writer thread:

1. Write and flush a complete step-1 record.
2. Write half of the step-2 JSON object.
3. Call `flush()` and `os.fsync()` so the partial tail is visible to another file descriptor.
4. Trigger the LlamaBoard monitor read while the writer is paused.
5. Complete and flush the step-2 record.
6. Read again.

The two records represent 50% and 100% progress:

```json
{"current_steps": 1, "total_steps": 2, "percentage": 50, "elapsed_time": "0:00:01", "remaining_time": "0:00:01"}
{"current_steps": 2, "total_steps": 2, "percentage": 100, "elapsed_time": "0:00:02", "remaining_time": "0:00:00"}
```

### `main`

The monitor cannot render the latest complete progress while the second line is in flight:

```text
PARTIAL_READ error=JSONDecodeError: Expecting ',' delimiter: line 1 column 57 (char 56)
COMPLETE_READ progress={"value": 100, "visible": true, "label": "Running 2/2: 0:00:02 < 0:00:00"}
MALFORMED_LINE error=JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

### This PR

The same interleaving keeps the progress bar on the latest complete record, then advances after the writer finishes:

```text
PARTIAL_READ progress={"value": 50, "visible": true, "label": "Running 1/2: 0:00:01 < 0:00:01"}
COMPLETE_READ progress={"value": 100, "visible": true, "label": "Running 2/2: 0:00:02 < 0:00:00"}
MALFORMED_LINE error=JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

The malformed-line control uses `not-json\n`. It still raises because a newline-terminated record is complete and should never be silently ignored.

## Changes

- Ignore only an unterminated malformed tail, which can represent an in-progress JSONL write.
- Continue using the latest complete log record for progress and plotting.
- Preserve strict failure for malformed records that end with a newline.
- Add regression tests for both behaviors.

## Verification

- Real concurrent file-descriptor reproduction on `main`: partial tail raises `JSONDecodeError`.
- Same reproduction on this PR: monitor returns the previous 50% progress, then advances to 100%.
- Complete malformed line: raises on both revisions.
- `WANDB_DISABLED=true .venv/bin/pytest -q tests/webui/test_control.py`: `2 passed`.
- `uvx ruff@0.15.5 check src/llamafactory/webui/control.py tests/webui/test_control.py`: passed.
- `uvx ruff@0.15.5 format --check src/llamafactory/webui/control.py tests/webui/test_control.py`: passed.

## Impact

- Scope: LlamaBoard progress-log monitoring only.
- Breaking change: No.
- Trainer logging format and write path: Unchanged.
- Complete malformed JSONL records: Still rejected.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LlamaFactory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
