### PR TITLE
fix(sft): keep ASFT loss finite for empty labels

### DIFF
--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -762,7 +762,7 @@ def _kl_divergence(
     # mask padding tokens
     mask = (labels != ignore_index).float()
 
-    return (kl * mask).sum() / mask.sum()
+    return (kl * mask).sum() / mask.sum().clamp_min(1.0)
 
 
 def eaft_loss_func(

--- a/tests/train/test_trainer_utils.py
+++ b/tests/train/test_trainer_utils.py
@@ -1,0 +1,35 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from llamafactory.extras.constants import IGNORE_INDEX
+from llamafactory.train.trainer_utils import asft_loss_func
+
+
+def test_asft_loss_with_fully_masked_labels():
+    policy_logits = torch.tensor(
+        [[[2.0, 0.0], [0.0, 2.0], [1.0, -1.0]]],
+        requires_grad=True,
+    )
+    ref_logits = torch.ones_like(policy_logits)
+    labels = torch.full((1, 3), IGNORE_INDEX)
+
+    loss = asft_loss_func({"logits": policy_logits}, labels, ref_logits)
+
+    assert loss.item() == 0.0
+    assert loss.requires_grad
+    loss.backward()
+    assert torch.isfinite(policy_logits.grad).all()
+    assert torch.count_nonzero(policy_logits.grad) == 0


### PR DESCRIPTION
# What does this PR do?

Prevents the ASFT loss from becoming `NaN` when a batch has no supervised tokens.

This follows up on the division-by-zero concern raised during the original ASFT review:
https://github.com/hiyouga/LlamaFactory/pull/10174#discussion_r2779459295

## Problem

`_kl_divergence()` averages over tokens whose labels are not `IGNORE_INDEX`. When every label is ignored, the mask sum is zero:

```text
main: loss=nan, finite=False
```

Returning a detached zero would avoid `NaN` but break `backward()`. Clamping the denominator to one keeps the zero-valued numerator connected to the policy logits.

## Changes

- Clamp the KL normalization denominator to at least one.
- Add a regression test for a fully masked batch.
- Verify that the loss is zero, retains its computation graph, and produces finite zero gradients.

Normal batches are unchanged because their mask sum is already at least one.

## Verification

- Before the fix: `WANDB_DISABLED=true .venv/bin/pytest -q tests/train/test_trainer_utils.py` (`1 failed`, loss was `NaN`)
- After the fix: the same command (`1 passed`)
- Full suite: `306 passed, 22 skipped, 3 xfailed, 4 xpassed`
- Changed-files pre-commit hooks: passed
- License check and wheel build: passed

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LlamaFactory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
