### PR TITLE
fix: align DeepSeek chat templates with Transformers

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -548,13 +548,16 @@ class DeepSeekR1Template(DeepSeekR1ReasoningMixin, ReasoningTemplate):
     r"""Render the original R1 thinking prefill before tokenization."""
 
     @override
-    def _process_rendered_messages(
+    def _process_thought_boundaries(
         self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
-    ) -> None:
+    ) -> set[int]:
         if self.enable_thinking is True:
-            self._move_thought_prefill(rendered_messages)
+            return self._move_thought_prefill(rendered_messages)
 
-    def _move_thought_prefill(self, rendered_messages: list["SLOTS"]) -> None:
+        return set()
+
+    def _move_thought_prefill(self, rendered_messages: list["SLOTS"]) -> set[int]:
+        processed_response_indices = set()
         thought_start = self.thought_words[0]
         for response_index in range(1, len(rendered_messages), 2):
             response_elements = rendered_messages[response_index]
@@ -573,6 +576,10 @@ class DeepSeekR1Template(DeepSeekR1ReasoningMixin, ReasoningTemplate):
 
             if response_content:
                 response_elements[0] = response_content[len(thought_start) :]
+
+            processed_response_indices.add(response_index)
+
+        return processed_response_indices
 
 
 @dataclass

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -531,6 +531,55 @@ class ReasoningTemplate(Template):
         return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(0, len(encoded_messages), 2)]
 
 
+class DeepSeekR1ReasoningMixin:
+    r"""Discard historical reasoning while preserving the whitespace after it."""
+
+    thought_end_tag = "</think>"
+
+    def remove_thought(self, content: str) -> str:
+        if self.thought_end_tag in content:
+            return content.split(self.thought_end_tag)[-1]
+
+        return content
+
+
+@dataclass
+class DeepSeekR1Template(DeepSeekR1ReasoningMixin, ReasoningTemplate):
+    r"""Render the original R1 thinking prefill before tokenization."""
+
+    @override
+    def _process_rendered_messages(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> None:
+        if self.enable_thinking is True:
+            self._move_thought_prefill(rendered_messages)
+
+    def _move_thought_prefill(self, rendered_messages: list["SLOTS"]) -> None:
+        thought_start = self.thought_words[0]
+        for response_index in range(1, len(rendered_messages), 2):
+            response_elements = rendered_messages[response_index]
+            if not response_elements or not isinstance(response_elements[0], str):
+                continue
+
+            response_content = response_elements[0]
+            if response_content and not response_content.startswith(thought_start):
+                continue
+
+            prompt_elements = rendered_messages[response_index - 1]
+            if prompt_elements and isinstance(prompt_elements[-1], str):
+                prompt_elements[-1] += thought_start
+            else:
+                prompt_elements.append(thought_start)
+
+            if response_content:
+                response_elements[0] = response_content[len(thought_start) :]
+
+
+@dataclass
+class DeepSeekR10528Template(DeepSeekR1ReasoningMixin, ReasoningTemplate):
+    r"""Keep the thinking marker in the response for R1-0528 tokenizers."""
+
+
 @dataclass
 class Glm47ReasoningTemplate(ReasoningTemplate):
     r"""GLM-4.7 uses only the closing </think> tag for empty thinking blocks."""
@@ -873,6 +922,7 @@ register_template(
 register_template(
     name="deepseek",
     format_user=StringFormatter(slots=["User: {{content}}\n\nAssistant:"]),
+    format_assistant=StringFormatter(slots=[" {{content}}", {"eos_token"}]),
     format_system=StringFormatter(slots=["{{content}}\n\n"]),
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
 )
@@ -890,7 +940,16 @@ register_template(
     name="deepseekr1",
     format_user=StringFormatter(slots=["<｜User｜>{{content}}<｜Assistant｜>"]),
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
-    template_class=ReasoningTemplate,
+    template_class=DeepSeekR1Template,
+)
+
+
+# copied from deepseekr1 template
+register_template(
+    name="deepseekr1_0528",
+    format_user=StringFormatter(slots=["<｜User｜>{{content}}<｜Assistant｜>"]),
+    format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
+    template_class=DeepSeekR10528Template,
 )
 
 
@@ -909,14 +968,14 @@ register_template(
 
 register_template(
     name="deepseekcoder",
-    format_user=StringFormatter(slots=["### Instruction:\n{{content}}\n### Response:"]),
-    format_assistant=StringFormatter(slots=["\n{{content}}\n<|EOT|>\n"]),
+    format_user=StringFormatter(slots=["### Instruction:\n{{content}}\n### Response:\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}\n<|EOT|>\n"]),
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
     default_system=(
-        "You are an AI programming assistant, utilizing the DeepSeek Coder model, "
-        "developed by DeepSeek Company, and you only answer questions related to computer science. "
+        "You are an AI programming assistant, utilizing the Deepseek Coder model, "
+        "developed by Deepseek Company, and you only answer questions related to computer science. "
         "For politically sensitive questions, security and privacy issues, "
-        "and other non-computer science questions, you will refuse to answer.\n"
+        "and other non-computer science questions, you will refuse to answer\n"
     ),
 )
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -65,7 +65,7 @@ class Template:
         tools: Optional[str] = None,
     ) -> tuple[list[int], list[int]]:
         r"""Return a single pair of token ids representing prompt and response respectively."""
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, _ = self._encode(tokenizer, messages, system, tools)
         prompt_ids = []
         for encoded_ids in encoded_messages[:-1]:
             prompt_ids += encoded_ids
@@ -82,7 +82,7 @@ class Template:
         discarding_history_cot: bool = False,  # only effect reasoning template
     ) -> list[tuple[list[int], list[int]]]:
         r"""Return multiple pairs of token ids representing prompts and responses respectively."""
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, _ = self._encode(tokenizer, messages, system, tools)
         return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(0, len(encoded_messages), 2)]
 
     def extract_tool(self, content: str) -> Union[str, list["FunctionCall"]]:
