### PR TITLE
fix(data): validate right padding length in multimodal packing

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -221,10 +221,25 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
 
         if has_dummy_image:
             # for [0, seq_len] = [0, unpadded_length + right_padding_length + fake_input_ids_len + collator_padding_length]
-            # FIXME: maybe right_padding_length is large, with improper max_cutoff_len
             unpadded_length = int(features["attention_mask"][0].bool().sum().item())
             right_padding_length = int((packing_params_list[0] or {}).get("right_padding_length") or 0)
-            fake_input_padding_length = max(0, seq_len - unpadded_length - right_padding_length)
+            if not 0 <= unpadded_length <= seq_len:
+                raise ValueError(
+                    "Invalid packing metadata: "
+                    f"seq_len={seq_len}, unpadded_length={unpadded_length}, "
+                    f"right_padding_length={right_padding_length}."
+                )
+
+            max_valid_right_padding = seq_len - unpadded_length
+            if not 0 <= right_padding_length <= max_valid_right_padding:
+                raise ValueError(
+                    "Invalid packing metadata: "
+                    f"seq_len={seq_len}, unpadded_length={unpadded_length}, "
+                    f"right_padding_length={right_padding_length}; expected right_padding_length in "
+                    f"[0, {max_valid_right_padding}]. Check max_cutoff_len."
+                )
+
+            fake_input_padding_length = max_valid_right_padding - right_padding_length
             # avoid continual cuseqlens breaking varlen attention @kuangdd
             # https://github.com/hiyouga/LlamaFactory/issues/10452
             dummy_image_right_padding_mrope = (

--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -26,6 +26,7 @@ import torch.nn.functional as F
 from peft import PeftModel
 from transformers import DataCollatorForSeq2Seq
 
+from ..extras import logging
 from ..extras.constants import AUDIO_PLACEHOLDER, IGNORE_INDEX, IMAGE_PLACEHOLDER, MROPE_MODELS
 from ..extras.packages import is_pillow_available
 
@@ -38,6 +39,9 @@ if TYPE_CHECKING:
     from transformers import ProcessorMixin
 
     from .template import Template
+
+
+logger = logging.get_logger(__name__)
 
 
 def _slice_mm_inputs_for_sample(
@@ -231,15 +235,21 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                 )
 
             max_valid_right_padding = seq_len - unpadded_length
-            if not 0 <= right_padding_length <= max_valid_right_padding:
+            if right_padding_length < 0:
                 raise ValueError(
                     "Invalid packing metadata: "
                     f"seq_len={seq_len}, unpadded_length={unpadded_length}, "
-                    f"right_padding_length={right_padding_length}; expected right_padding_length in "
-                    f"[0, {max_valid_right_padding}]. Check max_cutoff_len."
+                    f"right_padding_length={right_padding_length}; expected a non-negative right_padding_length."
+                )
+            elif right_padding_length > max_valid_right_padding:
+                logger.warning_rank0_once(
+                    "Invalid packing metadata: "
+                    f"seq_len={seq_len}, unpadded_length={unpadded_length}, "
+                    f"right_padding_length={right_padding_length}; expected right_padding_length <= "
+                    f"{max_valid_right_padding}. Clamping dummy-image padding to zero. Check max_cutoff_len."
                 )
 
-            fake_input_padding_length = max_valid_right_padding - right_padding_length
+            fake_input_padding_length = max(0, max_valid_right_padding - right_padding_length)
             # avoid continual cuseqlens breaking varlen attention @kuangdd
             # https://github.com/hiyouga/LlamaFactory/issues/10452
             dummy_image_right_padding_mrope = (

--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -227,13 +227,6 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
             # for [0, seq_len] = [0, unpadded_length + right_padding_length + fake_input_ids_len + collator_padding_length]
             unpadded_length = int(features["attention_mask"][0].bool().sum().item())
             right_padding_length = int((packing_params_list[0] or {}).get("right_padding_length") or 0)
-            if not 0 <= unpadded_length <= seq_len:
-                raise ValueError(
-                    "Invalid packing metadata: "
-                    f"seq_len={seq_len}, unpadded_length={unpadded_length}, "
-                    f"right_padding_length={right_padding_length}."
-                )
-
             max_valid_right_padding = seq_len - unpadded_length
             if right_padding_length < 0:
                 raise ValueError(

--- a/tests/data/test_collator.py
+++ b/tests/data/test_collator.py
@@ -15,6 +15,7 @@
 import inspect
 import os
 from collections import Counter
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -320,6 +321,52 @@ def test_multimodal_collator_with_packing():
     batch_input = data_collator(features)  # [3, bsz, seq_len]
     valid_len = expected_position_ids.shape[-1]
     assert batch_input["position_ids"][1:, :, :valid_len].eq(expected_position_ids).all()
+
+
+def _make_dummy_image_packing_collator() -> MultiModalDataCollatorForSeq2Seq:
+    data_collator = object.__new__(MultiModalDataCollatorForSeq2Seq)
+    data_collator.tokenizer = SimpleNamespace(padding_side="right")
+
+    def compute_rope_position_ids(features, mm_inputs):
+        del mm_inputs
+        features["position_ids"] = torch.zeros((3, 1, features["input_ids"].size(1)), dtype=torch.long)
+
+    data_collator._compute_rope_position_ids = compute_rope_position_ids
+    return data_collator
+
+
+def _compute_dummy_image_packing_positions(right_padding_length: int) -> dict[str, torch.Tensor]:
+    data_collator = _make_dummy_image_packing_collator()
+    features = {
+        "input_ids": torch.tensor([[10, 11, 0, 0]]),
+        "attention_mask": torch.tensor([[1, 1, 0, 0]]),
+    }
+    data_collator._compute_rope_position_ids_with_packing(
+        features=features,
+        mm_inputs={},
+        packing_params_list=[{"sequence_boundaries": [0, 2, 4], "right_padding_length": right_padding_length}],
+        batch_imglens=[1],
+        batch_vidlens=[0],
+        batch_audlens=[0],
+        has_dummy_image=True,
+    )
+    return features
+
+
+def test_multimodal_packing_accepts_max_right_padding_length():
+    features = _compute_dummy_image_packing_positions(right_padding_length=2)
+
+    assert features["position_ids"].shape == (3, 1, 4)
+    assert features["attention_mask"].shape == (1, 4)
+
+
+@pytest.mark.parametrize("right_padding_length", [-1, 3])
+def test_multimodal_packing_rejects_invalid_right_padding_length(right_padding_length):
+    with pytest.raises(
+        ValueError,
+        match=rf"seq_len=4, unpadded_length=2, right_padding_length={right_padding_length}",
+    ):
+        _compute_dummy_image_packing_positions(right_padding_length)
 
 
 @pytest.mark.runs_on(["cpu"])

--- a/tests/data/test_collator.py
+++ b/tests/data/test_collator.py
@@ -360,13 +360,22 @@ def test_multimodal_packing_accepts_max_right_padding_length():
     assert features["attention_mask"].shape == (1, 4)
 
 
-@pytest.mark.parametrize("right_padding_length", [-1, 3])
-def test_multimodal_packing_rejects_invalid_right_padding_length(right_padding_length):
+def test_multimodal_packing_rejects_negative_right_padding_length():
     with pytest.raises(
         ValueError,
-        match=rf"seq_len=4, unpadded_length=2, right_padding_length={right_padding_length}",
+        match=r"seq_len=4, unpadded_length=2, right_padding_length=-1",
     ):
-        _compute_dummy_image_packing_positions(right_padding_length)
+        _compute_dummy_image_packing_positions(-1)
+
+
+def test_multimodal_packing_warns_and_clamps_excessive_right_padding_length(caplog):
+    with caplog.at_level("WARNING", logger="llamafactory.data.collator"):
+        features = _compute_dummy_image_packing_positions(right_padding_length=3)
+
+    assert "seq_len=4, unpadded_length=2, right_padding_length=3" in caplog.text
+    assert "Clamping dummy-image padding to zero" in caplog.text
+    assert features["position_ids"].shape == (3, 1, 4)
+    assert features["attention_mask"].shape == (1, 4)
 
 
 @pytest.mark.runs_on(["cpu"])


### PR DESCRIPTION
# What does this PR do?

Fixes #10670

This PR validates multimodal packing metadata before computing RoPE position IDs:

- reject negative `right_padding_length` with a clear `ValueError`
- emit a rank-0 warning and preserve the existing clamp when `right_padding_length` exceeds `seq_len - unpadded_length`
- include `seq_len`, `unpadded_length`, and `right_padding_length` in diagnostics
- add regression coverage for the valid upper bound, negative padding, and excessive padding

For compatibility, excessive positive `right_padding_length` values do not fail the training run. They emit a warning and clamp dummy-image padding to zero, preserving the previous runtime behavior. Negative padding metadata remains a hard error because it is structurally invalid.

For non-negative packing metadata, this PR does not change the computed
padding. `max(0, (seq_len - unpadded_length) - right_padding_length)` is
algebraically equivalent to the previous expression. Excessive positive
values now emit a diagnostic warning while preserving the existing clamp.
Negative padding metadata remains a hard error because it is structurally
invalid.
## Tests

- `ruff check`: passed
- `ruff format --check`: passed
- `pytest tests/data/test_collator.py -q`: 3 passed, 4 skipped (device-marked tests skipped on CUDA)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?