### PR TITLE
perf: reduce DPO log-prob memory usage

### DIFF
--- a/src/llamafactory/train/dpo/trainer.py
+++ b/src/llamafactory/train/dpo/trainer.py
@@ -35,6 +35,26 @@ from ..callbacks import SaveProcessorCallback
 from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_batch_logps, nested_detach
 
 
+def get_batch_logps_memory_efficient(
+    logits: "torch.Tensor", labels: "torch.Tensor", label_pad_token_id: int = IGNORE_INDEX
+) -> tuple["torch.Tensor", "torch.Tensor"]:
+    r"""Compute label log probabilities without materializing full-vocabulary log-softmax."""
+    labels = labels[:, 1:].clone()
+    logits = logits[:, :-1, :]
+    loss_mask = labels != label_pad_token_id
+    labels[~loss_mask] = 0
+    logps = []
+    for start in range(0, logits.size(1), 64):
+        chunk = logits[:, start : start + 64, :].float()
+        chunk_labels = labels[:, start : start + 64]
+        target_logits = torch.gather(chunk, dim=2, index=chunk_labels.unsqueeze(2)).squeeze(2)
+        logps.append(target_logits - torch.logsumexp(chunk, dim=-1))
+
+    per_token_logps = torch.cat(logps, dim=1)
+    valid_length = loss_mask.sum(-1)
+    return (per_token_logps * loss_mask).sum(-1), valid_length
+
+
 if TYPE_CHECKING:
     from transformers import PreTrainedModel, ProcessorMixin
 
@@ -227,10 +247,11 @@ class CustomDPOTrainer(DPOTrainer):
             batch = nested_detach(batch, clone=True)  # avoid error
 
         labels = batch.pop("labels")  # dpo do not need compute loss in forward
-        all_logits: torch.Tensor = model(**batch, return_dict=True, use_cache=False).logits.to(torch.float32)
-        all_logps, valid_length = get_batch_logps(
-            logits=all_logits, labels=labels, ld_alpha=(self.ld_alpha if not is_ref_model else None)
-        )
+        all_logits: torch.Tensor = model(**batch, return_dict=True, use_cache=False).logits
+        if self.ld_alpha is not None and not is_ref_model:
+            all_logps, valid_length = get_batch_logps(logits=all_logits.float(), labels=labels, ld_alpha=self.ld_alpha)
+        else:
+            all_logps, valid_length = get_batch_logps_memory_efficient(logits=all_logits, labels=labels)
         if self.loss_type in ["ipo", "orpo", "simpo"]:
             all_logps = all_logps / valid_length
 

--- a/src/llamafactory/train/dpo/trainer.py
+++ b/src/llamafactory/train/dpo/trainer.py
@@ -35,7 +35,7 @@ from ..callbacks import SaveProcessorCallback
 from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_batch_logps, nested_detach
 
 
