### PR TITLE
fix(data): support GCS directory listings

### DIFF
--- a/src/llamafactory/data/data_utils.py
+++ b/src/llamafactory/data/data_utils.py
@@ -195,7 +195,7 @@ def read_cloud_json(cloud_path: str) -> list[Any]:
         fs = setup_fs(cloud_path)  # try again with credentials
 
     # filter out non-JSON files
-    files = [x["Key"] for x in fs.listdir(cloud_path)] if fs.isdir(cloud_path) else [cloud_path]
+    files = fs.ls(cloud_path, detail=False) if fs.isdir(cloud_path) else [cloud_path]
     files = list(filter(lambda file: file.endswith(".json") or file.endswith(".jsonl"), files))
     if not files:
         raise ValueError(f"No JSON/JSONL files found in the specified path: {cloud_path}.")

--- a/tests/data/test_data_utils.py
+++ b/tests/data/test_data_utils.py
@@ -1,0 +1,35 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import fsspec
+
+from llamafactory.data import data_utils
+
+
+def test_read_cloud_json_from_gcs_directory(monkeypatch):
+    fs = fsspec.filesystem("memory", skip_instance_cache=True)
+    cloud_dir = "gs://llamafactory-test/dataset"
+    with fs.open(f"{cloud_dir}/train.json", "w") as f:
+        f.write('[{"id": 1}]')
+
+    with fs.open(f"{cloud_dir}/eval.jsonl", "w") as f:
+        f.write('{"id": 2}\n{"id": 3}\n')
+
+    with fs.open(f"{cloud_dir}/README.txt", "w") as f:
+        f.write("not a dataset")
+
+    monkeypatch.setattr(data_utils, "setup_fs", lambda path, anon=False: fs)
+
+    records = data_utils.read_cloud_json(cloud_dir)
+    assert sorted(records, key=lambda record: record["id"]) == [{"id": 1}, {"id": 2}, {"id": 3}]

--- a/tests/data/test_data_utils.py
+++ b/tests/data/test_data_utils.py
@@ -12,13 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import fsspec
+from fsspec.implementations.memory import MemoryFileSystem
 
 from llamafactory.data import data_utils
 
 
+class GCSLikeMemoryFileSystem(MemoryFileSystem):
+    protocol = "gs"
+    store = {}
+    pseudo_dirs = [""]
+
+    @classmethod
+    def _strip_protocol(cls, path):
+        return str(path).removeprefix("gs://").strip("/")
+
+
 def test_read_cloud_json_from_gcs_directory(monkeypatch):
-    fs = fsspec.filesystem("memory", skip_instance_cache=True)
+    fs = GCSLikeMemoryFileSystem(skip_instance_cache=True)
     cloud_dir = "gs://llamafactory-test/dataset"
     with fs.open(f"{cloud_dir}/train.json", "w") as f:
         f.write('[{"id": 1}]')
@@ -28,6 +38,12 @@ def test_read_cloud_json_from_gcs_directory(monkeypatch):
 
     with fs.open(f"{cloud_dir}/README.txt", "w") as f:
         f.write("not a dataset")
+
+    assert fs.ls(cloud_dir, detail=False) == [
+        "llamafactory-test/dataset/README.txt",
+        "llamafactory-test/dataset/eval.jsonl",
+        "llamafactory-test/dataset/train.json",
+    ]
 
     monkeypatch.setattr(data_utils, "setup_fs", lambda path, anon=False: fs)
 


### PR DESCRIPTION
# What does this PR do?

GCS directory datasets currently fail before reading any records because `read_cloud_json` assumes every detailed fsspec listing entry has the S3-specific `Key` field. GCS entries use `name`, so a `gs://` directory raises `KeyError: 'Key'`.

This change requests path-only listings with the backend-neutral fsspec `ls(..., detail=False)` API. S3 and GCS directories then both provide file paths without depending on backend-specific metadata fields.

The regression test exercises a GCS-style directory containing JSON, JSONL, and an unrelated text file. It verifies that both supported data formats are read and non-data files remain ignored.

## Validation

- `pytest -q --import-mode=importlib tests/ tests_v1/`: 314 passed, 24 skipped, 3 xfailed, 4 xpassed
- Ruff 0.15.5 check and format verification on both changed files
- `make license`
- `uv build`

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
