### PR TITLE
fix(ppo): validate reward server responses

### DIFF
--- a/src/llamafactory/train/ppo/ppo_utils.py
+++ b/src/llamafactory/train/ppo/ppo_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Literal, Optional
 
@@ -36,7 +35,11 @@ def get_rewards_from_server(server_url: str, messages: list[str]) -> list["torch
     headers = {"Content-Type": "application/json"}
     payload = {"model": "model", "messages": messages}
     response = requests.post(server_url, json=payload, headers=headers)
-    rewards = json.loads(response.text)["scores"]
+    response.raise_for_status()
+    rewards = response.json()["scores"]
+    if not isinstance(rewards, list) or len(rewards) != len(messages):
+        raise ValueError("Reward server must return one score for each message.")
+
     return torch.Tensor(rewards)
 
 

--- a/tests/train/ppo/test_ppo_utils.py
+++ b/tests/train/ppo/test_ppo_utils.py
@@ -1,0 +1,56 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+import requests
+import torch
+
+from llamafactory.train.ppo import ppo_utils
+
+
+def _response(status_code, body):
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = json.dumps(body).encode()
+    return response
+
+
+def test_get_rewards_from_server_rejects_http_error(monkeypatch):
+    monkeypatch.setattr(ppo_utils.requests, "post", lambda *args, **kwargs: _response(500, {"scores": [0.5]}))
+
+    with pytest.raises(requests.HTTPError):
+        ppo_utils.get_rewards_from_server("http://reward.test", ["message"])
+
+
+def test_get_rewards_from_server_rejects_score_count_mismatch(monkeypatch):
+    monkeypatch.setattr(ppo_utils.requests, "post", lambda *args, **kwargs: _response(200, {"scores": [0.5]}))
+
+    with pytest.raises(ValueError, match="one score for each message"):
+        ppo_utils.get_rewards_from_server("http://reward.test", ["first", "second"])
+
+
+def test_get_rewards_from_server_returns_scores(monkeypatch):
+    def post(url, json, headers):
+        assert url == "http://reward.test"
+        assert json == {"model": "model", "messages": ["first", "second"]}
+        assert headers == {"Content-Type": "application/json"}
+        return _response(200, {"scores": [0.5, -0.25]})
+
+    monkeypatch.setattr(ppo_utils.requests, "post", post)
+
+    rewards = ppo_utils.get_rewards_from_server("http://reward.test", ["first", "second"])
+
+    torch.testing.assert_close(rewards, torch.tensor([0.5, -0.25]))


### PR DESCRIPTION
# What does this PR do?

This PR validates responses from the external PPO reward API before their scores enter a training step.

## Production path

When `reward_model_type: api` is configured, `CustomPPOTrainer.get_rewards()` decodes each query/response pair into one message and calls:

```python
get_rewards_from_server(self.reward_model, messages)
```

The returned tensor is used directly as the reward batch. The previous client parsed `response.text` without checking the HTTP status and did not verify that the server returned exactly one score per message.

That allowed two contract violations:

1. A failed HTTP request with a JSON `scores` field could be treated as a successful reward response.
2. A score list shorter or longer than the PPO message batch could enter the training step.

## Real HTTP reproduction

Environment:

- LLaMA Factory `0.9.6.dev0`
- Requests `2.34.2`
- PyTorch `2.13.0`

I ran the production `get_rewards_from_server()` function against a real local HTTP server. Every request contained two messages:

```json
{
  "model": "model",
  "messages": ["first", "second"]
}
```

The server exposed three response paths:

| Path | HTTP status | JSON body |
|---|---:|---|
| `/error` | 500 | `{"scores": [0.75, -0.25]}` |
| `/mismatch` | 200 | `{"scores": [0.75]}` |
| `/ok` | 200 | `{"scores": [0.75, -0.25]}` |

The server log confirmed that each request received two messages:

```text
REQUEST {"path": "/error", "message_count": 2, "model": "model"}
REQUEST {"path": "/mismatch", "message_count": 2, "model": "model"}
REQUEST {"path": "/ok", "message_count": 2, "model": "model"}
```

### `main`

Both invalid responses are accepted:

```text
error:    rewards=[0.75, -0.25] count=2
mismatch: rewards=[0.75] count=1
ok:       rewards=[0.75, -0.25] count=2
```

The first result ignores HTTP 500. The second creates a one-element reward tensor for a two-message PPO batch.

### This PR

The same HTTP server and client calls produce:

```text
error: error=HTTPError: 500 Server Error: Internal Server Error for url: http://127.0.0.1:8026/error
mismatch: error=ValueError: Reward server must return one score for each message.
ok: rewards=[0.75, -0.25] count=2
```

HTTP failures and response-shape violations now stop at the external service boundary. The successful response contract and returned tensor are unchanged.

## Changes

- Call `response.raise_for_status()` before reading reward data.
- Parse the body through `response.json()`.
- Require `scores` to be a list containing exactly one item per requested message.
- Add tests for HTTP failure, score-count mismatch, and the successful response contract.

## Verification

- Real HTTP server on `main`: HTTP 500 and score-count mismatch were accepted.
- Same server on this PR: `HTTPError` and `ValueError` respectively.
- Valid response on both revisions: `[0.75, -0.25]`.
- `WANDB_DISABLED=true .venv/bin/pytest -q tests/train/ppo/test_ppo_utils.py`: `3 passed`.
- `uvx ruff@0.15.5 check src/llamafactory/train/ppo/ppo_utils.py tests/train/ppo/test_ppo_utils.py`: passed.
- `uvx ruff@0.15.5 format --check src/llamafactory/train/ppo/ppo_utils.py tests/train/ppo/test_ppo_utils.py`: passed.

## Impact

- Scope: PPO external reward API responses only.
- Breaking change: Invalid reward responses now fail immediately.
- Valid reward service payload and tensor dtype: Unchanged.
- Local LoRA/OFT/full reward model paths: Unchanged.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LlamaFactory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
