### PR TITLE
Optimize CUDA fused MoE scatter index

### DIFF
--- a/src/llamafactory/v1/plugins/model_plugins/kernels/ops/mlp/cuda_fused_moe.py
+++ b/src/llamafactory/v1/plugins/model_plugins/kernels/ops/mlp/cuda_fused_moe.py
@@ -48,6 +48,16 @@ else:
 logger = logging.getLogger(__name__)
 
 
+def _compute_expert_scatter_index(expert_index: torch.Tensor) -> torch.Tensor:
+    flat_experts = expert_index.flatten()
+    sorted_order = flat_experts.argsort(stable=True)
+    scatter_index = torch.empty_like(sorted_order)
+    scatter_index[sorted_order] = torch.arange(
+        sorted_order.numel(), dtype=sorted_order.dtype, device=sorted_order.device
+    )
+    return scatter_index.int().view(expert_index.shape)
+
+
 # ---------------------------------------------------------------------------
 # Autograd Function: Full Triton MoE forward + backward
 # ---------------------------------------------------------------------------
@@ -82,7 +92,7 @@ class TritonFusedMoeFunction(torch.autograd.Function):
             fc2_weight: (E, hidden, inter) down projection weight
         """
         # Compute scatter index: maps (token, topk) → position in sorted buffer
-        scatter_index = expert_index.flatten().argsort(stable=True).argsort().int().view(expert_index.shape)
+        scatter_index = _compute_expert_scatter_index(expert_index)
 
         # Token counts per expert and cumulative boundaries
         splits = torch.zeros(num_experts, dtype=torch.int32, device=hidden_states.device)

--- a/tests/model/test_cuda_fused_moe.py
+++ b/tests/model/test_cuda_fused_moe.py
@@ -1,0 +1,64 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from llamafactory.v1.plugins.model_plugins.kernels.ops.mlp.cuda_fused_moe import _compute_expert_scatter_index
+
+
+def _old_compute_expert_scatter_index(expert_index: torch.Tensor) -> torch.Tensor:
+    return expert_index.flatten().argsort(stable=True).argsort().int().view(expert_index.shape)
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "top_k", "num_experts"),
+    [
+        (0, 2, 4),
+        (1, 1, 1),
+        (8, 2, 4),
+        (17, 4, 8),
+        (128, 8, 16),
+    ],
+)
+def test_compute_expert_scatter_index_matches_old_expression(num_tokens: int, top_k: int, num_experts: int):
+    expert_index = torch.randint(0, num_experts, (num_tokens, top_k), dtype=torch.int64)
+
+    scatter_index = _compute_expert_scatter_index(expert_index)
+
+    assert torch.equal(scatter_index, _old_compute_expert_scatter_index(expert_index))
+    assert scatter_index.dtype == torch.int32
+    assert scatter_index.device == expert_index.device
+
+
+def test_compute_expert_scatter_index_preserves_stable_expert_order():
+    expert_index = torch.tensor(
+        [
+            [2, 1],
+            [2, 0],
+            [1, 2],
+            [0, 1],
+        ],
+        dtype=torch.int64,
+    )
+
+    scatter_index = _compute_expert_scatter_index(expert_index)
+    sorted_flat_positions = torch.argsort(scatter_index.flatten()).tolist()
+    sorted_experts = expert_index.flatten()[sorted_flat_positions].tolist()
+
+    assert sorted_experts == sorted(expert_index.flatten().tolist())
+    for expert in expert_index.unique().tolist():
+        original_positions = (expert_index.flatten() == expert).nonzero(as_tuple=False).flatten().tolist()
+        sorted_positions = [pos for pos in sorted_flat_positions if expert_index.flatten()[pos].item() == expert]
+        assert sorted_positions == original_positions


### PR DESCRIPTION
## Summary

This PR optimizes the scatter-index construction in the CUDA fused MoE path.

The previous implementation used:

```python
expert_index.flatten().argsort(stable=True).argsort()
```

The first `argsort(stable=True)` is still required because MoE dispatch needs
stable ordering within each expert bucket. The second `argsort` only inverts the
permutation returned by the first sort, so it can be replaced by a linear scatter:

```python
scatter_index = torch.empty_like(sorted_order)
scatter_index[sorted_order] = torch.arange(sorted_order.numel(), device=sorted_order.device)
```

This keeps the same dispatch order while avoiding one full sort in the fused MoE
forward path.

## Motivation

This follows the same optimization shape as ByteDance-Seed/VeOmni#888: keep the
stable sort that groups tokens by expert, but compute the inverse permutation in
O(N) instead of using a second O(N log N) sort.

For LLaMA-Factory, the affected production path is
`src/llamafactory/v1/plugins/model_plugins/kernels/ops/mlp/cuda_fused_moe.py`.

## Changes

- Add `_compute_expert_scatter_index()` for the CUDA fused MoE path.
- Replace the old back-to-back sort expression with the helper.
- Add CPU-friendly parity tests covering:
  - exact equality with the old expression,
  - int32 output dtype,
  - same-device output,
  - stable ordering for tokens routed to the same expert.

## Validation

```bash
uvx ruff@0.15.5 check \
  src/llamafactory/v1/plugins/model_plugins/kernels/ops/mlp/cuda_fused_moe.py \
  tests/model/test_cuda_fused_moe.py

uvx ruff@0.15.5 format --check \
  src/llamafactory/v1/plugins/model_plugins/kernels/ops/mlp/cuda_fused_moe.py \
  tests/model/test_cuda_fused_moe.py
```

Both passed.

I also ran a lightweight direct parity check against the old expression under
Python 3.11:

```bash
PYTHONPATH=src .venv/bin/python - <<'PY'
import torch
from llamafactory.v1.plugins.model_plugins.kernels.ops.mlp.cuda_fused_moe import _compute_expert_scatter_index

cases = [(0, 2, 4), (1, 1, 1), (8, 2, 4), (17, 4, 8), (128, 8, 16)]
for num_tokens, top_k, num_experts in cases:
    expert_index = torch.randint(0, num_experts, (num_tokens, top_k), dtype=torch.int64)
    old = expert_index.flatten().argsort(stable=True).argsort().int().view(expert_index.shape)
    new = _compute_expert_scatter_index(expert_index)
    assert torch.equal(new, old), (num_tokens, top_k, num_experts)
    assert new.dtype == torch.int32
print("direct scatter-index parity passed")
PY
```

Output:

```text
direct scatter-index parity passed
```

Note: local `pytest tests/model/test_cuda_fused_moe.py -q` was not completed
because this checkout's `tests/conftest.py` imports the full `transformers` stack
during initial pytest configuration and was too slow in the local ad-hoc
environment. The added test itself is CPU-only and should run through the normal
project CI environment.
