### PR TITLE
fix(webui): handle missing output configuration

### DIFF
--- a/src/llamafactory/webui/runner.py
+++ b/src/llamafactory/webui/runner.py
@@ -527,7 +527,8 @@ class Runner:
 
             output_dir = get_save_dir(model_name, finetuning_type, output_dir)
             config_dict = load_args(os.path.join(output_dir, LLAMABOARD_CONFIG))  # load llamaboard config
-            for elem_id, value in config_dict.items():
-                output_dict[self.manager.get_elem_by_id(elem_id)] = value
+            if config_dict is not None:
+                for elem_id, value in config_dict.items():
+                    output_dict[self.manager.get_elem_by_id(elem_id)] = value
 
         return output_dict

--- a/tests/webui/test_runner.py
+++ b/tests/webui/test_runner.py
@@ -1,0 +1,43 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from llamafactory.webui import runner as runner_module
+from llamafactory.webui.locales import ALERTS
+from llamafactory.webui.runner import Runner
+
+
+class _Manager:
+    def get_elem_by_id(self, elem_id):
+        return elem_id
+
+
+def test_check_output_dir_without_saved_config(monkeypatch, tmp_path):
+    runner = Runner(_Manager())
+    monkeypatch.setattr(runner_module, "get_save_dir", lambda *args: str(tmp_path))
+    monkeypatch.setattr(runner_module.gr, "Warning", lambda *args, **kwargs: None)
+
+    output = runner.check_output_dir("en", "model", "lora", "output")
+
+    assert output == {"train.output_box": ALERTS["warn_output_dir_exists"]["en"]}
+
+
+def test_check_output_dir_restores_saved_config(monkeypatch, tmp_path):
+    runner = Runner(_Manager())
+    monkeypatch.setattr(runner_module, "get_save_dir", lambda *args: str(tmp_path))
+    monkeypatch.setattr(runner_module, "load_args", lambda path: {"train.learning_rate": 1e-5})
+    monkeypatch.setattr(runner_module.gr, "Warning", lambda *args, **kwargs: None)
+
+    output = runner.check_output_dir("en", "model", "lora", "output")
+
+    assert output["train.learning_rate"] == 1e-5


### PR DESCRIPTION
# What does this PR do?

Prevents LlamaBoard from crashing when a user selects an existing output directory without a valid `llamaboard_config.yaml`.

## Problem

The Train page binds the **Output dir** input to `Runner.check_output_dir()`. Existing directories may contain external checkpoints, interrupted runs, or copied artifacts.

`load_args()` returns `None` when the LlamaBoard config is missing or invalid, but the callback called `.items()` unconditionally:

```text
File "src/llamafactory/webui/runner.py", line 530, in check_output_dir
    for elem_id, value in config_dict.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

Real LlamaBoard flow:

```text
1. Train tab
2. Model: Llama-3-8B-Instruct
3. Finetuning method: lora
4. Output dir: an existing directory without llamaboard_config.yaml

main:    Gradio callback crashes
this PR: directory remains selected, no server exception
```

## Changes

- Preserve the existing output-directory warning.
- Restore form values only when a valid configuration was loaded.
- Keep valid configuration restoration unchanged.

## Verification

- Real browser flow reproduced on both revisions
- `WANDB_DISABLED=true .venv/bin/pytest -q tests/webui/test_runner.py`: `2 passed`
- Ruff lint and format checks: passed

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LlamaFactory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