-_LOGPS_CHUNK_ELEMENTS = 2**24  # ~64 MB of float32 temporaries per chunk
+_LOGPS_CHUNK_ELEMENTS = 2**24  # ~64 MB of float32 temporaries per chunk, summed over the batch dim
 
 
 def get_batch_logps_memory_efficient(
@@ -48,14 +48,15 @@ def get_batch_logps_memory_efficient(
 
     The sequence dimension is processed in chunks so that only ``chunk_size`` positions of
     float32 logit copies are allocated at a time. When ``chunk_size`` is None, it is derived
-    from the vocabulary size to bound each chunk near ``_LOGPS_CHUNK_ELEMENTS`` elements.
+    from the vocabulary size and the batch size to bound each chunk's total element count
+    (batch positions times vocabulary) near ``_LOGPS_CHUNK_ELEMENTS``.
     """
     labels = labels[:, 1:].clone()
     logits = logits[:, :-1, :]
     loss_mask = labels != label_pad_token_id
     labels[~loss_mask] = 0
     if chunk_size is None:
-        chunk_size = max(1, _LOGPS_CHUNK_ELEMENTS // logits.size(-1))
+        chunk_size = max(1, _LOGPS_CHUNK_ELEMENTS // (logits.size(-1) * logits.size(0)))
 
     logps = []
     for start in range(0, logits.size(1), chunk_size):

--- a/src/llamafactory/train/dpo/trainer.py
+++ b/src/llamafactory/train/dpo/trainer.py
@@ -35,18 +35,32 @@ from ..callbacks import SaveProcessorCallback
 from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, get_batch_logps, nested_detach
 
 
+_LOGPS_CHUNK_ELEMENTS = 2**24  # ~64 MB of float32 temporaries per chunk
+
+
 def get_batch_logps_memory_efficient(
-    logits: "torch.Tensor", labels: "torch.Tensor", label_pad_token_id: int = IGNORE_INDEX
+    logits: "torch.Tensor",
+    labels: "torch.Tensor",
+    label_pad_token_id: int = IGNORE_INDEX,
+    chunk_size: Optional[int] = None,
 ) -> tuple["torch.Tensor", "torch.Tensor"]:
-    r"""Compute label log probabilities without materializing full-vocabulary log-softmax."""
+    r"""Compute label log probabilities without materializing full-vocabulary log-softmax.
+
+    The sequence dimension is processed in chunks so that only ``chunk_size`` positions of
+    float32 logit copies are allocated at a time. When ``chunk_size`` is None, it is derived
+    from the vocabulary size to bound each chunk near ``_LOGPS_CHUNK_ELEMENTS`` elements.
+    """
     labels = labels[:, 1:].clone()
     logits = logits[:, :-1, :]
     loss_mask = labels != label_pad_token_id
     labels[~loss_mask] = 0
+    if chunk_size is None:
+        chunk_size = max(1, _LOGPS_CHUNK_ELEMENTS // logits.size(-1))
+
     logps = []
-    for start in range(0, logits.size(1), 64):
-        chunk = logits[:, start : start + 64, :].float()
-        chunk_labels = labels[:, start : start + 64]
+    for start in range(0, logits.size(1), chunk_size):
+        chunk = logits[:, start : start + chunk_size, :].float()
+        chunk_labels = labels[:, start : start + chunk_size]
         target_logits = torch.gather(chunk, dim=2, index=chunk_labels.unsqueeze(2)).squeeze(2)
         logps.append(target_logits - torch.logsumexp(chunk, dim=-1))
 
@@ -257,7 +271,10 @@ class CustomDPOTrainer(DPOTrainer):
 
         batch_size = batch["input_ids"].size(0) // 2
         chosen_logps, rejected_logps = all_logps.split(batch_size, dim=0)
-        chosen_logits, rejected_logits = all_logits.split(batch_size, dim=0)
+        # only the means are consumed by get_batch_loss_metrics; reduce here so the full
+        # [batch, seq, vocab] logits are released before the reference model forward
+        chosen_logits = all_logits[:batch_size].mean()
+        rejected_logits = all_logits[batch_size:].mean()
         chosen_length, _ = valid_length.split(batch_size, dim=0)
         if self.loss_type in ["ipo", "orpo", "simpo"]:
             chosen_logps_avg = chosen_logps
@@ -329,8 +346,8 @@ class CustomDPOTrainer(DPOTrainer):
         metrics[f"{prefix}rewards/margins"] = (chosen_rewards - rejected_rewards).mean().item()
         metrics[f"{prefix}logps/chosen"] = policy_chosen_logps.mean().item()
         metrics[f"{prefix}logps/rejected"] = policy_rejected_logps.mean().item()
-        metrics[f"{prefix}logits/chosen"] = policy_chosen_logits.mean().item()
-        metrics[f"{prefix}logits/rejected"] = policy_rejected_logits.mean().item()
+        metrics[f"{prefix}logits/chosen"] = policy_chosen_logits.item()
+        metrics[f"{prefix}logits/rejected"] = policy_rejected_logits.item()
         if self.loss_type == "orpo":
             metrics[f"{prefix}sft_loss"] = sft_loss.mean().item()
             metrics[f"{prefix}odds_ratio_loss"] = ((losses - sft_loss) / self.beta).mean().item()

--- a/tests/train/test_dpo_trainer.py
+++ b/tests/train/test_dpo_trainer.py
@@ -1,0 +1,36 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from llamafactory.train.dpo.trainer import get_batch_logps_memory_efficient
+from llamafactory.train.trainer_utils import get_batch_logps
+
+
+def test_get_batch_logps_memory_efficient_matches_baseline():
+    torch.manual_seed(42)
+    labels = torch.randint(0, 17, (4, 130))
+    labels[:, :3] = -100
+    baseline_logits = torch.randn(4, 130, 17, requires_grad=True)
+    chunked_logits = baseline_logits.detach().clone().requires_grad_(True)
+
+    expected_logps, expected_lengths = get_batch_logps(baseline_logits, labels)
+    actual_logps, actual_lengths = get_batch_logps_memory_efficient(chunked_logits, labels)
+
+    torch.testing.assert_close(actual_logps, expected_logps)
+    torch.testing.assert_close(actual_lengths, expected_lengths)
+
+    expected_logps.sum().backward()
+    actual_logps.sum().backward()
+    torch.testing.assert_close(chunked_logits.grad, baseline_logits.grad)

--- a/tests/train/test_dpo_trainer.py
+++ b/tests/train/test_dpo_trainer.py
@@ -26,10 +26,15 @@ def test_get_batch_logps_memory_efficient_matches_baseline():
     chunked_logits = baseline_logits.detach().clone().requires_grad_(True)
 
     expected_logps, expected_lengths = get_batch_logps(baseline_logits, labels)
-    actual_logps, actual_lengths = get_batch_logps_memory_efficient(chunked_logits, labels)
+    actual_logps, actual_lengths = get_batch_logps_memory_efficient(chunked_logits, labels, chunk_size=32)
 
     torch.testing.assert_close(actual_logps, expected_logps)
     torch.testing.assert_close(actual_lengths, expected_lengths)
+
+    # adaptive chunk size (vocabulary-aware default) must match the baseline as well
+    default_logps, default_lengths = get_batch_logps_memory_efficient(baseline_logits.detach(), labels)
+    torch.testing.assert_close(default_logps, expected_logps)
+    torch.testing.assert_close(default_lengths, expected_lengths)
 
     expected_logps.sum().backward()
     actual_logps.sum().backward()


### PR DESCRIPTION
 ## What does this PR do?

  Reduces peak memory usage during DPO log-probability computation.

  Instead of materializing `logits.log_softmax(-1)` for the full `[batch, `sequence,` vocabulary]` tensor, this computes target-token log probabilities in sequence chunks
  using `gather` and `logsumexp`. This preserves the same outputs and gradients while limiting temporary float32 allocations.

  LD-DPO keeps the existing implementation because it needs per-token log probabilities for its custom masking logic.

  ## Motivation

  The full-vocabulary float32 log-softmax tensor can cause out-of-memory failures during preference training, especially with long sequences and large vocabularies.
  Chunking across the sequence dimension lowers temporary memory without changing model outputs.

  ## Tests

  - Added numerical equivalence coverage against `get_batch_logps`
  - Added gradient equivalence coverage
  - `ruff check` and `ruff format --check` pass
  - `WANDB_DISABLED=true pytest -q --import-mode=importlib tests/train/test_dpo_trainer.py` `passes```