@@ -135,7 +135,7 @@ class Template:
         messages: list[dict[str, str]],
         system: Optional[str],
         tools: Optional[str],
-    ) -> list[list[int]]:
+    ) -> tuple[list[list[int]], set[int]]:
         r"""Encode formatted inputs to pairs of token ids.
 
         Turn 0: prefix + system + query        resp
@@ -147,15 +147,17 @@ class Template:
 
         rendered_messages = self._render(messages, system, tools)
         self._process_rendered_messages(rendered_messages, messages)
-        return [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+        processed_response_indices = self._process_thought_boundaries(rendered_messages, messages)
+        encoded_messages = [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+        return encoded_messages, processed_response_indices
 
     def _process_messages(self, messages: list[dict[str, str]]) -> Optional[list[dict[str, str]]]:
         r"""Return model-specific messages before rendering, or use the original messages."""
-        pass
+        return None
 
     def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
         r"""Return model-specific system and tool elements, or use the default formatter."""
-        pass
+        return None
 
     def _render(
         self,
@@ -200,7 +202,13 @@ class Template:
         self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
     ) -> None:
         r"""Apply model-specific changes to formatter output before tokenization."""
-        pass
+        return None
+
+    def _process_thought_boundaries(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> set[int]:
+        r"""Process model-specific thought boundaries and return the handled response indices."""
+        return set()
 
     @staticmethod
     def _add_or_replace_eos_token(tokenizer: "PreTrainedTokenizer", eos_token: str) -> None:
@@ -452,7 +460,7 @@ class ReasoningTemplate(Template):
 
     def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
         r"""Process model-specific historical reasoning and return whether it was handled."""
-        pass
+        return False
 
     @override
     def encode_oneturn(
@@ -470,8 +478,14 @@ class ReasoningTemplate(Template):
         if self.enable_thinking is False:  # remove all cot
             messages[-1]["content"] = self.remove_thought(messages[-1]["content"])
 
-        prompt_ids, response_ids = super().encode_oneturn(tokenizer, messages, system, tools)
-        if (
+        encoded_messages, processed_response_indices = self._encode(tokenizer, messages, system, tools)
+        prompt_ids = []
+        for encoded_ids in encoded_messages[:-1]:
+            prompt_ids += encoded_ids
+
+        response_index = len(encoded_messages) - 1
+        response_ids = encoded_messages[response_index]
+        if response_index not in processed_response_indices and (
             self.thought_words[0].strip() not in messages[-1]["content"]
             and self.thought_words[1].strip() not in messages[-1]["content"]
         ):  # add empty cot
@@ -500,14 +514,14 @@ class ReasoningTemplate(Template):
             for i in range(1, len(messages) - 2, 2):  # preserve the last cot
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, processed_response_indices = self._encode(tokenizer, messages, system, tools)
         if discarding_history_cot:
             turn_indices = [len(messages) - 2]
         else:
             turn_indices = range(0, len(messages), 2)
 
         for i in turn_indices:
-            if (
+            if i + 1 not in processed_response_indices and (
                 self.thought_words[0].strip() not in messages[i + 1]["content"]
                 and self.thought_words[1].strip() not in messages[i + 1]["content"]
             ):  # add empty cot

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -141,16 +141,43 @@ class Template:
         Turn 0: prefix + system + query        resp
         Turn t: query                          resp.
         """
