### PR TITLE
fix(data): close video containers after decoding

### DIFF
--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -288,18 +288,18 @@ class MMPluginMixin:
                 frames = video
                 durations.append(len(frames) / kwargs.get("video_fps", 2.0))
             else:
-                container = av.open(video, "r")
-                video_stream = next(stream for stream in container.streams if stream.type == "video")
-                sample_indices = self._get_video_sample_indices(video_stream, **kwargs)
-                container.seek(0)
-                for frame_idx, frame in enumerate(container.decode(video_stream)):
-                    if frame_idx in sample_indices:
-                        frames.append(frame.to_image())
+                with av.open(video, "r") as container:
+                    video_stream = next(stream for stream in container.streams if stream.type == "video")
+                    sample_indices = self._get_video_sample_indices(video_stream, **kwargs)
+                    container.seek(0)
+                    for frame_idx, frame in enumerate(container.decode(video_stream)):
+                        if frame_idx in sample_indices:
+                            frames.append(frame.to_image())
 
-                if video_stream.duration is None:
-                    durations.append(len(frames) / kwargs.get("video_fps", 2.0))
-                else:
-                    durations.append(float(video_stream.duration * video_stream.time_base))
+                    if video_stream.duration is None:
+                        durations.append(len(frames) / kwargs.get("video_fps", 2.0))
+                    else:
+                        durations.append(float(video_stream.duration * video_stream.time_base))
 
             frames = self._regularize_images(frames, **kwargs)["images"]
             results.append(frames)
@@ -980,21 +980,23 @@ class Gemma4Plugin(BasePlugin):
                 durations.append(len(frames) / kwargs.get("video_fps", 2.0))
                 frames_indices.append(list(range(len(frames))))
             else:
-                container = av.open(video, "r")
-                video_stream = next(stream for stream in container.streams if stream.type == "video")
-                sample_indices = self._get_video_sample_indices(video_stream, **kwargs)
-                original_fps = float(video_stream.average_rate)
-                # for correctly calculate timestamps
-                frames_indices.append([idx / original_fps * kwargs.get("video_fps", 2.0) for idx in sample_indices])
-                container.seek(0)
-                for frame_idx, frame in enumerate(container.decode(video_stream)):
-                    if frame_idx in sample_indices:
-                        frames.append(frame.to_image())
+                with av.open(video, "r") as container:
+                    video_stream = next(stream for stream in container.streams if stream.type == "video")
+                    sample_indices = self._get_video_sample_indices(video_stream, **kwargs)
+                    original_fps = float(video_stream.average_rate)
+                    # for correctly calculate timestamps
+                    frames_indices.append(
+                        [idx / original_fps * kwargs.get("video_fps", 2.0) for idx in sample_indices]
+                    )
+                    container.seek(0)
+                    for frame_idx, frame in enumerate(container.decode(video_stream)):
+                        if frame_idx in sample_indices:
+                            frames.append(frame.to_image())
 
-                if video_stream.duration is None:
-                    durations.append(len(frames) / kwargs.get("video_fps", 2.0))
-                else:
-                    durations.append(float(video_stream.duration * video_stream.time_base))
+                    if video_stream.duration is None:
+                        durations.append(len(frames) / kwargs.get("video_fps", 2.0))
+                    else:
+                        durations.append(float(video_stream.duration * video_stream.time_base))
 
             frames = self._regularize_images(frames, **kwargs)["images"]
             results.append(frames)
@@ -2290,25 +2292,27 @@ class Qwen2VLPlugin(BasePlugin):
                 durations.append(len(frames) / kwargs.get("video_fps", 2.0))
                 frames_indices.append(list(range(len(frames))))
             else:
-                container = av.open(video, "r")
-                video_stream = next(stream for stream in container.streams if stream.type == "video")
-                sample_indices = self._get_video_sample_indices(video_stream, **kwargs)
-                original_fps = float(video_stream.average_rate)
-                # for qwen3vl video timestamp calculation
-                frames_indices.append(
-                    [idx / original_fps * kwargs.get("video_fps", 2.0) for idx in sample_indices]
-                )  # hack usage when do_sample_frames=False
-                container.seek(0)
-                for frame_idx, frame in enumerate(container.decode(video_stream)):
-                    if frame_idx in sample_indices:
-                        frames.append(frame.to_image())
+                with av.open(video, "r") as container:
+                    video_stream = next(stream for stream in container.streams if stream.type == "video")
+                    sample_indices = self._get_video_sample_indices(video_stream, **kwargs)
+                    original_fps = float(video_stream.average_rate)
+                    # for qwen3vl video timestamp calculation
+                    frames_indices.append(
+                        [idx / original_fps * kwargs.get("video_fps", 2.0) for idx in sample_indices]
+                    )  # hack usage when do_sample_frames=False
+                    container.seek(0)
+                    for frame_idx, frame in enumerate(container.decode(video_stream)):
+                        if frame_idx in sample_indices:
+                            frames.append(frame.to_image())
 
