### PR TITLE
feat: make torchaudio optional for text-only training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     # core deps
     "torch>=2.4.0",
     "torchvision>=0.19.0",
-    "torchaudio>=2.4.0",
     "transformers>=4.55.0,<=5.8.0,!=4.57.0,!=5.6.0",
     "datasets>=2.16.0,<=4.0.0",
     "accelerate>=1.3.0,<=1.11.0",
@@ -73,6 +72,11 @@ dependencies = [
     "uvicorn",
     "fastapi",
     "sse-starlette",
+]
+
+[project.optional-dependencies]
+multimodal = [
+    "torchaudio>=2.4.0",
 ]
 
 [project.scripts]

--- a/src/llamafactory/data/mm_plugin.py
+++ b/src/llamafactory/data/mm_plugin.py
@@ -27,7 +27,6 @@ from typing import TYPE_CHECKING, Any, BinaryIO, Literal, NotRequired, Optional,
 
 import numpy as np
 import torch
-import torchaudio
 from transformers.image_utils import get_image_size, is_valid_image, make_flat_list_of_images, to_numpy_array
 from transformers.models.mllama.processing_mllama import (
     convert_sparse_cross_attention_mask_to_dense,
@@ -37,7 +36,12 @@ from transformers.video_utils import make_batched_videos
 from typing_extensions import override
 
 from ..extras.constants import AUDIO_PLACEHOLDER, IGNORE_INDEX, IMAGE_PLACEHOLDER, VIDEO_PLACEHOLDER
-from ..extras.packages import is_pillow_available, is_pyav_available, is_transformers_version_greater_than
+from ..extras.packages import (
+    is_pillow_available,
+    is_pyav_available,
+    is_torchaudio_available,
+    is_transformers_version_greater_than,
+)
 
 
 if is_pillow_available():
@@ -47,6 +51,10 @@ if is_pillow_available():
 
 if is_pyav_available():
     import av
+
+
+if is_torchaudio_available():
+    import torchaudio
 
 
 if TYPE_CHECKING:
@@ -313,6 +321,11 @@ class MMPluginMixin:
         results, sampling_rates = [], []
         for audio in audios:
             if not isinstance(audio, np.ndarray):
+                if not is_torchaudio_available():
+                    raise ImportError(
+                        "torchaudio is required to process audio data. Please install it with `pip install torchaudio`."
+                    )
+
                 audio, sr = torchaudio.load(audio)
                 if audio.shape[0] > 1:
                     audio = audio.mean(dim=0, keepdim=True)

--- a/src/llamafactory/extras/packages.py
+++ b/src/llamafactory/extras/packages.py
@@ -43,6 +43,15 @@ def is_pyav_available():
     return _is_package_available("av")
 
 
+def is_torchaudio_available():
+    try:
+        spec = importlib.util.find_spec("torchaudio")
+    except (ImportError, AttributeError, TypeError, ValueError):
+        return False
+
+    return spec is not None and spec.origin is not None
+
+
 def is_librosa_available():
     return _is_package_available("librosa")
 

--- a/src/llamafactory/v1/core/rendering/format.py
+++ b/src/llamafactory/v1/core/rendering/format.py
@@ -21,6 +21,7 @@ conversion used by ``rendering.py``.
 
 import json
 
+from ....extras.packages import is_torchaudio_available
 from ...utils.helper import get_tokenizer
 from ...utils.types import Message, Processor
 
@@ -129,13 +130,21 @@ def _count_media_in_messages(messages: list[Message]) -> tuple[int, int, int]:
 def _load_audios(values: list, sampling_rate: int) -> list:
     """Load audio inputs into mono waveforms resampled to ``sampling_rate``."""
     import numpy as np
-    import torchaudio
 
+    torchaudio = None
     results = []
     for value in values:
         if isinstance(value, np.ndarray):
             results.append(value)
             continue
+
+        if torchaudio is None:
+            if not is_torchaudio_available():
+                raise ImportError(
+                    "torchaudio is required to process audio data. Please install it with `pip install torchaudio`."
+                )
+
+            import torchaudio
 
         waveform, sr = torchaudio.load(value)
         if waveform.shape[0] > 1:  # downmix to mono


### PR DESCRIPTION
## Motivation
LLaMA-Factory unconditionally imports torchaudio in src/llamafactory/data/mm_plugin.py and declares it as a core dependency. On platforms without a matching torchaudio wheel (e.g. Windows cu126 with torch 2.13.0+cu126), text-only LoRA SFT fails at import time even though audio is never used.

## Changes
- Add is_torchaudio_available() in src/llamafactory/extras/packages.py.
- Make torchaudio an optional import in src/llamafactory/data/mm_plugin.py and raise a clear ImportError only when audio data is processed.
- Make _load_audios() in src/llamafactory/v1/core/rendering/format.py import torchaudio on demand.
- Move torchaudio from core dependencies to the multimodal extra in pyproject.toml.

## Verification
- Verified text-only Qwen2.5-0.5B LoRA SFT runs end-to-end without torchaudio installed.
- Verified audio code paths fail with a clear ImportError when torchaudio is missing.
- ruff check and ruff format --check pass.