### PR TITLE
fix(chat): close async streams on sync cancellation

### DIFF
--- a/src/llamafactory/chat/chat_model.py
+++ b/src/llamafactory/chat/chat_model.py
@@ -119,12 +119,15 @@ class ChatModel:
     ) -> Generator[str, None, None]:
         r"""Get the response token-by-token of the chat model."""
         generator = self.astream_chat(messages, system, tools, images, videos, audios, **input_kwargs)
-        while True:
-            try:
-                task = asyncio.run_coroutine_threadsafe(generator.__anext__(), self._loop)
-                yield task.result()
-            except StopAsyncIteration:
-                break
+        try:
+            while True:
+                try:
+                    task = asyncio.run_coroutine_threadsafe(generator.__anext__(), self._loop)
+                    yield task.result()
+                except StopAsyncIteration:
+                    break
+        finally:
+            asyncio.run_coroutine_threadsafe(generator.aclose(), self._loop).result()
 
     async def astream_chat(
         self,

--- a/tests/e2e/test_chat.py
+++ b/tests/e2e/test_chat.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import os
+from threading import Thread
 
 import pytest
 
 from llamafactory.chat import ChatModel
+from llamafactory.chat.chat_model import _start_background_loop
 
 
 TINY_LLAMA3 = os.getenv("TINY_LLAMA3", "llamafactory/tiny-random-Llama-3")
@@ -37,6 +40,25 @@ MESSAGES = [
 EXPECTED_RESPONSE = "_rho"
 
 
+class _AsyncStream:
+    def __init__(self):
+        self.closed = False
+        self.started = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self.started:
+            self.started = True
+            return "first"
+
+        await asyncio.Event().wait()
+
+    async def aclose(self):
+        self.closed = True
+
+
 @pytest.mark.runs_on(["cpu", "mps"])
 def test_chat():
     chat_model = ChatModel(INFER_ARGS)
@@ -51,3 +73,22 @@ def test_stream_chat():
         response += token
 
     assert response == EXPECTED_RESPONSE
+
+
+def test_stream_chat_closes_async_generator():
+    stream = _AsyncStream()
+    chat_model = object.__new__(ChatModel)
+    chat_model.astream_chat = lambda *args, **kwargs: stream
+    chat_model._loop = asyncio.new_event_loop()
+    chat_model._thread = Thread(target=_start_background_loop, args=(chat_model._loop,), daemon=True)
+    chat_model._thread.start()
+
+    try:
+        generator = chat_model.stream_chat([])
+        assert next(generator) == "first"
+        generator.close()
+        assert stream.closed
+    finally:
+        chat_model._loop.call_soon_threadsafe(chat_model._loop.stop)
+        chat_model._thread.join()
+        chat_model._loop.close()


### PR DESCRIPTION
# What does this PR do?

This PR closes the asynchronous stream behind `ChatModel.stream_chat()` when the synchronous consumer stops early.

The synchronous bridge previously requested tokens from the async generator but never called `aclose()`. Breaking out of a synchronous streaming loop could therefore leave backend cleanup blocks, concurrency slots, and streaming resources active. The bridge now closes the async generator in a `finally` block on normal completion, errors, and consumer cancellation.

No associated issue.

## Verification

- Before the fix: `WANDB_DISABLED=true .venv/bin/pytest -q tests/e2e/test_chat.py -k closes_async_generator` (`1 failed`)
- After the fix: the same command (`1 passed`)
- Chat E2E suite: `WANDB_DISABLED=true .venv/bin/pytest -q tests/e2e/test_chat.py` (`3 passed`)
- Lint: `uvx ruff@0.15.5 check src/llamafactory/chat/chat_model.py tests/e2e/test_chat.py`
- Format: `uvx ruff@0.15.5 format --check src/llamafactory/chat/chat_model.py tests/e2e/test_chat.py`

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LlamaFactory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
