### PR TITLE
feat: respect `training_args.data_seed` for data loading and splitting

### DIFF
--- a/src/llamafactory/data/loader.py
+++ b/src/llamafactory/data/loader.py
@@ -183,7 +183,8 @@ def _get_merged_dataset(
     if return_dict:
         return datasets
     else:
-        return merge_dataset(list(datasets.values()), data_args, seed=training_args.seed)
+        data_seed = training_args.data_seed if training_args.data_seed is not None else training_args.seed
+        return merge_dataset(list(datasets.values()), data_args, seed=data_seed)
 
 
 def _get_dataset_processor(
@@ -312,7 +313,8 @@ def get_dataset(
 
     with training_args.main_process_first(desc="pre-process dataset", local=(not data_args.data_shared_file_system)):
         # move front to make sure eval_dataset(if contain or split) can preprocessed appropriately
-        train_dict, eval_dict = split_dataset(dataset, eval_dataset, data_args, seed=training_args.seed)
+        data_seed = training_args.data_seed if training_args.data_seed is not None else training_args.seed
+        train_dict, eval_dict = split_dataset(dataset, eval_dataset, data_args, seed=data_seed)
 
         if "train" in train_dict:
             train_dict["train"] = _get_preprocessed_dataset(

--- a/src/llamafactory/train/megatron_bridge/workflow.py
+++ b/src/llamafactory/train/megatron_bridge/workflow.py
@@ -166,7 +166,8 @@ def _load_aligned_datasets(
         stage,
         return_dict=data_args.eval_on_each_dataset,
     )
-    train_dict, eval_dict = split_dataset(dataset, eval_dataset, data_args, seed=training_args.seed)
+    data_seed = training_args.data_seed if training_args.data_seed is not None else training_args.seed
+    train_dict, eval_dict = split_dataset(dataset, eval_dataset, data_args, seed=data_seed)
     return train_dict.get("train"), eval_dict
 
 

--- a/tests/data/test_data_seed.py
+++ b/tests/data/test_data_seed.py
@@ -1,0 +1,101 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for data_seed support in the data loading pipeline.
+
+Verifies that training_args.data_seed (from HuggingFace TrainingArguments)
+is respected by LLaMA-Factory's data loading and splitting logic.
+"""
+
+import os
+
+import pytest
+
+from llamafactory.train.test_utils import load_dataset_module
+
+
+TINY_LLAMA3 = os.getenv("TINY_LLAMA3", "llamafactory/tiny-random-Llama-3")
+
+TINY_DATA = os.getenv("TINY_DATA", "llamafactory/tiny-supervised-dataset")
+
+BASE_ARGS = {
+    "model_name_or_path": TINY_LLAMA3,
+    "stage": "sft",
+    "do_train": True,
+    "finetuning_type": "full",
+    "template": "llama3",
+    "dataset": TINY_DATA,
+    "dataset_dir": "ONLINE",
+    "cutoff_len": 8192,
+    "output_dir": "dummy_dir",
+    "overwrite_output_dir": True,
+    "fp16": True,
+}
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_data_seed_not_set():
+    """When data_seed is not set, data loading should work as before (uses seed)."""
+    dataset_module = load_dataset_module(val_size=0.1, seed=42, **BASE_ARGS)
+    assert dataset_module.get("train_dataset") is not None
+    assert dataset_module.get("eval_dataset") is not None
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_data_seed_explicit():
+    """When data_seed is set, dataset loading should succeed."""
+    dataset_module = load_dataset_module(val_size=0.1, seed=42, data_seed=123, **BASE_ARGS)
+    assert dataset_module.get("train_dataset") is not None
+    assert dataset_module.get("eval_dataset") is not None
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_data_seed_reproducibility():
+    """Same data_seed should produce identical train/eval splits."""
+    module_a = load_dataset_module(val_size=0.1, seed=42, data_seed=99, **BASE_ARGS)
+    module_b = load_dataset_module(val_size=0.1, seed=42, data_seed=99, **BASE_ARGS)
+
+    train_a = list(module_a["train_dataset"])
+    train_b = list(module_b["train_dataset"])
+    assert len(train_a) == len(train_b)
+    for a, b in zip(train_a, train_b):
+        assert a["input_ids"] == b["input_ids"]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_different_data_seeds_differ():
+    """Different data_seed values should produce different splits."""
+    module_a = load_dataset_module(val_size=0.1, seed=42, data_seed=10, **BASE_ARGS)
+    module_b = load_dataset_module(val_size=0.1, seed=42, data_seed=99, **BASE_ARGS)
+
+    eval_a = list(module_a["eval_dataset"])
+    eval_b = list(module_b["eval_dataset"])
+
+    if len(eval_a) > 1 and len(eval_b) > 1:
+        ids_a = [ex["input_ids"] for ex in eval_a]
+        ids_b = [ex["input_ids"] for ex in eval_b]
+        assert ids_a != ids_b, "Different data_seed values should produce different eval splits"
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_data_seed_isolates_from_training_seed():
+    """Changing training seed while keeping data_seed fixed should yield identical data splits."""
+    module_a = load_dataset_module(val_size=0.1, seed=42, data_seed=77, **BASE_ARGS)
+    module_b = load_dataset_module(val_size=0.1, seed=999, data_seed=77, **BASE_ARGS)
+
+    train_a = list(module_a["train_dataset"])
+    train_b = list(module_b["train_dataset"])
+    assert len(train_a) == len(train_b)
+    for a, b in zip(train_a, train_b):
+        assert a["input_ids"] == b["input_ids"]


### PR DESCRIPTION
## Summary

**Fixes the `data_seed` parameter being silently ignored in LLaMA-Factory's data loading pipeline.**

HuggingFace's `TrainingArguments` provides a dedicated [`data_seed`](https://huggingface.co/docs/transformers/main_classes/trainer#transformers.TrainingArguments.data_seed) field to control randomness for data operations (shuffling, splitting) independently of the training `seed` (which controls model init, dropout, etc.). However, LLaMA-Factory was hardcoding `training_args.seed` at all data-related call sites, making the `data_seed` parameter a no-op.

## Root Cause

Three call sites in the data pipeline passed `seed=training_args.seed` directly, ignoring `training_args.data_seed` entirely:

| Call site | Function | File |
|-----------|----------|------|
| `_get_merged_dataset()` | `merge_dataset(..., seed=training_args.seed)` | `src/llamafactory/data/loader.py:186` |
| `get_dataset()` | `split_dataset(..., seed=training_args.seed)` | `src/llamafactory/data/loader.py:315` |
| `_load_aligned_datasets()` | `split_dataset(..., seed=training_args.seed)` | `src/llamafactory/train/megatron_bridge/workflow.py:169` |

This meant that even when users explicitly set `--data_seed 123`, all data operations still used `--seed` instead, silently producing different shuffles/splits than expected.

## Fix

At each of the three call sites, replaced the hardcoded `training_args.seed` with a resolution that prefers `data_seed` when set, falling back to `seed` for backward compatibility:

**Before:**
```python
return merge_dataset(list(datasets.values()), data_args, seed=training_args.seed)
```

**After:**
```python
data_seed = training_args.data_seed if training_args.data_seed is not None else training_args.seed
return merge_dataset(list(datasets.values()), data_args, seed=data_seed)
```

The same pattern is applied at all three sites. When `data_seed` is `None` (the default), behavior is **identical** to before the change — no existing workflows are affected.

## Files Changed

| File | Change | Lines |
|------|--------|-------|
| `src/llamafactory/data/loader.py` | Use `data_seed` in `_get_merged_dataset()` and `get_dataset()` | +4 / -2 |
| `src/llamafactory/train/megatron_bridge/workflow.py` | Use `data_seed` in `_load_aligned_datasets()` (Megatron path) | +2 / -1 |
| `tests/data/test_data_seed.py` | New: 5 test cases validating `data_seed` behavior | +101 / -0 |

**No new dependencies.** No new fields. This leverages the existing `data_seed` field already present in HuggingFace `TrainingArguments`.

## Usage

```yaml
# In training config YAML:
seed: 42            # controls model init, dropout, gradient accumulation order
data_seed: 123      # controls data merging, shuffling, and train/eval splitting
```

Or via CLI:
```bash
llamafactory-cli train --seed 42 --data_seed 123 ...
```

When `data_seed` is omitted, behavior is unchanged — `seed` is used for everything, exactly as before.

## Tests

Added `tests/data/test_data_seed.py` with 5 test cases:

| # | Test | What it verifies |
|---|------|------------------|
| 1 | `test_data_seed_not_set` | **Backward compatibility**: omitting `data_seed` produces valid train/eval datasets (no regression) |
| 2 | `test_data_seed_explicit` | Setting `data_seed` explicitly does not break dataset loading |
| 3 | `test_data_seed_reproducibility` | Same `data_seed` across two runs produces **identical** train splits (determinism) |
| 4 | `test_different_data_seeds_differ` | Different `data_seed` values produce **different** eval splits (the seed actually matters) |
| 5 | `test_data_seed_isolates_from_training_seed` | Fixed `data_seed` + varying `seed` → **identical** data splits (data randomness is decoupled from training randomness) |

All tests use `llamafactory/tiny-random-Llama-3` and `llamafactory/tiny-supervised-dataset` for fast, CI-friendly execution.