+        processed_messages = self._process_messages(messages)
+        if processed_messages is not None:
+            messages = processed_messages
+
+        rendered_messages = self._render(messages, system, tools)
+        self._process_rendered_messages(rendered_messages, messages)
+        return [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+
+    def _process_messages(self, messages: list[dict[str, str]]) -> Optional[list[dict[str, str]]]:
+        r"""Return model-specific messages before rendering, or use the original messages."""
+        pass
+
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
+        r"""Return model-specific system and tool elements, or use the default formatter."""
+        pass
+
+    def _render(
+        self,
+        messages: list[dict[str, str]],
+        system: Optional[str],
+        tools: Optional[str],
+    ) -> list["SLOTS"]:
+        r"""Render messages into formatter elements before tokenization."""
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
             if i == 0:
                 elements += self.format_prefix.apply()
                 if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    elements += self.format_system.apply(content=(system + tool_text))
+                    system_and_tools = self._format_system_and_tools(system, tools)
+                    if system_and_tools is None:
+                        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+                        system_and_tools = self.format_system.apply(content=(system + tool_text))
+
+                    elements += system_and_tools
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
@@ -165,9 +192,15 @@ class Template:
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
+
+    def _process_rendered_messages(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> None:
+        r"""Apply model-specific changes to formatter output before tokenization."""
+        pass
 
     @staticmethod
     def _add_or_replace_eos_token(tokenizer: "PreTrainedTokenizer", eos_token: str) -> None:
@@ -336,45 +369,12 @@ class Template:
 @dataclass
 class MossVLTemplate(Template):
     @override
-    def _encode(
-        self,
-        tokenizer: "PreTrainedTokenizer",
-        messages: list[dict[str, str]],
-        system: Optional[str],
-        tools: Optional[str],
-    ) -> list[list[int]]:
-        system = system or self.default_system
-        encoded_messages = []
-        for i, message in enumerate(messages):
-            elements = []
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> "SLOTS":
+        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+        if tools and not system:
+            tool_text = tool_text.lstrip("\n")
 
-            if i == 0:
-                elements += self.format_prefix.apply()
-                if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    if tools and not system:
-                        tool_text = tool_text.lstrip("\n")
-
-                    elements += self.format_system.apply(content=(system + tool_text))
-
-            if message["role"] == Role.USER:
-                elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
-            elif message["role"] == Role.ASSISTANT:
-                elements += self.format_assistant.apply(content=message["content"])
-            elif message["role"] == Role.OBSERVATION:
-                elements += self.format_observation.apply(content=message["content"])
-            elif message["role"] == Role.FUNCTION:
-                elements += self.format_function.apply(
-                    content=message["content"],
-                    thought_words=self.thought_words,
-                    tool_call_words=self.tool_call_words,
-                )
-            else:
-                raise NotImplementedError("Unexpected role: {}".format(message["role"]))
-
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
-
-        return encoded_messages
+        return self.format_system.apply(content=(system + tool_text))
 
 
 @dataclass
@@ -382,15 +382,14 @@ class Llama2Template(Template):
     r"""A template that fuse the system message to first user message."""
 
     @override
-    def _encode(
+    def _render(
         self,
-        tokenizer: "PreTrainedTokenizer",
         messages: list[dict[str, str]],
         system: str,
         tools: str,
-    ) -> list[list[int]]:
+    ) -> list["SLOTS"]:
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
@@ -412,9 +411,9 @@ class Llama2Template(Template):
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
 
     def _get_jinja_template(self, tokenizer: "PreTrainedTokenizer") -> str:
         prefix = self._convert_slots_to_jinja(self.format_prefix.apply(), tokenizer)
@@ -451,6 +450,10 @@ class Llama2Template(Template):
 class ReasoningTemplate(Template):
     r"""A template that add thought to assistant message."""
 
+    def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
+        r"""Process model-specific historical reasoning and return whether it was handled."""
+        pass
+
     @override
     def encode_oneturn(
         self,
@@ -460,7 +463,7 @@ class ReasoningTemplate(Template):
         tools: Optional[str] = None,
     ) -> tuple[list[int], list[int]]:
         messages = deepcopy(messages)
-        if not self.preserve_thinking:
+        if not self.preserve_thinking and not self._process_history_thoughts(messages, is_inference=True):
             for i in range(1, len(messages) - 2, 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
@@ -493,7 +496,7 @@ class ReasoningTemplate(Template):
             for i in range(1, len(messages), 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
-        if discarding_history_cot:
+        if discarding_history_cot and not self._process_history_thoughts(messages, is_inference=False):
             for i in range(1, len(messages) - 2, 2):  # preserve the last cot
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -198,9 +198,7 @@ class Template:
 
         return rendered_messages
 
-    def _process_rendered_messages(
-        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
-    ) -> None:
+    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
         r"""Apply model-specific changes to formatter output before tokenization."""
         return None
 

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -545,6 +545,13 @@ register_model_group(
             DownloadSource.DEFAULT: "deepseek-ai/DeepSeek-R1",
             DownloadSource.MODELSCOPE: "deepseek-ai/DeepSeek-R1",
         },
+    },
+    template="deepseekr1",
+)
+
+
+register_model_group(
+    models={
         "DeepSeek-R1-0528-8B-Distill": {
             DownloadSource.DEFAULT: "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
             DownloadSource.MODELSCOPE: "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
@@ -554,7 +561,7 @@ register_model_group(
             DownloadSource.MODELSCOPE: "deepseek-ai/DeepSeek-R1-0528",
         },
     },
-    template="deepseekr1",
+    template="deepseekr1_0528",
 )
 
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import pytest
@@ -95,6 +97,58 @@ def _check_template(
     assert content_str == prompt_str + answer_str
     assert content_ids == prompt_ids + answer_ids
     _check_tokenization(tokenizer, (prompt_ids, answer_ids), (prompt_str, answer_str))
+
+
+def test_rendering_refactor_preserves_existing_template_boundaries():
+    class ByteTokenizer:
+        bos_token_id = 1000
+        eos_token_id = 1001
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            return list(text.encode())
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    tokenizer = ByteTokenizer()
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+
+    standard = deepcopy(TEMPLATES["falcon_h1"])
+    prompt_ids, response_ids = standard.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<|im_start|>system\nsystem<|im_end|>\n"
+        "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    tools = json.dumps(
+        [
+            {
+                "name": "search",
+                "description": "Search documents.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            }
+        ]
+    )
+    moss_vl = deepcopy(TEMPLATES["moss_vl"])
+    prompt_ids, response_ids = moss_vl.encode_oneturn(tokenizer, messages, tools=tools)
+    tool_text = moss_vl.format_tools.apply(content=tools)[0].lstrip("\n")
+    assert prompt_ids == tokenizer.encode(
+        moss_vl.format_system.apply(content=tool_text)[0]
+        + "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    llama2 = deepcopy(TEMPLATES["gemma"])
+    prompt_ids, response_ids = llama2.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<start_of_turn>user\nsystem\n\nquestion<end_of_turn>\n<start_of_turn>model\n"
+    )
+    assert response_ids == tokenizer.encode("answer<end_of_turn>\n")
 
 
 def test_moss_vl_registration():

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -56,6 +56,25 @@ MESSAGES_WITH_THOUGHT = [
 ]
 
 
+class _RecordingTokenizer:
+    bos_token_id = 1
+    eos_token_id = 2
+
+    def __init__(self):
+        self.encoded_texts = []
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        assert not add_special_tokens
+        self.encoded_texts.append(text)
+        return [len(self.encoded_texts) + 2]
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    def decode(self, *args, **kwargs) -> str:
+        raise AssertionError("DeepSeek formatter rendering must not decode token ids.")
+
+
 def _check_tokenization(
     tokenizer: "PreTrainedTokenizer", batch_input_ids: list[list[int]], batch_text: list[str]
 ) -> None:
@@ -498,3 +517,173 @@ def test_parse_qwen3_template():
     assert template.format_system.slots == ["<|im_start|>system\n{{content}}<|im_end|>\n"]
     assert template.format_prefix.slots == []
     assert template.default_system == ""
+
+
+@pytest.mark.parametrize(
+    ("enable_thinking", "response", "expected_prompt", "expected_response"),
+    [
+        (
+            True,
+            "<think>\nreasoning\n</think>\n\nanswer",
+            "<｜User｜>question<｜Assistant｜><think>\n",
+            "reasoning\n</think>\n\nanswer",
+        ),
+        (
+            True,
+            "<think>reasoning</think>\n\nanswer",
+            "<｜User｜>question<｜Assistant｜>",
+            "<think>reasoning</think>\n\nanswer",
+        ),
+    ],
+)
+def test_deepseekr1_renders_thinking_boundary_before_tokenization(
+    enable_thinking: bool,
+    response: str,
+    expected_prompt: str,
+    expected_response: str,
+):
+    tokenizer = _RecordingTokenizer()
+    template = deepcopy(TEMPLATES["deepseekr1"])
+    template.enable_thinking = enable_thinking
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": response},
+    ]
+    original_messages = deepcopy(messages)
+
+    prompt_ids, response_ids = template.encode_oneturn(tokenizer, messages)
+
+    assert messages == original_messages
+    assert tokenizer.encoded_texts == [expected_prompt, expected_response]
+    assert prompt_ids == [tokenizer.bos_token_id, 3]
+    assert response_ids == [4, tokenizer.eos_token_id]
+
+
+def test_deepseekr1_multiturn_discards_only_historical_thinking():
+    tokenizer = _RecordingTokenizer()
+    template = deepcopy(TEMPLATES["deepseekr1"])
+    template.enable_thinking = True
+    messages = [
+        {"role": "user", "content": "question 1"},
+        {"role": "assistant", "content": "<think>\nreasoning 1\n</think>\n\nanswer 1"},
+        {"role": "user", "content": "question 2"},
+        {"role": "assistant", "content": "<think>\nreasoning 2\n</think>\n\nanswer 2"},
+    ]
+    original_messages = deepcopy(messages)
+
+    encoded_pairs = template.encode_multiturn(tokenizer, messages, discarding_history_cot=True)
+
+    assert messages == original_messages
+    assert tokenizer.encoded_texts == [
+        "<｜User｜>question 1<｜Assistant｜>",
+        "\n\nanswer 1",
+        "<｜User｜>question 2<｜Assistant｜><think>\n",
+        "reasoning 2\n</think>\n\nanswer 2",
+    ]
+    assert encoded_pairs == [
+        ([tokenizer.bos_token_id, 3], [4, tokenizer.eos_token_id]),
+        ([5], [6, tokenizer.eos_token_id]),
+    ]
+
+
+def test_deepseekr1_inference_adds_thinking_prefill():
+    tokenizer = _RecordingTokenizer()
+    template = deepcopy(TEMPLATES["deepseekr1"])
+    template.enable_thinking = True
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": ""},
+    ]
+
+    prompt_ids, _ = template.encode_oneturn(tokenizer, messages)
+
+    assert tokenizer.encoded_texts[0] == "<｜User｜>question<｜Assistant｜><think>\n"
+    assert prompt_ids == [tokenizer.bos_token_id, 3]
+
+
+def test_deepseekr1_0528_keeps_thinking_marker_in_response():
+    tokenizer = _RecordingTokenizer()
+    template = deepcopy(TEMPLATES["deepseekr1_0528"])
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "<think>\nreasoning\n</think>\n\nanswer"},
+    ]
+
+    template.encode_oneturn(tokenizer, messages)
+
+    assert tokenizer.encoded_texts == [
+        "<｜User｜>question<｜Assistant｜>",
+        "<think>\nreasoning\n</think>\n\nanswer",
+    ]
+
+
+def test_default_rendered_message_processing_leaves_formatter_output_unchanged():
+    tokenizer = _RecordingTokenizer()
+    template = deepcopy(TEMPLATES["deepseek3"])
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "<think>\nreasoning\n</think>\n\nanswer"},
+    ]
+
+    template.encode_oneturn(tokenizer, messages)
+
+    assert tokenizer.encoded_texts == [
+        "<｜User｜>question<｜Assistant｜>",
+        "<think>\nreasoning\n</think>\n\nanswer",
+    ]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_deepseek_template_consistency():
+    expected_templates = {
+        "DeepSeek-Coder-6.7B-Instruct": "deepseekcoder",
+        "DeepSeek-Coder-7B-Instruct": "deepseekcoder",
+        "DeepSeek-Coder-33B-Instruct": "deepseekcoder",
+        "DeepSeek-LLM-7B-Chat": "deepseek",
+        "DeepSeek-LLM-67B-Chat": "deepseek",
+        "DeepSeek-Math-7B-Instruct": "deepseek",
+        "DeepSeek-R1-1.5B-Distill": "deepseekr1",
+        "DeepSeek-R1-7B-Distill": "deepseekr1",
+        "DeepSeek-R1-8B-Distill": "deepseekr1",
+        "DeepSeek-R1-14B-Distill": "deepseekr1",
+        "DeepSeek-R1-32B-Distill": "deepseekr1",
+        "DeepSeek-R1-70B-Distill": "deepseekr1",
+        "DeepSeek-R1-671B-Chat-Zero": "deepseekr1",
+        "DeepSeek-R1-671B-Chat": "deepseekr1",
+        "DeepSeek-R1-0528-8B-Distill": "deepseekr1_0528",
+        "DeepSeek-R1-0528-671B-Chat": "deepseekr1_0528",
+    }
+    for model_name, template_name in expected_templates.items():
+        assert DEFAULT_TEMPLATE[model_name] == template_name
+
+    cases = [
+        ("deepseek-ai/deepseek-coder-6.7b-instruct", "deepseekcoder", MESSAGES),
+        ("deepseek-ai/deepseek-llm-7b-chat", "deepseek", MESSAGES),
+        ("deepseek-ai/deepseek-math-7b-instruct", "deepseek", MESSAGES),
+        ("deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B", "deepseekr1", MESSAGES_WITH_THOUGHT),
+        ("deepseek-ai/DeepSeek-R1-0528-Qwen3-8B", "deepseekr1_0528", MESSAGES_WITH_THOUGHT),
+        ("deepseek-ai/DeepSeek-R1-0528", "deepseekr1_0528", MESSAGES_WITH_THOUGHT),
+    ]
+    for model_id, template_name, messages in cases:
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        reference_tokenizer = AutoTokenizer.from_pretrained(model_id)
+        template = get_template_and_fix_tokenizer(
+            tokenizer,
+            DataArguments(template=template_name, enable_thinking=True),
+        )
+        prompt_ids, _ = template.encode_oneturn(tokenizer, messages)
+        inference_prompt_ids, _ = template.encode_oneturn(
+            tokenizer,
+            messages[:-1] + [{"role": "assistant", "content": ""}],
+        )
+        reference_prompt_ids = reference_tokenizer.apply_chat_template(
+            messages[:-1],
+            tokenize=True,
+            add_generation_prompt=True,
+            enable_thinking=True,
+        )
+        if is_transformers_version_greater_than("5.0.0"):
+            reference_prompt_ids = reference_prompt_ids["input_ids"]
+
+        assert prompt_ids == reference_prompt_ids, model_id
+        assert inference_prompt_ids == reference_prompt_ids, model_id

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -120,8 +120,7 @@ def test_rendering_refactor_preserves_existing_template_boundaries():
     standard = deepcopy(TEMPLATES["falcon_h1"])
     prompt_ids, response_ids = standard.encode_oneturn(tokenizer, messages, system="system")
     assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
