### PR TITLE
fix(webui): handle SwanLab local mode without cloud config

### DIFF
--- a/src/llamafactory/webui/control.py
+++ b/src/llamafactory/webui/control.py
@@ -148,7 +148,7 @@ def get_trainer_info(lang: str, output_path: os.PathLike, do_train: bool) -> tup
     if os.path.isfile(swanlab_config_path):
         with open(swanlab_config_path, encoding="utf-8") as f:
             swanlab_public_config = json.load(f)
-            swanlab_link = swanlab_public_config["cloud"]["experiment_url"]
+            swanlab_link = (swanlab_public_config.get("cloud") or {}).get("experiment_url")
             if swanlab_link is not None:
                 running_info["swanlab_link"] = gr.Markdown(
                     ALERTS["info_swanlab_link"][lang] + swanlab_link, visible=True


### PR DESCRIPTION
## Summary

Fix a WebUI crash that occurs when training with SwanLab in local mode.

## Problem

When `swanlab_mode` is set to `local`, the generated SwanLab public configuration does not contain a `cloud` section.

However, the WebUI training monitor accesses the cloud experiment URL directly:

```python
swanlab_public_config["cloud"]["experiment_url"]
```

This raises the following exception:

```text
KeyError: 'cloud'
```

and causes the WebUI monitoring process to fail.

## Changes

Use optional dictionary lookups when reading the SwanLab cloud experiment URL:

```python
swanlab_public_config.get("cloud", {}).get("experiment_url")
```

The cloud experiment link continues to be displayed when available, while local-mode experiments no longer crash the WebUI monitor.