-                if video_stream.duration is None:
-                    fps_per_video.append(kwargs.get("video_fps", 2.0))
-                    durations.append(len(frames) / kwargs.get("video_fps", 2.0))
-                else:
-                    fps_per_video.append(len(sample_indices) / float(video_stream.duration * video_stream.time_base))
-                    durations.append(float(video_stream.duration * video_stream.time_base))
+                    if video_stream.duration is None:
+                        fps_per_video.append(kwargs.get("video_fps", 2.0))
+                        durations.append(len(frames) / kwargs.get("video_fps", 2.0))
+                    else:
+                        fps_per_video.append(
+                            len(sample_indices) / float(video_stream.duration * video_stream.time_base)
+                        )
+                        durations.append(float(video_stream.duration * video_stream.time_base))
 
             if len(frames) % 2 != 0:
                 frames.append(frames[-1])

--- a/tests/data/test_mm_plugin.py
+++ b/tests/data/test_mm_plugin.py
@@ -91,6 +91,32 @@ LABELS = [0, 1, 2, 3, 4]
 BATCH_IDS = [[1] * 1024]
 
 
+class _FakeVideoFrame:
+    def to_image(self):
+        return IMAGES[0]
+
+
+class _FakeVideoContainer:
+    def __init__(self):
+        self.closed = False
+        self.streams = [SimpleNamespace(type="video", duration=2, time_base=0.5, average_rate=2)]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
+        self.closed = True
+
+    def seek(self, offset):
+        pass
+
+    def decode(self, stream):
+        return [_FakeVideoFrame(), _FakeVideoFrame()]
+
+
 def _get_mm_inputs(processor: "ProcessorMixin") -> dict[str, "torch.Tensor"]:
     image_processor: BaseImageProcessor = getattr(processor, "image_processor")
     return image_processor(images=IMAGES, return_tensors="pt")
@@ -186,6 +212,26 @@ def test_base_plugin():
     base_plugin = get_mm_plugin(name="base")
     check_inputs = {"plugin": base_plugin, **tokenizer_module}
     _check_plugin(**check_inputs)
+
+
+@pytest.mark.parametrize("plugin_name", ["base", "gemma4", "qwen3_vl"])
+def test_regularize_videos_closes_container(monkeypatch, plugin_name):
+    containers = []
+
+    def open_video(*args, **kwargs):
+        container = _FakeVideoContainer()
+        containers.append(container)
+        return container
+
+    plugin = get_mm_plugin(name=plugin_name)
+    monkeypatch.setattr("llamafactory.data.mm_plugin.av.open", open_video)
+    monkeypatch.setattr(plugin, "_get_video_sample_indices", lambda *args, **kwargs: [0, 1])
+    monkeypatch.setattr(plugin, "_regularize_images", lambda images, **kwargs: {"images": images})
+
+    plugin._regularize_videos(["video.mp4"], video_fps=2.0, video_maxlen=8)
+
+    assert len(containers) == 1
+    assert containers[0].closed
 
 
 @pytest.mark.runs_on(["cpu", "mps"])


### PR DESCRIPTION
# What does this PR do?

This PR closes PyAV input containers after video frames are decoded in the shared, Gemma 4, and Qwen VL multimodal preprocessing paths.

These paths previously called `av.open()` without closing the returned container. Repeated video preprocessing could therefore retain file descriptors and decoder resources, including when decoding raised an exception. The existing Qwen metadata helper already uses explicit cleanup; this change applies PyAV's native context manager consistently to the frame decoding paths.

No associated issue.

## Verification

- Before the fix: `WANDB_DISABLED=true .venv/bin/pytest -q tests/data/test_mm_plugin.py -k closes_container` (`3 failed`)
- After the fix: the same command (`3 passed`)
- Plugin suite: `WANDB_DISABLED=true .venv/bin/pytest -q tests/data/test_mm_plugin.py` (`18 passed, 2 skipped`)
- Lint: `uvx ruff@0.15.5 check src/llamafactory/data/mm_plugin.py tests/data/test_mm_plugin.py`
- Format: `uvx ruff@0.15.5 format --check src/llamafactory/data/mm_plugin.py tests/data/test_mm_plugin.py`

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LlamaFactory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