-        "<|im_start|>system\nsystem<|im_end|>\n"
-        "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+        "<|im_start|>system\nsystem<|im_end|>\n<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
     )
     assert response_ids == tokenizer.encode("answer<|im_end|>\n")
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -21,7 +21,7 @@ import pytest
 from transformers import AutoTokenizer
 
 from llamafactory.data import get_template_and_fix_tokenizer
-from llamafactory.data.template import TEMPLATES, parse_template
+from llamafactory.data.template import TEMPLATES, ReasoningTemplate, parse_template
 from llamafactory.extras.constants import (
     DEFAULT_TEMPLATE,
     MULTIMODAL_SUPPORTED_MODELS,
@@ -149,6 +149,42 @@ def test_rendering_refactor_preserves_existing_template_boundaries():
         "<start_of_turn>user\nsystem\n\nquestion<end_of_turn>\n<start_of_turn>model\n"
     )
     assert response_ids == tokenizer.encode("answer<end_of_turn>\n")
+
+
+def test_thought_boundary_hook_reports_handled_responses():
+    class ByteTokenizer:
+        bos_token_id = 1000
+        eos_token_id = 1001
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            return list(text.encode())
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    class HookedReasoningTemplate(ReasoningTemplate):
+        def _process_thought_boundaries(self, rendered_messages, messages) -> set[int]:
+            response_index = len(rendered_messages) - 1
+            rendered_messages[response_index][0] = self.add_thought() + rendered_messages[response_index][0]
+            return {response_index}
+
+    template = HookedReasoningTemplate(**vars(deepcopy(TEMPLATES["qwen3"])))
+    template.enable_thinking = True
+    messages = [
+        {"role": "user", "content": "question 1"},
+        {"role": "assistant", "content": "answer 1"},
+        {"role": "user", "content": "question 2"},
+        {"role": "assistant", "content": "answer 2"},
+    ]
+
+    tokenizer = ByteTokenizer()
+    response_ids = template.encode_oneturn(tokenizer, messages)[1]
+    assert response_ids == list((template.add_thought() + "answer 2<|im_end|>\n").encode())
+
+    encoded_pairs = template.encode_multiturn(tokenizer, messages)
+    assert encoded_pairs[0][1] == list((template.add_thought() + "answer 1<|im_end|>\n").encode())
+    assert encoded_pairs[1][1] == list((template.add_thought() + "answer 2<|im_end|>\n").encode())
 
 
 def test_moss_vl_registration():


