### PR TITLE
[trainer] measure throughput and ETA from the resume point

### DIFF
--- a/src/llamafactory/train/callbacks.py
+++ b/src/llamafactory/train/callbacks.py
@@ -177,6 +177,8 @@ class LogCallback(TrainerCallback):
     def __init__(self) -> None:
         # Progress
         self.start_time = 0
+        self.start_step = 0
+        self.start_tokens = 0
         self.cur_steps = 0
         self.max_steps = 0
         self.elapsed_time = ""
@@ -196,9 +198,11 @@ class LogCallback(TrainerCallback):
     def _set_abort(self, signum, frame) -> None:
         self.aborted = True
 
-    def _reset(self, max_steps: int = 0) -> None:
+    def _reset(self, max_steps: int = 0, start_step: int = 0, start_tokens: int = 0) -> None:
         self.start_time = time.time()
-        self.cur_steps = 0
+        self.start_step = start_step
+        self.start_tokens = start_tokens
+        self.cur_steps = start_step
         self.max_steps = max_steps
         self.elapsed_time = ""
         self.remaining_time = ""
@@ -206,7 +210,8 @@ class LogCallback(TrainerCallback):
     def _timing(self, cur_steps: int) -> None:
         cur_time = time.time()
         elapsed_time = cur_time - self.start_time
-        avg_time_per_step = elapsed_time / cur_steps if cur_steps != 0 else 0
+        steps_done = cur_steps - self.start_step
+        avg_time_per_step = elapsed_time / steps_done if steps_done > 0 else 0
         remaining_time = (self.max_steps - cur_steps) * avg_time_per_step
         self.cur_steps = cur_steps
         self.elapsed_time = str(timedelta(seconds=int(elapsed_time)))
@@ -239,7 +244,11 @@ class LogCallback(TrainerCallback):
     def on_train_begin(self, args: "TrainingArguments", state: "TrainerState", control: "TrainerControl", **kwargs):
         if args.should_save:
             self.do_train = True
-            self._reset(max_steps=state.max_steps)
+            self._reset(
+                max_steps=state.max_steps,
+                start_step=state.global_step,
+                start_tokens=state.num_input_tokens_seen,
+            )
             self._create_thread_pool(output_dir=args.output_dir)
 
     @override
@@ -289,7 +298,8 @@ class LogCallback(TrainerCallback):
             remaining_time=self.remaining_time,
         )
         if state.num_input_tokens_seen:
-            logs["throughput"] = round(state.num_input_tokens_seen / (time.time() - self.start_time), 2)
+            new_tokens = state.num_input_tokens_seen - self.start_tokens
+            logs["throughput"] = round(new_tokens / (time.time() - self.start_time), 2)
             logs["total_tokens"] = state.num_input_tokens_seen
 
         if is_env_enabled("RECORD_VRAM"):

