### PR TITLE
fix(ppo): restore temporary model state on errors

### DIFF
--- a/src/llamafactory/train/ppo/trainer.py
+++ b/src/llamafactory/train/ppo/trainer.py
@@ -357,14 +357,17 @@ class CustomPPOTrainer(PPOTrainer, Trainer):
 
         with unwrap_model_for_generation(self.model, self.accelerator) as unwrapped_model:
             unwrapped_model: AutoModelForCausalLMWithValueHead = self.accelerator.unwrap_model(self.model)
+            layernorm_params = None
             if self.model_args.upcast_layernorm:
                 layernorm_params = dump_layernorm(unwrapped_model)
 
-            generate_output: torch.Tensor = unwrapped_model.generate(
-                generation_config=self.generation_config, logits_processor=get_logits_processor(), **batch
-            )
-            if self.model_args.upcast_layernorm:
-                restore_layernorm(unwrapped_model, layernorm_params)
+            try:
+                generate_output: torch.Tensor = unwrapped_model.generate(
+                    generation_config=self.generation_config, logits_processor=get_logits_processor(), **batch
+                )
+            finally:
+                if layernorm_params is not None:
+                    restore_layernorm(unwrapped_model, layernorm_params)
 
         query = batch["input_ids"].detach().cpu()
         response = generate_output[:, batch["input_ids"].size(-1) :].detach().cpu()
@@ -403,17 +406,21 @@ class CustomPPOTrainer(PPOTrainer, Trainer):
         batch: dict[str, torch.Tensor] = self.prepare_model_inputs(queries, responses)
         unwrapped_model: AutoModelForCausalLMWithValueHead = self.accelerator.unwrap_model(self.model)
 
-        if self.finetuning_args.reward_model_type in ["lora", "oft"]:
+        use_reward_adapter = self.finetuning_args.reward_model_type in ["lora", "oft"]
+        adapter_replaced = False
+        if use_reward_adapter:
             replace_model(unwrapped_model, target="reward")
+            adapter_replaced = True
             reward_model = self.model
         else:
             reward_model = self.reward_model
 
-        with unwrap_model_for_generation(reward_model, self.accelerator), self.amp_context:  # support bf16
-            values: torch.Tensor = reward_model(**batch, return_dict=True, use_cache=False)[-1]
-
-        if self.finetuning_args.reward_model_type in ["lora", "oft"]:
-            replace_model(unwrapped_model, target="default")
+        try:
+            with unwrap_model_for_generation(reward_model, self.accelerator), self.amp_context:  # support bf16
+                values: torch.Tensor = reward_model(**batch, return_dict=True, use_cache=False)[-1]
+        finally:
+            if adapter_replaced:
+                replace_model(unwrapped_model, target="default")
 
         rewards = values.gather(dim=-1, index=(batch["attention_mask"].sum(dim=-1, keepdim=True) - 1))
         return rewards.float().detach()  # use fp32 type

--- a/tests/train/ppo/test_trainer.py
+++ b/tests/train/ppo/test_trainer.py
@@ -1,0 +1,75 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
+import torch
+
+import llamafactory.train.ppo.trainer as ppo_trainer
+
+
+class FailingModel:
+    def generate(self, **kwargs):
+        raise RuntimeError("generation failed")
+
+    def __call__(self, **kwargs):
+        raise RuntimeError("reward failed")
+
+
+def test_get_inputs_restores_layernorm_after_generation_error(monkeypatch):
+    model = FailingModel()
+    restore_layernorm = Mock()
+    trainer = SimpleNamespace(
+        model=model,
+        accelerator=SimpleNamespace(unwrap_model=lambda _: model),
+        model_args=SimpleNamespace(upcast_layernorm=True),
+        generation_config=object(),
+        tokenizer=SimpleNamespace(pad_token_id=0, eos_token_id=1),
+    )
+    batch = {
+        "input_ids": torch.tensor([[1, 2], [3, 4]]),
+        "attention_mask": torch.ones((2, 2), dtype=torch.long),
+    }
+    layernorm_params = {"layernorm.weight": torch.ones(1)}
+    monkeypatch.setattr(ppo_trainer, "unwrap_model_for_generation", lambda *_: nullcontext(model))
+    monkeypatch.setattr(ppo_trainer, "dump_layernorm", Mock(return_value=layernorm_params))
+    monkeypatch.setattr(ppo_trainer, "restore_layernorm", restore_layernorm)
+
+    with pytest.raises(RuntimeError, match="generation failed"):
+        ppo_trainer.CustomPPOTrainer.get_inputs(trainer, batch)
+
+    restore_layernorm.assert_called_once_with(model, layernorm_params)
+
+
+def test_get_rewards_restores_default_adapter_after_forward_error(monkeypatch):
+    model = FailingModel()
+    replace_model = Mock()
+    trainer = SimpleNamespace(
+        model=model,
+        reward_model=None,
+        accelerator=SimpleNamespace(unwrap_model=lambda _: model),
+        finetuning_args=SimpleNamespace(reward_model_type="lora"),
+        amp_context=nullcontext(),
+        prepare_model_inputs=lambda *_: {"attention_mask": torch.ones((1, 2), dtype=torch.long)},
+    )
+    monkeypatch.setattr(ppo_trainer, "unwrap_model_for_generation", lambda *_: nullcontext())
+    monkeypatch.setattr(ppo_trainer, "replace_model", replace_model)
+
+    with pytest.raises(RuntimeError, match="reward failed"):
+        ppo_trainer.CustomPPOTrainer.get_rewards(trainer, [torch.tensor([1])], [torch.tensor([2])])
+
+    assert replace_model.call_args_list == [call(model, target="reward"), call(model, target="default")]


### PR DESCRIPTION
# What does this PR do?

This PR guarantees that temporary PPO model state is restored when generation or reward inference raises an exception.

## Background

PPO temporarily changes model state in two paths:

- LayerNorm parameters are converted for generation when `upcast_layernorm` is enabled.
- LoRA/OFT reward adapters and value heads are activated for reward inference.

Both restoration steps previously ran only after successful inference. An exception left the model in the temporary state, which could contaminate later cleanup, retries, or caller-visible state.

## Changes

- Restore converted LayerNorm parameters in a `finally` block.
- Restore the default adapter and value head in a `finally` block after a successful reward-state switch.
- Add focused regression tests that force both inference paths to fail.

## Verification

- Before the fix: both focused tests failed because neither restoration function ran.
- After the fix: `WANDB_DISABLED=true .venv/bin/pytest -q tests/train/ppo/test_trainer.py` reports `2 passed`.
- Full suite: `make test` reports `307 passed, 22 skipped, 3 xfailed, 4 xpassed`.
- Ruff 0.15.5, changed-files pre-commit hooks, license checks, and `make build` pass.

## Impact

- Scope: PPO exception cleanup only.
- Breaking change: No.
- Successful generation and reward behavior: Unchanged.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