### PR DESCRIPTION
# What does this PR do?

Aligns the DeepSeek-Coder, DeepSeek-R1, DeepSeek-LLM-Chat, and DeepSeek-Math templates with their official Transformers chat templates. The changes correct default-system text, prompt/label boundaries, historical assistant formatting, historical reasoning removal, and the different generation-prefill rules used by original R1 and R1-0528 tokenizers.

### Affected Model Series and Templates

| Model series | Template |
| --- | --- |
| `DeepSeek-Coder-*B-Instruct` | `deepseekcoder` |
| `DeepSeek-R1-*B-Distill`; `DeepSeek-R1-671B-Chat*` | `deepseekr1` |
| `DeepSeek-R1-0528-*B-Distill`; `DeepSeek-R1-0528-671B-Chat` | `deepseekr1_0528` |
| `DeepSeek-LLM-*B-Chat`; `DeepSeek-Math-*B-Instruct`; `DeepSeek-MoE-*B-Chat`; `DeepSeek-V2-*B-Chat`; `DeepSeek-Coder-V2-*B-Instruct` | `deepseek` |

This PR depends on #10784 for the shared pre-tokenization hooks. It retains only the DeepSeek-specific history and thought-boundary overrides, template registrations, model mappings, and tests on top of that base.

I have added unit tests to this PR. All the models have been verified and modified through the unit tests and our consistency-checking mechanism script. There are no errors after the modification.



