### PR TITLE
fix(sft): ignore empty labels in token accuracy

### DIFF
--- a/src/llamafactory/train/sft/metric.py
+++ b/src/llamafactory/train/sft/metric.py
@@ -65,7 +65,7 @@ class ComputeAccuracy:
     def _dump(self) -> Optional[dict[str, float]]:
         result = None
         if hasattr(self, "score_dict"):
-            result = {k: float(np.mean(v)) for k, v in self.score_dict.items()}
+            result = {k: float(np.mean(v)) for k, v in self.score_dict.items() if len(v) > 0}
 
         self.score_dict = {"accuracy": []}
         return result
@@ -78,7 +78,8 @@ class ComputeAccuracy:
         for i in range(len(preds)):
             pred, label = preds[i, :-1], labels[i, 1:]
             label_mask = label != IGNORE_INDEX
-            self.score_dict["accuracy"].append(np.mean(pred[label_mask] == label[label_mask]))
+            if label_mask.any():
+                self.score_dict["accuracy"].append(np.mean(pred[label_mask] == label[label_mask]))
 
         if compute_result:
             return self._dump()

--- a/tests/train/sft/test_metric.py
+++ b/tests/train/sft/test_metric.py
@@ -1,0 +1,52 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+import numpy as np
+from transformers import EvalPrediction
+
+from llamafactory.extras.constants import IGNORE_INDEX
+from llamafactory.train.sft.metric import ComputeAccuracy
+
+
+def test_compute_accuracy_ignores_samples_without_valid_labels():
+    eval_preds = EvalPrediction(
+        predictions=np.array([[1, 2, 3], [2, 3, 0]]),
+        label_ids=np.array(
+            [
+                [IGNORE_INDEX, IGNORE_INDEX, IGNORE_INDEX],
+                [IGNORE_INDEX, 2, 3],
+            ]
+        ),
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = ComputeAccuracy()(eval_preds)
+
+    assert result == {"accuracy": 1.0}
+
+
+def test_compute_accuracy_returns_empty_result_without_valid_labels():
+    eval_preds = EvalPrediction(
+        predictions=np.array([[1, 2, 3]]),
+        label_ids=np.array([[IGNORE_INDEX, IGNORE_INDEX, IGNORE_INDEX]]),
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = ComputeAccuracy()(eval_preds)
+
+    assert result == {}


### PR DESCRIPTION
# What does this PR do?

Prevents one SFT evaluation sample with no post-shift target labels from turning the batch token accuracy into `NaN`.

## Problem

With the `empty` template, a valid one-token response has no labels left after the causal shift used by token accuracy. `ComputeAccuracy` called `np.mean()` on that empty selection, emitting warnings and contaminating the metric from other valid samples.

I reproduced this through the full CLI evaluation path with two retained Alpaca samples:

```json
[
  {"instruction": "", "input": "", "output": "a"},
  {"instruction": "", "input": "", "output": "a b"}
]
```

```text
                main        this PR
eval_accuracy   nan         0.0
eval_loss       3.8994      3.8994
warnings        2           0
```

The unchanged loss confirms that only metric aggregation changes.

## Changes

- Skip samples with no valid target labels after the causal shift.
- Return an empty metric dictionary when an entire window has no valid labels.
- Test mixed and fully masked batches with RuntimeWarnings promoted to errors.

## Verification

- `WANDB_DISABLED=true .venv/bin/pytest -q tests/train/sft/test_metric.py`: `2 passed`
- Ruff lint and format checks: passed
- Full implementation suite: `307 passed, 22 skipped, 3 xfailed, 4 xpassed`

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LlamaFactory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
