### PR TITLE
fix(webui): preserve zero values in loss plots

### DIFF
--- a/src/llamafactory/extras/ploting.py
+++ b/src/llamafactory/extras/ploting.py
@@ -54,7 +54,7 @@ def gen_loss_plot(trainer_log: list[dict[str, Any]]) -> "matplotlib.figure.Figur
     ax = fig.add_subplot(111)
     steps, losses = [], []
     for log in trainer_log:
-        if log.get("loss", None):
+        if log.get("loss") is not None:
             steps.append(log["current_steps"])
             losses.append(log["loss"])
 

--- a/tests/extras/test_ploting.py
+++ b/tests/extras/test_ploting.py
@@ -1,0 +1,30 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from llamafactory.extras.ploting import gen_loss_plot
+
+
+def test_gen_loss_plot_preserves_zero_loss():
+    figure = gen_loss_plot(
+        [
+            {"current_steps": 1, "loss": 0.0},
+            {"current_steps": 2},
+            {"current_steps": 3, "loss": 1.0},
+            {"current_steps": 4, "loss": None},
+        ]
+    )
+
+    original_line = figure.axes[0].lines[0]
+    assert original_line.get_xdata().tolist() == [1, 3]
+    assert original_line.get_ydata().tolist() == [0.0, 1.0]


### PR DESCRIPTION
# What does this PR do?

This PR preserves valid zero-valued loss records in LlamaBoard training plots.

## Production path

`LogCallback.on_log()` copies the Trainer's current loss into each `trainer_log.jsonl` record:

```python
loss=state.log_history[-1].get("loss")
```

LlamaBoard then reads the JSONL file in `get_trainer_info()` and passes all records to `gen_loss_plot()` for the original and EMA-smoothed curves.

A loss can legitimately be exactly `0.0`, for example after a small dataset is overfit or a low-precision/logged value reaches zero. The previous plot filter used Python truthiness:

```python
if log.get("loss", None):
```

That treated `0.0` like a missing value and silently removed the step from both curves.

## LlamaBoard log reproduction

Environment:

- LLaMA Factory `0.9.6.dev0`
- Gradio `5.50.0`
- Matplotlib `3.11.1`

I wrote these records to a real `trainer_log.jsonl` file and passed its directory through the production `get_trainer_info(..., do_train=True)` monitor path:

```json
{"current_steps": 1, "total_steps": 4, "percentage": 25, "elapsed_time": "0:00:01", "remaining_time": "0:00:03", "loss": 0.0}
{"current_steps": 2, "total_steps": 4, "percentage": 50, "elapsed_time": "0:00:02", "remaining_time": "0:00:02"}
{"current_steps": 3, "total_steps": 4, "percentage": 75, "elapsed_time": "0:00:03", "remaining_time": "0:00:01", "loss": 1.0}
{"current_steps": 4, "total_steps": 4, "percentage": 100, "elapsed_time": "0:00:04", "remaining_time": "0:00:00", "loss": null}
```

The monitor successfully produced the Gradio Matplotlib plot and a 100% progress bar in both revisions. The plotted coordinates differ:

### `main`

```text
PROGRESS value=100 visible=True
GRADIO_PLOT type=matplotlib encoded=True
ORIGINAL steps=[3] losses=[1.0]
SMOOTHED steps=[3] losses=[1.0]
```

The valid zero at step 1 is absent from both curves.

### This PR

```text
PROGRESS value=100 visible=True
GRADIO_PLOT type=matplotlib encoded=True
ORIGINAL steps=[1, 3] losses=[0.0, 1.0]
SMOOTHED steps=[1, 3] losses=[0.0, 0.955037462537908]
```

The explicit zero is restored and becomes the EMA starting point. Step 2, where `loss` is absent, and step 4, where it is `null`, remain excluded.

## Changes

- Treat any non-`None` loss value, including `0.0`, as a valid metric.
- Continue skipping records where the loss field is missing or explicitly `None`.
- Add a regression test that inspects the plotted step and loss data.

## Verification

- Real `trainer_log.jsonl` through LlamaBoard monitor path on `main`: zero-loss step omitted.
- Same log on this PR: original and smoothed curves both include the zero-loss step.
- Missing and null losses: excluded on both revisions.
- `WANDB_DISABLED=true .venv/bin/pytest -q tests/extras/test_ploting.py`: `1 passed`.
- `uvx ruff@0.15.5 check src/llamafactory/extras/ploting.py tests/extras/test_ploting.py`: passed.
- `uvx ruff@0.15.5 format --check src/llamafactory/extras/ploting.py tests/extras/test_ploting.py`: passed.
- Full suite from the implementation run: `306 passed, 22 skipped, 3 xfailed, 4 xpassed`.

## Impact

- Scope: LlamaBoard loss visualization only.
- Breaking change: No.
- Training metrics and model behavior: Unchanged.
- Missing/null loss filtering: Unchanged.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LlamaFactory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