## Introduction

While reviewing issues recently, I found a large number of problems caused by inconsistencies between templates.

This made us realize that these inconsistencies are not isolated incidents, especially for less common models. When users use the official templates provided by these models, such inconsistencies can cause severe mismatches between training and inference, significantly affecting training speed and the inference accuracy of the trained models.

This work consists of two parts:

1. I will use a script to perform large-scale testing on all models using the examples described below. The test will compare the generated text/token sequences across LlamaFactory training, LlamaFactory inference, and vLLM inference using the standard Transformers `chat_template` interface. I will then fix the issues one by one. Since there are many models, the fixes will be submitted in multiple PRs organized by model family to make them easier to review.

2. I will add a consistency-checking mechanism that runs automatically before training. If inconsistencies are detected, it will issue a warning and save the corresponding test examples, but it will not block training. This mechanism will be submitted as a separate PR.

The most common problems can be roughly divided into the following categories:

1. The native LlamaFactory templates do not have sufficiently fine-grained coverage. For example, Qwen3 includes several model variants, such as the Qwen3-8B-Thinking series and the Qwen3-30B-A3B-Thinking-2507 series. Qwen2.5 also includes variants such as Coder and Math. These models have subtle differences: the Qwen3-8B-Thinking series supports both thinking and non-thinking modes, while Qwen3-30B-A3B-Thinking-2507 only supports thinking mode. The official templates for the Coder and Math series also use different system prompts. However, the native system does not distinguish between these variants and applies the same template to all of them.

2. The handling of thinking traces is inconsistent. LlamaFactory provides `mask_history` and `preserve_thinking` to control whether historical thinking traces are removed during training and inference, but it currently uses the generic `remove_thought()` function for all models. In practice, different models require different handling, for example:

   - DeepSeek-R1: remove historical thinking content while preserving the two newlines after the closing tag.
   - GLM-4.5: remove the thinking content while preserving an empty thinking block.
   - Qwen/QwQ: follow the tokenizer-specific rules for historical assistant/tool messages.
   - Hunyuan: preserve or generate the corresponding boundaries according to its tokenizer; a generic removal function cannot be used.

3. The handling of whether the `<think>` tag is generated by the model is inconsistent. In the DeepSeek-R1-*B-Distill series, the `<think>` tag is part of the model output during training and is included in loss computation. During inference, however, the template automatically adds the `<think>` tag as part of the prompt, so the model does not need to generate it.

4. There are also various minor bugs of this kind. I will analyze and fix these issues individually.

### Verified Correct Models

The following models completed template validation and already match their tokenizer chat templates. They do not require a template change in this series of PRs.

- Kimi-Dev-*B-Instruct
- Llama-3.1-*B-Chinese-Chat
- Phi-4-*B-Instruct
- Qwen2.5-*B-Instruct (standard, AWQ, GPTQ-Int4, and GPTQ-Int8)
- Qwen2.5-Coder-*B-Instruct
- Qwen3-*-Instruct-2507
- Qwen3-*-Thinking* (excluding the 2507-only thinking series)
- Qwen3-Next-80B-A3B-Instruct
- Seed-Coder-*B-Instruct
- SmolLM-*-Instruct
- Yi-Coder-*B-Chat

### Submit PR List

| PR | Model family or scope | Status |
| --- | --- | --- |
| 1 (current PR) | `DeepSeek-Coder-*B-Instruct`; `DeepSeek-R1*`; `DeepSeek-LLM-*B-Chat`; `DeepSeek-Math-*B-Instruct` | √ |
| 2 | `GLM-4-0414-*B-Chat`; `GLM-4.5-*Thinking`; `GLM-Z1-0414-*B-Chat` | √ |
| 3 | `Hunyuan-*B-Instruct`; `Hunyuan-MT-*B-Instruct`; `HY-MT1.5-*B-Instruct`; `Hy-MT2-*B-Instruct` | × |
| 4 | `Qwen2-*`; `Qwen2.5-*-Instruct-1M`; `Qwen2.5-Math-*-Instruct` | × |
| 5 | `Qwen3-*-Instruct-2507`; `Qwen3-*-Thinking*`; `Qwen3-Next-*-Instruct`; `Qwen3-Next-*-Thinking` | × |
| 6 | `QwQ-32B-Instruct`; `QwQ-32B-Preview-Instruct` | × |
| 7 | `Falcon-H1-*B-*Instruct` | × |
| 8 | `Granite-3.0-*B-A400M-Instruct` | × |
| 9 | `Llama-3-*B-Chinese-Chat` | × |
| 10 | `Yi-6B-Chat`; `Yi-34B-Chat` | × |
| 11 | Automatic pre-training consistency warning | × |