--- a/tests/train/test_callbacks.py
+++ b/tests/train/test_callbacks.py
@@ -1,0 +1,83 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from transformers import TrainerControl, TrainerState, TrainingArguments
+
+from llamafactory.extras.constants import TRAINER_LOG
+from llamafactory.train.callbacks import LogCallback
+
+
+ELAPSED_SECONDS = 20.0
+
+NEW_STEPS = 10
+
+NEW_TOKENS = 20000
+
+
+def _drive_log_callback(output_dir: Path, resumed_steps: int, resumed_tokens: int) -> dict[str, float]:
+    r"""Run one logging round after `ELAPSED_SECONDS` of training and return the written log entry."""
+    args = TrainingArguments(output_dir=str(output_dir), report_to=[])
+    state = TrainerState()
+    state.global_step = resumed_steps
+    state.max_steps = 2000
+    state.num_input_tokens_seen = resumed_tokens
+    state.log_history = [{"loss": 1.0, "learning_rate": 5e-5, "epoch": 1.0}]
+
+    callback = LogCallback()
+    callback.on_train_begin(args, state, TrainerControl())
+    callback.start_time -= ELAPSED_SECONDS  # avoid sleeping for real
+
+    state.global_step += NEW_STEPS
+    state.num_input_tokens_seen += NEW_TOKENS
+    callback.on_log(args, state, TrainerControl())
+    callback.on_train_end(args, state, TrainerControl())
+
+    with open(os.path.join(output_dir, TRAINER_LOG), encoding="utf-8") as f:
+        return json.loads(f.read().splitlines()[-1])
+
+
+def _to_seconds(formatted: str) -> int:
+    hours, minutes, seconds = (int(part) for part in formatted.split(":"))
+    return hours * 3600 + minutes * 60 + seconds
+
+
+@pytest.mark.parametrize(("resumed_steps", "resumed_tokens"), [(0, 0), (1000, 10_000_000)])
+def test_throughput_counts_only_tokens_seen_since_the_resume_point(
+    tmp_path: Path, resumed_steps: int, resumed_tokens: int
+):
+    """Transformers restores `num_input_tokens_seen` before `on_train_begin` fires.
+
+    Dividing that whole-run total by the time since the resume inflates throughput by the ratio between
+    the two, so a run resumed near its end reports a throughput orders of magnitude too high.
+    """
+    logs = _drive_log_callback(tmp_path, resumed_steps, resumed_tokens)
+
+    assert logs["throughput"] == pytest.approx(NEW_TOKENS / ELAPSED_SECONDS, rel=0.05)
+    assert logs["total_tokens"] == resumed_tokens + NEW_TOKENS
+
+
+@pytest.mark.parametrize(("resumed_steps", "resumed_tokens"), [(0, 0), (1000, 10_000_000)])
+def test_remaining_time_counts_only_steps_taken_since_the_resume_point(
+    tmp_path: Path, resumed_steps: int, resumed_tokens: int
+):
+    """`global_step` is restored the same way, so averaging over it understates the seconds per step."""
+    logs = _drive_log_callback(tmp_path, resumed_steps, resumed_tokens)
+
+    remaining_steps = 2000 - (resumed_steps + NEW_STEPS)
+    assert _to_seconds(logs["remaining_time"]) == pytest.approx(remaining_steps * ELAPSED_SECONDS / NEW_STEPS, abs=10)


### PR DESCRIPTION
# What does this PR do?

`LogCallback` zeroes its progress counters in `on_train_begin`, but transformers restores `global_step` and `num_input_tokens_seen` from the checkpoint before that hook runs. A resumed run therefore divides the whole run's token count by the seconds since the resume, and the seconds since the resume by the whole run's step count. `throughput` comes out far too high and `remaining_time` far too low, in both `trainer_log.jsonl` and the LlamaBoard progress bar.

`_reset` now records the step and token counts it starts from, and `_timing` and `on_log` measure against those. Fresh runs start from zero, so nothing changes for them.

Fixes #7415

An 800 step LoRA run, then the same config with `max_steps: 2400` and the same `output_dir` so it resumes from `checkpoint-800`:

```bash
llamafactory-cli train demo.yaml   # max_steps 800, save_steps 800
llamafactory-cli train demo.yaml   # max_steps 2400, resumes from checkpoint-800
cat saves/tiny-llama3/lora/sft/trainer_log.jsonl
```

The first leg measured 4025 to 4282 tok/s, and the resumed leg really took 19 seconds:

```
--- before ---
step  810/2400  elapsed 0:00:00  remaining  0:00:01  throughput   76232.11
step 1200/2400  elapsed 0:00:05  remaining  0:00:05  throughput   12142.12
step 1800/2400  elapsed 0:00:12  remaining  0:00:04  throughput    7508.26
step 2400/2400  elapsed 0:00:19  remaining  0:00:00  throughput    6494.08

--- after ---
step  810/2400  elapsed 0:00:00  remaining  0:01:05  throughput    1251.45
step 1200/2400  elapsed 0:00:05  remaining  0:00:15  throughput    4222.75
step 1800/2400  elapsed 0:00:12  remaining  0:00:07  throughput    4250.86
step 2400/2400  elapsed 0:00:19  remaining  0:00:00  throughput    4367.46
```

`tests/train/test_callbacks.py` covers both metrics. The resumed cases fail on `main` (`throughput 500999.05 != 1000.0 ± 50`, `remaining_time 19 != 1980 ± 10`) and pass here; the fresh-run cases pass either way.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
