### PR TITLE
fix(data): pad position_ids on non-FA2 packing path (fixes rotary crash for Gemma-3/4)

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -541,6 +541,17 @@ class SFTDataCollatorWith4DAttentionMask(MultiModalDataCollatorForSeq2Seq):
                 self._unpad_packed_features(features)
 
             features["attention_mask"] = None  # let transformers handle causal packed mask.
+        else:
+            # `DataCollatorForSeq2Seq(pad_to_multiple_of=...)` pads `input_ids`/`attention_mask`
+            # but leaves `position_ids` untouched (it is not in `model_input_names`). On the
+            # non-FA2 packing path we do not unpad, so `position_ids` stays shorter than
+            # `input_ids`, which makes cos/sin shorter than query and crashes
+            # `apply_rotary_pos_emb`. Right-pad `position_ids` to the padded length to match.
+            position_ids = features.get("position_ids")
+            if torch.is_tensor(position_ids):
+                pad_len = features["input_ids"].shape[-1] - position_ids.shape[-1]
+                if pad_len > 0:
+                    features["position_ids"] = F.pad(position_ids, (0, pad_len), value=0)
 
         for key, value in features.items():  # cast data dtype for paligemma
             if torch.is_tensor(value) and torch.is_floating_point(value):


### PR DESCRIPTION
### 这个 PR 做了什么

修复 **非 FlashAttention-2** 路径（SDPA / eager）下打包（packing）SFT 时 `position_ids` 与 `input_ids` 长度不一致导致的崩溃。该 bug 使得任何 `head_dim=256` 的模型（例如 **Gemma-3 / Gemma-4**）无法使用 packing —— 因为这些模型用不了 FA2，只能走 SDPA。

Closes #10736

### 现象

```text
File "transformers/models/gemma4/modeling_gemma4.py", line 806, in apply_rotary_pos_emb
    return (x * cos) + (rotate_half(x) * sin)
RuntimeError: The size of tensor a (1288) must match the size of tensor b (1024) at non-singleton dimension 1
```

### 根因

打包处理器会产出显式的 `position_ids`，但**只有 FA2 分支会对其重新对齐**（`_unpad_packed_features`）。

`SFTDataCollatorWith4DAttentionMask.__call__` 调用 `super().__call__`，即 `train/sft/workflow.py` 里以 `pad_to_multiple_of=8` 创建的 `DataCollatorForSeq2Seq`。`tokenizer.pad` 会把 `input_ids` / `attention_mask` / `labels` 补齐到 8 的倍数，**但 `position_ids` 不在 `model_input_names` 里，因此保持原打包长度不变**。在 SDPA / `block_diag_attn` 分支上没有任何逻辑对它做对齐，于是从 `position_ids` 推出的 `cos`/`sin` 比 `query_states` 短，`apply_rotary_pos_emb` 报错。

### 修复

在非 FA2 的 packing 路径上，把 `position_ids` 右侧补齐到 padding 后的序列长度，使其与 `input_ids` 保持一致。仅在 `position_ids` 存在且短于 `input_ids` 时才补齐，因此不影响非 packing / FA2 路径。

### 验证

用 `google/gemma-4-E2B-it`、`packing: true`、`neat_packing: true`、`flash_attn: sdpa` 在本地复现并验证，除 collator 外配置完全相同：

- **修复前**：第 0 步崩溃（`apply_rotary_pos_emb` 尺寸不匹配，1288 vs 1024）。
- **修复后**：8/8 步正常训练，loss 5.4 → 4.5，正常退出。
