### PR TITLE
fix(api): reject non-positive response counts

### DIFF
--- a/src/llamafactory/api/protocol.py
+++ b/src/llamafactory/api/protocol.py
@@ -101,7 +101,7 @@ class ChatCompletionRequest(BaseModel):
     do_sample: bool | None = None
     temperature: float | None = None
     top_p: float | None = None
-    n: int = 1
+    n: int = Field(default=1, ge=1)
     presence_penalty: float | None = None
     max_tokens: int | None = None
     stop: str | list[str] | None = None

--- a/tests/api/test_protocol.py
+++ b/tests/api/test_protocol.py
@@ -1,0 +1,33 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from pydantic import ValidationError
+
+from llamafactory.api.protocol import ChatCompletionRequest
+
+
+MESSAGES = [{"role": "user", "content": "Hello"}]
+
+
+@pytest.mark.parametrize("n", [0, -1])
+def test_chat_completion_request_rejects_non_positive_response_count(n):
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(model="test", messages=MESSAGES, n=n)
+
+
+def test_chat_completion_request_allows_multiple_non_streamed_responses():
+    request = ChatCompletionRequest(model="test", messages=MESSAGES, n=2)
+
+    assert request.n == 2


### PR DESCRIPTION
# What does this PR do?

Rejects OpenAI-compatible chat completion requests with `n <= 0` before they reach an inference backend.

## Problem

`ChatCompletionRequest.n` accepted any integer and passed it unchanged as `num_return_sequences`.

Using the real FastAPI application under uvicorn with a recording backend:

```text
                main                 this PR
n=0             HTTP 200, backend    HTTP 422, no backend call
n=-1            HTTP 200, backend    HTTP 422, no backend call
n=2             HTTP 200, backend    HTTP 200, backend
```

The 422 response identifies `body.n` and reports `Input should be greater than or equal to 1`.

## Changes

- Define `n` as `Field(default=1, ge=1)`.
- Test zero, negative, and valid multiple-response values.
- Keep the existing streaming `n > 1` behavior unchanged.

## Verification

- `WANDB_DISABLED=true .venv/bin/pytest -q tests/api/test_protocol.py`: `3 passed`
- Ruff lint and format checks: passed
- Full implementation suite: `308 passed, 22 skipped, 3 xfailed, 4 xpassed`

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LlamaFactory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
