### PR TITLE
[xpu] add Intel XPU support to test infrastructure and ulysses CP test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,8 @@ def _get_visible_devices_env() -> str | None:
         return "CUDA_VISIBLE_DEVICES"
     elif CURRENT_DEVICE == "npu":
         return "ASCEND_RT_VISIBLE_DEVICES"
+    elif CURRENT_DEVICE == "xpu":
+        return "ZE_AFFINITY_MASK"
     else:
         return None
 
@@ -160,6 +162,8 @@ def _manage_distributed_env(request: FixtureRequest, monkeypatch: MonkeyPatch) -
             monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
         elif CURRENT_DEVICE == "npu":
             monkeypatch.setattr(torch.npu, "device_count", lambda: 1)
+        elif CURRENT_DEVICE == "xpu":
+            monkeypatch.setattr(torch.xpu, "device_count", lambda: 1)
 
 
 @pytest.fixture

--- a/tests_v1/conftest.py
+++ b/tests_v1/conftest.py
@@ -79,6 +79,8 @@ def _get_visible_devices_env() -> str | None:
         return "CUDA_VISIBLE_DEVICES"
     elif CURRENT_DEVICE == "npu":
         return "ASCEND_RT_VISIBLE_DEVICES"
+    elif CURRENT_DEVICE == "xpu":
+        return "ZE_AFFINITY_MASK"
     else:
         return None
 
@@ -172,6 +174,8 @@ def _manage_distributed_env(request: FixtureRequest, monkeypatch: MonkeyPatch) -
             monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
         elif CURRENT_DEVICE == "npu":
             monkeypatch.setattr(torch.npu, "device_count", lambda: 1)
+        elif CURRENT_DEVICE == "xpu":
+            monkeypatch.setattr(torch.xpu, "device_count", lambda: 1)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests_v1/plugins/model_plugins/test_ulysses_cp.py
+++ b/tests_v1/plugins/model_plugins/test_ulysses_cp.py
@@ -56,7 +56,7 @@ def _test_sequence_parallel_loss(
         assert loss is not None
 
 
-@pytest.mark.runs_on(["cuda", "npu"])
+@pytest.mark.runs_on(["cuda", "npu", "xpu"])
 @pytest.mark.require_distributed(2)
 @pytest.mark.parametrize(("cp_size", "dp_size", "batch_size"), [(2, 1, 1), (2, 1, 2)])
 def test_sequence_parallel_loss(cp_size, dp_size, batch_size):


### PR DESCRIPTION
## Summary

Treats Intel XPU as a first-class device alongside `cuda` and `npu` in the test harness, and extends the Ulysses sequence-parallel test to run on XPU CI targets.

### Changes

- **`tests/conftest.py`, `tests_v1/conftest.py`**
  - `_get_visible_devices_env`: return `ZE_AFFINITY_MASK` for `xpu` so device-count checks (`require_distributed` skip logic) work correctly
  - `_manage_distributed_env`: patch `torch.xpu.device_count` to `1` for single-device test isolation (mirrors existing `cuda`/`npu` handling)

- **`tests_v1/plugins/model_plugins/test_ulysses_cp.py`**
  - Add `"xpu"` to `@pytest.mark.runs_on` for `test_sequence_parallel_loss`
  - The test uses generic `torch.distributed` / `mp.spawn` with no CUDA-specific APIs; already supported on `npu`, so `xpu` is a natural extension
