### PR TITLE
fix: reject top_p<=0 at config-parse time instead of rewriting to 1.0

### DIFF
--- a/scripts/vllm_infer.py
+++ b/scripts/vllm_infer.py
@@ -129,7 +129,7 @@ def vllm_infer(
     train_dataset = dataset_module["train_dataset"]
 
     sampling_params = SamplingParams(
-        repetition_penalty=generating_args.repetition_penalty or 1.0,  # repetition_penalty must > 0
+        repetition_penalty=generating_args.repetition_penalty,
         temperature=generating_args.temperature,
         top_p=generating_args.top_p,
         top_k=generating_args.top_k or -1,  # top_k must > 0

--- a/scripts/vllm_infer.py
+++ b/scripts/vllm_infer.py
@@ -131,7 +131,7 @@ def vllm_infer(
     sampling_params = SamplingParams(
         repetition_penalty=generating_args.repetition_penalty or 1.0,  # repetition_penalty must > 0
         temperature=generating_args.temperature,
-        top_p=generating_args.top_p or 1.0,  # top_p must > 0
+        top_p=generating_args.top_p,
         top_k=generating_args.top_k or -1,  # top_k must > 0
         stop_token_ids=template_obj.get_stop_token_ids(tokenizer),
         max_tokens=generating_args.max_new_tokens,

--- a/src/llamafactory/chat/sglang_engine.py
+++ b/src/llamafactory/chat/sglang_engine.py
@@ -200,8 +200,7 @@ class SGLangEngine(BaseEngine):
             "max_new_tokens": max_tokens,
             "repetition_penalty": (
                 repetition_penalty if repetition_penalty is not None else self.generating_args["repetition_penalty"]
-            )
-            or 1.0,  # repetition_penalty must > 0
+            ),
             "skip_special_tokens": skip_special_tokens
             if skip_special_tokens is not None
             else self.generating_args["skip_special_tokens"],

--- a/src/llamafactory/chat/sglang_engine.py
+++ b/src/llamafactory/chat/sglang_engine.py
@@ -193,7 +193,7 @@ class SGLangEngine(BaseEngine):
 
         sampling_params = {
             "temperature": temperature if temperature is not None else self.generating_args["temperature"],
-            "top_p": (top_p if top_p is not None else self.generating_args["top_p"]) or 1.0,  # top_p must > 0
+            "top_p": top_p if top_p is not None else self.generating_args["top_p"],
             "top_k": (top_k if top_k is not None else self.generating_args["top_k"]) or -1,  # top_k must > 0
             "stop": stop,
             "stop_token_ids": self.template.get_stop_token_ids(self.tokenizer),

--- a/src/llamafactory/chat/vllm_engine.py
+++ b/src/llamafactory/chat/vllm_engine.py
@@ -171,7 +171,7 @@ class VllmEngine(BaseEngine):
             )
             or 1.0,  # repetition_penalty must > 0
             temperature=temperature if temperature is not None else self.generating_args["temperature"],
-            top_p=(top_p if top_p is not None else self.generating_args["top_p"]) or 1.0,  # top_p must > 0
+            top_p=top_p if top_p is not None else self.generating_args["top_p"],
             top_k=(top_k if top_k is not None else self.generating_args["top_k"]) or -1,  # top_k must > 0
             stop=stop,
             stop_token_ids=self.template.get_stop_token_ids(self.tokenizer),

--- a/src/llamafactory/chat/vllm_engine.py
+++ b/src/llamafactory/chat/vllm_engine.py
@@ -168,8 +168,7 @@ class VllmEngine(BaseEngine):
             n=num_return_sequences,
             repetition_penalty=(
                 repetition_penalty if repetition_penalty is not None else self.generating_args["repetition_penalty"]
-            )
-            or 1.0,  # repetition_penalty must > 0
+            ),
             temperature=temperature if temperature is not None else self.generating_args["temperature"],
             top_p=top_p if top_p is not None else self.generating_args["top_p"],
             top_k=(top_k if top_k is not None else self.generating_args["top_k"]) or -1,  # top_k must > 0

--- a/src/llamafactory/hparams/generating_args.py
+++ b/src/llamafactory/hparams/generating_args.py
@@ -67,6 +67,10 @@ class GeneratingArguments:
         metadata={"help": "Whether or not to remove special tokens in the decoding."},
     )
 
+    def __post_init__(self) -> None:
+        if self.top_p <= 0:
+            raise ValueError("`top_p` must be in the interval (0, 1], got {0}.".format(self.top_p))
+
     def to_dict(self, obey_generation_config: bool = False) -> dict[str, Any]:
         args = asdict(self)
         if args.get("max_new_tokens", -1) > 0:

--- a/src/llamafactory/hparams/generating_args.py
+++ b/src/llamafactory/hparams/generating_args.py
@@ -70,6 +70,10 @@ class GeneratingArguments:
     def __post_init__(self) -> None:
         if not 0 < self.top_p <= 1:
             raise ValueError("`top_p` must be in the interval (0, 1], got {0}.".format(self.top_p))
+        if self.repetition_penalty <= 0:
+            raise ValueError(
+                "`repetition_penalty` must be a strictly positive float, got {0}.".format(self.repetition_penalty)
+            )
 
     def to_dict(self, obey_generation_config: bool = False) -> dict[str, Any]:
         args = asdict(self)

--- a/src/llamafactory/hparams/generating_args.py
+++ b/src/llamafactory/hparams/generating_args.py
@@ -68,7 +68,7 @@ class GeneratingArguments:
     )
 
     def __post_init__(self) -> None:
-        if self.top_p <= 0:
+        if not 0 < self.top_p <= 1:
             raise ValueError("`top_p` must be in the interval (0, 1], got {0}.".format(self.top_p))
 
     def to_dict(self, obey_generation_config: bool = False) -> dict[str, Any]:


### PR DESCRIPTION
Fixes hiyouga/LLaMA-Factory#10709

## Summary
`top_p = 0.0` (and, in the same shape, `repetition_penalty = 0.0`) were silently rewritten to `1.0` before reaching the backend on the vLLM, SGLang and `vllm_infer` paths, inverting the user's request (maximal diversity where minimal was asked; no penalty where a penalty was intended) with nothing logged. The HF engine already passed the value through faithfully, so the same config behaved differently per backend.

Two fixes:
1. **Validate at config-parse time** — `GeneratingArguments.__post_init__` now rejects `top_p` outside `(0, 1]` and `repetition_penalty <= 0`, surfacing bad YAML/values before a model is loaded.
2. **Drop the `or 1.0` rewrites** at all three sites that had them (`vllm_engine.py`, `sglang_engine.py`, `vllm_infer.py`), so every backend now passes the real value through — a bad value reaches the engine and the engine rejects it, naming the actual value instead of a substituted one.

The one `or` that remains is `top_k ... or -1`, which is deliberate: `top_k==0` means disabled on the HF/transformers side and `-1` is the disabled sentinel on vLLM's side, so that mapping preserves intent rather than inverting it.

## Validation coverage
The `__post_init__` validator runs on more entry points than just the config file: `scripts/vllm_infer.py` takes `top_p`/`repetition_penalty` as function parameters, but those flow through `get_infer_args(HfArgumentParser)`, which constructs `GeneratingArguments`, so CLI flags and the training path are covered too. Only the per-request override bypasses it — and that path now reaches the backend unmodified, where vLLM/transformers reject it, so it's validated by the component that owns the constraint.

## Tests
Verified locally the guard accepts `top_p` in `(0,1]` and `repetition_penalty > 0`, and rejects `0.0`, negatives, and `top_p > 1`.

Co-authored in review with @ErenAta16, who reproduced and validated against the actual commit each round.
