### PR TITLE
fix(sglang): close streaming responses on cancellation

### DIFF
--- a/src/llamafactory/chat/sglang_engine.py
+++ b/src/llamafactory/chat/sglang_engine.py
@@ -217,17 +217,17 @@ class SGLangEngine(BaseEngine):
             }
             if self.lora_request:
                 json_data["lora_request"] = ["lora0"]
-            response = requests.post(f"{self.base_url}/generate", json=json_data, stream=True)
-            if response.status_code != 200:
-                raise RuntimeError(f"SGLang server error: {response.status_code}, {response.text}")
+            with requests.post(f"{self.base_url}/generate", json=json_data, stream=True) as response:
+                if response.status_code != 200:
+                    raise RuntimeError(f"SGLang server error: {response.status_code}, {response.text}")
 
-            for chunk in response.iter_lines(decode_unicode=False):
-                chunk = str(chunk.decode("utf-8"))
-                if chunk == "data: [DONE]":
-                    break
+                for chunk in response.iter_lines(decode_unicode=False):
+                    chunk = str(chunk.decode("utf-8"))
+                    if chunk == "data: [DONE]":
+                        break
 
-                if chunk and chunk.startswith("data:"):
-                    yield json.loads(chunk[5:].strip("\n"))
+                    if chunk and chunk.startswith("data:"):
+                        yield json.loads(chunk[5:].strip("\n"))
 
         return await asyncio.to_thread(stream_request)
 

--- a/tests/chat/test_sglang_engine.py
+++ b/tests/chat/test_sglang_engine.py
@@ -1,0 +1,68 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from types import SimpleNamespace
+
+from llamafactory.chat import sglang_engine
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self):
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
+        self.closed = True
+
+    def iter_lines(self, decode_unicode=False):
+        yield b'data: {"text": "partial"}'
+        yield b"data: [DONE]"
+
+
+def test_generate_closes_response_when_stream_stops_early(monkeypatch):
+    response = _FakeResponse()
+    monkeypatch.setattr(sglang_engine.requests, "post", lambda *args, **kwargs: response)
+
+    engine = object.__new__(sglang_engine.SGLangEngine)
+    engine.base_url = "http://localhost:30000"
+    engine.generating_args = {
+        "max_new_tokens": 8,
+        "repetition_penalty": 1.0,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "top_k": 50,
+        "skip_special_tokens": True,
+    }
+    engine.lora_request = False
+    engine.processor = None
+    engine.tokenizer = SimpleNamespace()
+    engine.template = SimpleNamespace(
+        mm_plugin=SimpleNamespace(process_messages=lambda messages, *args: messages),
+        encode_oneturn=lambda *args: ([1, 2], None),
+        get_stop_token_ids=lambda tokenizer: [3],
+    )
+
+    generator = asyncio.run(engine._generate([{"role": "user", "content": "hello"}]))
+    assert next(generator) == {"text": "partial"}
+    generator.close()
+
+    assert response.closed


### PR DESCRIPTION
# What does this PR do?

This PR ensures that SGLang streaming HTTP responses are closed when a consumer stops reading before the server sends `[DONE]`.

`stream_request` previously kept the `requests.Response` outside a context manager. Closing the Python generator early therefore left the response open. The response is now managed with a `with` block, which releases the connection on normal completion, HTTP errors, and generator cancellation.

No associated issue.

## Verification

- Before the fix: `WANDB_DISABLED=true .venv/bin/pytest -q tests/chat/test_sglang_engine.py` (`1 failed`, response remained open)
- After the fix: `WANDB_DISABLED=true .venv/bin/pytest -q tests/chat/test_sglang_engine.py` (`1 passed`)
- Full suite: `make test` (`306 passed, 22 skipped, 3 xfailed, 4 xpassed`)
- Lint: `uvx ruff@0.15.5 check src/llamafactory/chat/sglang_engine.py tests/chat/test_sglang_engine.py`
- Format: `uvx ruff@0.15.5 format --check src/llamafactory/chat/sglang_engine.py tests/chat/test_sglang_engine.py`

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LlamaFactory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