### Planned PR
The validation and correction work described above has already covered 80% of the models. Some model families, such as Qwen 3.5, Gemini, MiniCPM, and MiniMax, could not be completed immediately due to the workload and the need to merge other contributors’ PRs. They will be gradually addressed in follow-up work.


## Models Fixed Diff

### deepseek-ai/deepseek-coder-*b-instruct

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system` | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;YouareanAIprogrammingassistant,utilizingtheDeep<mark>s</mark>eekCodermodel,developedbyDeep<mark>s</mark>eekCompany,andyouonlyanswerquestionsrelatedtocomputerscience.Forpoliticallysensitivequestions,securityandprivacyissues,andothernon-computersciencequestions,youwillrefusetoanswer###Instruction:Whatis17multipliedby24?###Response:</code> | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;YouareanAIprogrammingassistant,utilizingtheDeep<mark>S</mark>eekCodermodel,developedbyDeep<mark>S</mark>eekCompany,andyouonlyanswerquestionsrelatedtocomputerscience.Forpoliticallysensitivequestions,securityandprivacyissues,andothernon-computersciencequestions,youwillrefusetoanswer<mark>.</mark>###Instruction:Whatis17multipliedby24?###Response:</code> | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;YouareanAIprogrammingassistant,utilizingtheDeepseekCodermodel,developedbyDeepseekCompany,andyouonlyanswerquestionsrelatedtocomputerscience.Forpoliticallysensitivequestions,securityandprivacyissues,andothernon-computersciencequestions,youwillrefusetoanswer###Instruction:Whatis17multipliedby24?###Response:</code> |

### deepseek-ai/deepseek-llm-*b-chat

The original template was already consistent.

### deepseek-ai/deepseek-math-*b-instruct

The original template was already consistent.

### deepseek-ai/DeepSeek-R1-Distill-Qwen-*B

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system_with_thinking` | <code>&lt;｜begin▁of▁sentence｜&gt;&lt;｜User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜Assistant｜&gt;<mark>&lt;think&gt;<br></mark></code> | <code>&lt;｜begin▁of▁sentence｜&gt;&lt;｜User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜Assistant｜&gt;</code> | <code>&lt;｜begin▁of▁sentence｜&gt;&lt;｜User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜Assistant｜&gt;&lt;think&gt;<br></code> |
| `single_turn_with_system_and_thinking` | <code>&lt;｜begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜Assistant｜&gt;<mark>&lt;think&gt;<br></mark></code> | <code>&lt;｜begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜Assistant｜&gt;</code> | <code>&lt;｜begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜Assistant｜&gt;&lt;think&gt;<br></code> |
| `multi_turn_with_system_and_thinking` | <code>&lt;｜begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜User｜&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;｜Assistant｜&gt;<mark><br><br></mark>There&nbsp;are&nbsp;20&nbsp;markers.&lt;｜end▁of▁sentence｜&gt;&lt;｜User｜&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;｜Assistant｜&gt;<mark>&lt;think&gt;<br></mark></code> | <code>&lt;｜begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜User｜&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;｜Assistant｜&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;｜end▁of▁sentence｜&gt;&lt;｜User｜&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;｜Assistant｜&gt;</code> | <code>&lt;｜begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜User｜&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;｜Assistant｜&gt;<br><br>There&nbsp;are&nbsp;20&nbsp;markers.&lt;｜end▁of▁sentence｜&gt;&lt;｜User｜&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;｜Assistant｜&gt;&lt;think&gt;<br></code> |

### deepseek-ai/DeepSeek-R1-Distill-Llama-*B

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system_with_thinking` | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;&lt;｜User｜&gt;Whatis17multipliedby24?&lt;｜Assistant｜&gt;<mark>&lt;think&gt;</mark></code> | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;&lt;｜User｜&gt;Whatis17multipliedby24?&lt;｜Assistant｜&gt;</code> | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;&lt;｜User｜&gt;Whatis17multipliedby24?&lt;｜Assistant｜&gt;&lt;think&gt;</code> |
| `single_turn_with_system_and_thinking` | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;Youareahelpfulmathassistant.Giveaconcisefinalanswer.&lt;｜User｜&gt;Whatis17multipliedby24?&lt;｜Assistant｜&gt;<mark>&lt;think&gt;</mark></code> | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;Youareahelpfulmathassistant.Giveaconcisefinalanswer.&lt;｜User｜&gt;Whatis17multipliedby24?&lt;｜Assistant｜&gt;</code> | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;Youareahelpfulmathassistant.Giveaconcisefinalanswer.&lt;｜User｜&gt;Whatis17multipliedby24?&lt;｜Assistant｜&gt;&lt;think&gt;</code> |
| `multi_turn_with_system_and_thinking` | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;Youareahelpfulmathassistant.Giveaconcisefinalanswer.&lt;｜User｜&gt;Aboxcontains12redmarkersand8bluemarkers.Howmanymarkersarethere?&lt;｜Assistant｜&gt;Thereare20markers.&lt;｜end&nbsp;of&nbsp;sentence｜&gt;&lt;｜User｜&gt;If5markersareremoved,howmanyremain?&lt;｜Assistant｜&gt;<mark>&lt;think&gt;</mark></code> | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;Youareahelpfulmathassistant.Giveaconcisefinalanswer.&lt;｜User｜&gt;Aboxcontains12redmarkersand8bluemarkers.Howmanymarkersarethere?&lt;｜Assistant｜&gt;Thereare20markers.&lt;｜end&nbsp;of&nbsp;sentence｜&gt;&lt;｜User｜&gt;If5markersareremoved,howmanyremain?&lt;｜Assistant｜&gt;</code> | <code>&lt;｜begin&nbsp;of&nbsp;sentence｜&gt;Youareahelpfulmathassistant.Giveaconcisefinalanswer.&lt;｜User｜&gt;Aboxcontains12redmarkersand8bluemarkers.Howmanymarkersarethere?&lt;｜Assistant｜&gt;Thereare20markers.&lt;｜end&nbsp;of&nbsp;sentence｜&gt;&lt;｜User｜&gt;If5markersareremoved,howmanyremain?&lt;｜Assistant｜&gt;&lt;think&gt;</code> |


## Models Fixed in This PR

**DeepSeek-Coder-\*B-Instruct Series**

**Affected Model Names**

- DeepSeek-Coder-6.7B-Instruct
- DeepSeek-Coder-7B-Instruct
- DeepSeek-Coder-33B-Instruct

**Background**

The tokenizer uses `Deepseek Coder` and `Deepseek Company`, ends the default system message without a period, and places the newline after `### Response:` in the prompt. LlamaFactory used different capitalization, added the period, and placed that newline at the beginning of the supervised assistant response.

