### PR TITLE
[Updated] fix: work around list-shaped extra_special_tokens in load_tokenizer

### DIFF
--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -25,6 +25,7 @@ from transformers import (
     AutoProcessor,
     AutoTokenizer,
 )
+from transformers.models.auto.tokenization_auto import get_tokenizer_config
 from trl import AutoModelForCausalLMWithValueHead
 
 from ..extras import logging
@@ -68,12 +69,45 @@ def _get_init_kwargs(model_args: "ModelArguments") -> dict[str, Any]:
     }
 
 
+def _pop_list_shaped_extra_special_tokens(model_args: "ModelArguments", init_kwargs: dict[str, Any]) -> list[str]:
+    r"""Work around transformers<5.0 crashing on list-shaped `extra_special_tokens`.
+
+    Some public checkpoints (e.g. Gemma-family, google/gemma-4-26B-A4B-it) ship
+    `extra_special_tokens` as a *list* in `tokenizer_config.json`. Every
+    transformers 4.55.0-4.57.6 release unconditionally calls `.keys()` on that
+    value in `_set_model_specific_special_tokens` and crashes with
+    `AttributeError: 'list' object has no attribute 'keys'`. The `isinstance`
+    guard fixing this only landed in the 5.0 rewrite, and we can't simply raise
+    our transformers floor to skip 4.x: `model_utils/longlora.py` and
+    `model/patcher.py` both mandate specific transformers<5.0 versions for their
+    own code paths, so 4.x has to keep working.
+
+    Instead, peek at the raw tokenizer config before `AutoTokenizer.from_pretrained`
+    even touches it. If the field is list-shaped, return its contents and let the
+    caller override the kwarg with an empty dict so the buggy code path never sees
+    the list -- the tokens themselves get re-added via `add_special_tokens` after
+    loading, so nothing is silently dropped.
+    """
+    try:
+        tokenizer_config = get_tokenizer_config(model_args.model_name_or_path, **init_kwargs)
+    except Exception:
+        return []
+
+    extra_special_tokens = tokenizer_config.get("extra_special_tokens")
+    if not isinstance(extra_special_tokens, list):
+        return []
+
+    init_kwargs["extra_special_tokens"] = {}
+    return [str(token) for token in extra_special_tokens]
+
+
 def load_tokenizer(model_args: "ModelArguments") -> "TokenizerModule":
     r"""Load pretrained tokenizer and optionally loads processor.
 
     Note: including inplace operation of model_args.
     """
     init_kwargs = _get_init_kwargs(model_args)
+    stray_extra_special_tokens = _pop_list_shaped_extra_special_tokens(model_args, init_kwargs)
     try:
         tokenizer = AutoTokenizer.from_pretrained(
             model_args.model_name_or_path,
@@ -91,6 +125,9 @@ def load_tokenizer(model_args: "ModelArguments") -> "TokenizerModule":
         )
     except Exception as e:
         raise OSError("Failed to load tokenizer.") from e
+
+    if stray_extra_special_tokens:
+        tokenizer.add_special_tokens({"additional_special_tokens": stray_extra_special_tokens})
 
     patch_tokenizer(tokenizer, model_args)
 


### PR DESCRIPTION
## Update (addressing review feedback)

The original version of this PR raised the `transformers` floor in
`pyproject.toml` from `>=4.55.0` to `>=5.0.0` to skip a broken 4.x tail.
A reviewer correctly flagged that this breaks the project in three places:

1. `.github/workflows/tests.yml` runs an explicit backward-compat matrix
   job pinned to `transformers==4.55.0` and `transformers==4.57.1` --
   both below the proposed floor, so those CI jobs would fail outright.
2. `model_utils/longlora.py` has a **mandatory** check,
   `check_version("transformers>=4.45.0,<4.48.0", mandatory=True)`. A
   global `>=5.0.0` floor makes LongLoRA permanently unsatisfiable, not
   just untested.
3. `model/patcher.py` has a **mandatory** check,
   `check_version("transformers==4.57.1", mandatory=True)`, gating
   MOSS-VL -- same contradiction against a `>=5.0.0` floor.

All three are correct. Raising the floor was the wrong tool for a bug
that only manifests when loading one specific tokenizer shape.

**This PR has been reworked accordingly.** `pyproject.toml` and
`extras/misc.py` are reverted to `main`'s original transformers range.
`.github/workflows/tests.yml`, `model_utils/longlora.py`, and
`model/patcher.py` are untouched.

## What (new approach)
Fixes the crash at its actual source in `model/loader.py::load_tokenizer`
instead of the dependency floor.

Some public checkpoints (e.g. `google/gemma-4-26B-A4B-it`) ship
`extra_special_tokens` in `tokenizer_config.json` as a **list** rather than
a dict. Every `transformers` 4.55.0-4.57.6 release unconditionally calls
`.keys()` on that value inside `_set_model_specific_special_tokens` and
crashes with `AttributeError: 'list' object has no attribute 'keys'`. The
`isinstance` guard fixing this only landed in the 5.0 rewrite and was never
backported.

Rather than requiring 5.0+ globally, `load_tokenizer` now:
1. Peeks at the raw tokenizer config via transformers' own
   `get_tokenizer_config()` helper, before `AutoTokenizer.from_pretrained`
   is called.
2. If `extra_special_tokens` is list-shaped, overrides it with `{}` in the
   kwargs passed to `from_pretrained` -- the buggy unguarded code path
   never sees a list, on any transformers version, 4.x or 5.x alike.
3. After the tokenizer loads, re-registers the stripped tokens via
   `tokenizer.add_special_tokens({"additional_special_tokens": [...]})` so
   nothing is silently dropped.

This also happens to line up better with how LLaMA-Factory already
consumes these tokens: `train/sft/workflow.py` and
`train/hyper_parallel/workflow.py` both read
`tokenizer.additional_special_tokens_ids` as their *primary* path (only
falling back to transformers' private `_extra_special_tokens` attribute if
that isn't a list). Routing the reclaimed tokens through
`add_special_tokens` populates exactly the field this codebase's own
training loops read, without relying on a transformers-internal attribute.

## Testing
- Live-reproduced the crash in a fresh venv with real `transformers==4.57.1`
  against a synthetic `tokenizer_config.json` carrying
  `"extra_special_tokens": ["<|video|>", "<|image|>"]` (the exact shape
  shipped by the real gemma4 checkpoint) -- baseline
  `AutoTokenizer.from_pretrained` reproduces the reported
  `AttributeError`; with the fix it loads cleanly and both tokens end up
  in `tokenizer.additional_special_tokens_ids` with valid ids.
- Same venv, tokenizer config with no `extra_special_tokens` field at all
  (the common case): fix is a no-op, load path unaffected -- no
  regression.
- `ruff check` / `ruff format --check` pass on the modified file.

## Scope
Single-file change (`src/llamafactory/model/loader.py`), +37/-0. No
changes to `pyproject.toml`, `extras/misc.py`, CI config, or any
version-check assertions elsewhere in the tree.

---
Happy to iterate further -- feel free to reach out at
ayushman.bhatt@walmart.com or theperfectionist0922@gmail.com if useful.

Closes #10766