**Root Cause**

The `deepseekcoder` registration in `src/llamafactory/data/template.py` did not reproduce the tokenizer-defined default system text or the `### Response:\n` prompt/response boundary.

**Solution**

1. In `src/llamafactory/data/template.py`, end `deepseekcoder.format_user` with `### Response:\n`.
2. Remove the leading newline from `format_assistant` so it is not included in response labels.
3. Correct the default model and company names to `Deepseek` and remove the extra final period.

**DeepSeek-R1 and DeepSeek-R1-Distill Series**

**Affected Model Names**

- DeepSeek-R1-1.5B-Distill
- DeepSeek-R1-7B-Distill
- DeepSeek-R1-8B-Distill
- DeepSeek-R1-14B-Distill
- DeepSeek-R1-32B-Distill
- DeepSeek-R1-70B-Distill
- DeepSeek-R1-671B-Chat-Zero
- DeepSeek-R1-671B-Chat
- DeepSeek-R1-0528-8B-Distill
- DeepSeek-R1-0528-671B-Chat

**Background**

Original R1 and R1-Distill tokenizers prefill the opening thinking marker in the generation prompt and preserve the exact whitespace after removed historical reasoning. R1-0528 tokenizers do not prefill that marker, so it must remain in the response target.

**Root Cause**

In `src/llamafactory/data/template.py`, all R1 variants shared `deepseekr1` with the generic `ReasoningTemplate`. It could not move a tokenizer-prefilled marker across the prompt/response boundary, preserve R1-specific whitespace, or distinguish R1-0528.

**Solution**

1. Override the shared base hook `_process_thought_boundaries()` in `DeepSeekR1Template`.
2. Before tokenization, move the opening thinking marker from each affected assistant formatter slot to the preceding prompt slot when thinking is enabled, then return the handled response indices so `ReasoningTemplate` does not add another thinking boundary. This does not decode or re-encode token IDs.
3. Add `DeepSeekR1ReasoningMixin.remove_thought()` to preserve all text and whitespace after the closing marker.
4. Use `DeepSeekR1Template` for prefilled R1 variants and add `DeepSeekR10528Template` plus `deepseekr1_0528` for non-prefilled R1-0528.
5. In `src/llamafactory/extras/constants.py`, move the two R1-0528 mappings to `deepseekr1_0528`.

**DeepSeek-LLM-\*B-Chat and DeepSeek-Math Series**

**Affected Model Names**

- DeepSeek-LLM-7B-Chat
- DeepSeek-LLM-67B-Chat
- DeepSeek-Math-7B-Instruct
- DeepSeek-MoE-16B-Chat
- DeepSeek-V2-16B-Chat
- DeepSeek-V2-236B-Chat
- DeepSeek-Coder-V2-16B-Instruct
- DeepSeek-Coder-V2-236B-Instruct

**Background**

The final generation boundary already ends at bare `Assistant:`. Completed assistant turns in multi-turn history, however, require a leading space before their content.

**Root Cause**

The shared `deepseek` registration in `src/llamafactory/data/template.py` relied on the default assistant formatter, which joined completed content directly to `Assistant:`.

**Solution**

1. In `src/llamafactory/data/template.py`, set `deepseek.format_assistant` to `StringFormatter(slots=[" {{content}}", {"eos_token"}])`.
2. Keep the final generation boundary in `format_user`, so unfinished assistant turns do not gain a trailing space.
3. Keep the existing model mappings because the correction belongs to their shared template.

## Unit Tests

`tests/data/test_template.py` adds `test_deepseek_template_consistency()`. It checks the affected template mappings and compares prompt token IDs for DeepSeek-Coder, the shared DeepSeek dialogue format, original R1 prefill, and both R1-0528 tokenizer variants.

```bash
pytest -q tests/data/test_template.py::test_deepseek_template_consistency
```


## About Test Samples

Models are classified as reasoning-only, non-reasoning-only, or dual-mode. Reasoning-only models use the reasoning sample, non-reasoning-only models use the non-reasoning sample, and dual-mode models use both. Each sample covers a single turn without a system prompt, a single turn with a system prompt, multi-turn dialogue with a system prompt, and multi-turn tool use with a system prompt. 

Specific test examples will be elaborated in the consistency-checking mechanism PR.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
