### PR TITLE
fix: align Hunyuan chat templates with Transformers

### DIFF
--- a/src/llamafactory/data/formatter.py
+++ b/src/llamafactory/data/formatter.py
@@ -141,25 +141,6 @@ class FunctionFormatter(StringFormatter):
 
 
 @dataclass
-class HunyuanFunctionFormatter(FunctionFormatter):
-    r"""Join Hunyuan reasoning directly to the following tool-call block."""
-
-    @override
-    def apply(self, **kwargs) -> SLOTS:
-        content = kwargs.get("content", "")
-        thought_words = kwargs.get("thought_words")
-        slots = super().apply(**kwargs)
-        if thought_words and len(thought_words) == 2 and thought_words[1] in content:
-            thought_end = thought_words[1]
-            return [
-                slot.replace(thought_end, thought_end.rstrip("\n"), 1) if isinstance(slot, str) else slot
-                for slot in slots
-            ]
-
-        return slots
-
-
-@dataclass
 class ToolFormatter(Formatter):
     def __post_init__(self):
         self.tool_utils = get_tool_utils(self.tool_format)

--- a/src/llamafactory/data/formatter.py
+++ b/src/llamafactory/data/formatter.py
@@ -141,6 +141,25 @@ class FunctionFormatter(StringFormatter):
 
 
 @dataclass
+class HunyuanFunctionFormatter(FunctionFormatter):
+    r"""Join Hunyuan reasoning directly to the following tool-call block."""
+
+    @override
+    def apply(self, **kwargs) -> SLOTS:
+        content = kwargs.get("content", "")
+        thought_words = kwargs.get("thought_words")
+        slots = super().apply(**kwargs)
+        if thought_words and len(thought_words) == 2 and thought_words[1] in content:
+            thought_end = thought_words[1]
+            return [
+                slot.replace(thought_end, thought_end.rstrip("\n"), 1) if isinstance(slot, str) else slot
+                for slot in slots
+            ]
+
+        return slots
+
+
+@dataclass
 class ToolFormatter(Formatter):
     def __post_init__(self):
         self.tool_utils = get_tool_utils(self.tool_format)

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -21,7 +21,7 @@ from typing_extensions import override
 
 from ..extras import logging
 from .data_utils import Role
-from .formatter import EmptyFormatter, FunctionFormatter, StringFormatter, ToolFormatter
+from .formatter import EmptyFormatter, FunctionFormatter, HunyuanFunctionFormatter, StringFormatter, ToolFormatter
 from .mm_plugin import get_mm_plugin
 
 
@@ -129,6 +129,10 @@ class Template:
 
         return token_ids
 
+    def _format_message_prefix(self, message: dict[str, str], index: int) -> "SLOTS":
+        r"""Return model-specific elements inserted before an individual message."""
+        return []
+
     def _encode(
         self,
         tokenizer: "PreTrainedTokenizer",
@@ -180,6 +184,8 @@ class Template:
                         system_and_tools = self.format_system.apply(content=(system + tool_text))
 
                     elements += system_and_tools
+
+            elements += self._format_message_prefix(message, i)
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
@@ -529,6 +535,46 @@ class ReasoningTemplate(Template):
                     encoded_messages[i + 1] = self.get_thought_word_ids(tokenizer) + encoded_messages[i + 1]
 
         return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(0, len(encoded_messages), 2)]
+
+
+@dataclass
+class HunyuanReasoningTemplate(ReasoningTemplate):
+    r"""Format Hunyuan system and tool instructions with the official separator."""
+
+    @override
+    def add_thought(self, content: str = "") -> str:
+        return f"{self.thought_words[0]}\n{content}\n{self.thought_words[1]}\n"
+
+    @override
+    def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
+        for message in messages[:-1]:
+            if message["role"] == Role.ASSISTANT and "<answer>" in message["content"]:
+                answer = message["content"].split("<answer>", maxsplit=1)[-1]
+                message["content"] = answer.split("</answer>", maxsplit=1)[0].strip()
+
+        return True
+
+    @override
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> "SLOTS":
+        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+        if system and tool_text:
+            content = system + "\n\n" + tool_text
+        else:
+            content = system or tool_text
+
+        return self.format_system.apply(content=content)
+
+
+@dataclass
+class HunyuanMT7BTemplate(Template):
+    r"""Start every Hunyuan MT user turn with the tokenizer BOS token."""
+
+    @override
+    def _format_message_prefix(self, message: dict[str, str], index: int) -> "SLOTS":
+        if index > 0 and message["role"] == Role.USER:
+            return [{"bos_token"}]
+
+        return []
 
 
 @dataclass
@@ -904,6 +950,30 @@ register_template(
     replace_eos=True,
     thought_words=("<think>", "</think>"),
     template_class=ReasoningTemplate,
+)
+
+
+register_template(
+    name="hunyuan_instruct",
+    format_user=StringFormatter(slots=["<｜hy_User｜>{{content}}<｜hy_Assistant｜>"]),
+    format_assistant=StringFormatter(slots=["{{content}}<｜hy_place▁holder▁no▁2｜>"]),
+    format_system=StringFormatter(slots=["{{content}}<｜hy_place▁holder▁no▁3｜>"]),
+    format_function=HunyuanFunctionFormatter(
+        slots=["{{content}}<｜hy_place▁holder▁no▁2｜>"],
+        tool_format="hunyuan",
+    ),
+    format_observation=StringFormatter(
+        slots=[
+            "<｜hy_User｜><tool_responses><tool_response>{{content}}</tool_response></tool_responses>"
+            "<｜hy_Assistant｜>"
+        ]
+    ),
+    format_tools=ToolFormatter(tool_format="hunyuan"),
+    format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
+    stop_words=["<｜hy_place▁holder▁no▁2｜>"],
+    replace_eos=True,
+    thought_words=("<think>", "</think>"),
+    template_class=HunyuanReasoningTemplate,
 )
 
 
@@ -1335,8 +1405,16 @@ register_template(
 )
 
 
-# The following two templates are copied from the official Hy-MT2 chat templates:
-# https://github.com/Tencent-Hunyuan/Hy-MT2/blob/main/train/llama_factory_support/hy_dense_template.py
+register_template(
+    name="hy_mt_1_8b",
+    format_user=StringFormatter(slots=["<｜hy_User｜>{{content}}<｜hy_Assistant｜>"]),
+    format_assistant=StringFormatter(slots=["{{content}}<｜hy_place▁holder▁no▁2｜>"]),
+    format_system=StringFormatter(slots=["{{content}}<｜hy_place▁holder▁no▁3｜>"]),
+    format_prefix=EmptyFormatter(slots=["<｜hy_begin▁of▁sentence｜>"]),
+    stop_words=["<｜hy_place▁holder▁no▁2｜>"],
+)
+
+
 register_template(
     name="hy_dense_1_8b",
     format_user=StringFormatter(slots=["<｜hy_User｜>{{content}}"]),
@@ -1356,6 +1434,18 @@ register_template(
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
     stop_words=["<|eos|>"],
     efficient_eos=True,
+)
+
+
+# These slots preserve the tokenizer-defined prompt/response boundary for current Hunyuan 7B tokenizers.
+register_template(
+    name="hy_mt_7b",
+    format_user=StringFormatter(slots=["{{content}}<|extra_0|>"]),
+    format_assistant=StringFormatter(slots=["{{content}}<|eos|>"]),
+    format_system=StringFormatter(slots=["{{content}}<|extra_4|>"]),
+    format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
+    stop_words=["<|eos|>"],
+    template_class=HunyuanMT7BTemplate,
 )
 
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -65,7 +65,7 @@ class Template:
         tools: Optional[str] = None,
     ) -> tuple[list[int], list[int]]:
         r"""Return a single pair of token ids representing prompt and response respectively."""
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, _ = self._encode(tokenizer, messages, system, tools)
         prompt_ids = []
         for encoded_ids in encoded_messages[:-1]:
             prompt_ids += encoded_ids
@@ -82,7 +82,7 @@ class Template:
         discarding_history_cot: bool = False,  # only effect reasoning template
     ) -> list[tuple[list[int], list[int]]]:
         r"""Return multiple pairs of token ids representing prompts and responses respectively."""
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, _ = self._encode(tokenizer, messages, system, tools)
         return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(0, len(encoded_messages), 2)]
 
     def extract_tool(self, content: str) -> Union[str, list["FunctionCall"]]:
@@ -135,7 +135,7 @@ class Template:
         messages: list[dict[str, str]],
         system: Optional[str],
         tools: Optional[str],
-    ) -> list[list[int]]:
+    ) -> tuple[list[list[int]], set[int]]:
         r"""Encode formatted inputs to pairs of token ids.
 
         Turn 0: prefix + system + query        resp
@@ -147,15 +147,17 @@ class Template:
 
         rendered_messages = self._render(messages, system, tools)
         self._process_rendered_messages(rendered_messages, messages)
-        return [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+        processed_response_indices = self._process_thought_boundaries(rendered_messages, messages)
+        encoded_messages = [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+        return encoded_messages, processed_response_indices
 
     def _process_messages(self, messages: list[dict[str, str]]) -> Optional[list[dict[str, str]]]:
         r"""Return model-specific messages before rendering, or use the original messages."""
-        pass
+        return None
 
     def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
         r"""Return model-specific system and tool elements, or use the default formatter."""
-        pass
+        return None
 
     def _render(
         self,
@@ -200,7 +202,13 @@ class Template:
         self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
     ) -> None:
         r"""Apply model-specific changes to formatter output before tokenization."""
-        pass
+        return None
+
+    def _process_thought_boundaries(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> set[int]:
+        r"""Process model-specific thought boundaries and return the handled response indices."""
+        return set()
 
     @staticmethod
     def _add_or_replace_eos_token(tokenizer: "PreTrainedTokenizer", eos_token: str) -> None:
@@ -452,7 +460,7 @@ class ReasoningTemplate(Template):
 
     def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
         r"""Process model-specific historical reasoning and return whether it was handled."""
-        pass
+        return False
 
     @override
     def encode_oneturn(
@@ -470,8 +478,14 @@ class ReasoningTemplate(Template):
         if self.enable_thinking is False:  # remove all cot
             messages[-1]["content"] = self.remove_thought(messages[-1]["content"])
 
-        prompt_ids, response_ids = super().encode_oneturn(tokenizer, messages, system, tools)
-        if (
+        encoded_messages, processed_response_indices = self._encode(tokenizer, messages, system, tools)
+        prompt_ids = []
+        for encoded_ids in encoded_messages[:-1]:
+            prompt_ids += encoded_ids
+
+        response_index = len(encoded_messages) - 1
+        response_ids = encoded_messages[response_index]
+        if response_index not in processed_response_indices and (
             self.thought_words[0].strip() not in messages[-1]["content"]
             and self.thought_words[1].strip() not in messages[-1]["content"]
         ):  # add empty cot
@@ -500,14 +514,14 @@ class ReasoningTemplate(Template):
             for i in range(1, len(messages) - 2, 2):  # preserve the last cot
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, processed_response_indices = self._encode(tokenizer, messages, system, tools)
         if discarding_history_cot:
             turn_indices = [len(messages) - 2]
         else:
             turn_indices = range(0, len(messages), 2)
 
         for i in turn_indices:
-            if (
+            if i + 1 not in processed_response_indices and (
                 self.thought_words[0].strip() not in messages[i + 1]["content"]
                 and self.thought_words[1].strip() not in messages[i + 1]["content"]
             ):  # add empty cot

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -21,7 +21,7 @@ from typing_extensions import override
 
 from ..extras import logging
 from .data_utils import Role
-from .formatter import EmptyFormatter, FunctionFormatter, HunyuanFunctionFormatter, StringFormatter, ToolFormatter
+from .formatter import EmptyFormatter, FunctionFormatter, StringFormatter, ToolFormatter
 from .mm_plugin import get_mm_plugin
 
 
@@ -129,10 +129,6 @@ class Template:
 
         return token_ids
 
-    def _format_message_prefix(self, message: dict[str, str], index: int) -> "SLOTS":
-        r"""Return model-specific elements inserted before an individual message."""
-        return []
-
     def _encode(
         self,
         tokenizer: "PreTrainedTokenizer",
@@ -184,8 +180,6 @@ class Template:
                         system_and_tools = self.format_system.apply(content=(system + tool_text))
 
                     elements += system_and_tools
-
-            elements += self._format_message_prefix(message, i)
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
@@ -570,11 +564,10 @@ class HunyuanMT7BTemplate(Template):
     r"""Start every Hunyuan MT user turn with the tokenizer BOS token."""
 
     @override
-    def _format_message_prefix(self, message: dict[str, str], index: int) -> "SLOTS":
-        if index > 0 and message["role"] == Role.USER:
-            return [{"bos_token"}]
-
-        return []
+    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
+        for index, message in enumerate(messages):
+            if index > 0 and message["role"] == Role.USER:
+                rendered_messages[index].insert(0, {"bos_token"})
 
 
 @dataclass
@@ -958,7 +951,7 @@ register_template(
     format_user=StringFormatter(slots=["<｜hy_User｜>{{content}}<｜hy_Assistant｜>"]),
     format_assistant=StringFormatter(slots=["{{content}}<｜hy_place▁holder▁no▁2｜>"]),
     format_system=StringFormatter(slots=["{{content}}<｜hy_place▁holder▁no▁3｜>"]),
-    format_function=HunyuanFunctionFormatter(
+    format_function=FunctionFormatter(
         slots=["{{content}}<｜hy_place▁holder▁no▁2｜>"],
         tool_format="hunyuan",
     ),

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -542,9 +542,14 @@ class HunyuanReasoningTemplate(ReasoningTemplate):
     @override
     def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
         for message in messages[:-1]:
-            if message["role"] == Role.ASSISTANT and "<answer>" in message["content"]:
+            if message["role"] != Role.ASSISTANT:
+                continue
+
+            if "<answer>" in message["content"]:
                 answer = message["content"].split("<answer>", maxsplit=1)[-1]
                 message["content"] = answer.split("</answer>", maxsplit=1)[0].strip()
+            else:
+                message["content"] = self.remove_thought(message["content"])
 
         return True
 
@@ -1408,6 +1413,8 @@ register_template(
 )
 
 
+# The following two templates are copied from the official Hy-MT2 chat templates:
+# https://github.com/Tencent-Hunyuan/Hy-MT2/blob/main/train/llama_factory_support/hy_dense_template.py
 register_template(
     name="hy_dense_1_8b",
     format_user=StringFormatter(slots=["<｜hy_User｜>{{content}}"]),

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -141,16 +141,43 @@ class Template:
         Turn 0: prefix + system + query        resp
         Turn t: query                          resp.
         """
+        processed_messages = self._process_messages(messages)
+        if processed_messages is not None:
+            messages = processed_messages
+
+        rendered_messages = self._render(messages, system, tools)
+        self._process_rendered_messages(rendered_messages, messages)
+        return [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+
+    def _process_messages(self, messages: list[dict[str, str]]) -> Optional[list[dict[str, str]]]:
+        r"""Return model-specific messages before rendering, or use the original messages."""
+        pass
+
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
+        r"""Return model-specific system and tool elements, or use the default formatter."""
+        pass
+
+    def _render(
+        self,
+        messages: list[dict[str, str]],
+        system: Optional[str],
+        tools: Optional[str],
+    ) -> list["SLOTS"]:
+        r"""Render messages into formatter elements before tokenization."""
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
             if i == 0:
                 elements += self.format_prefix.apply()
                 if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    elements += self.format_system.apply(content=(system + tool_text))
+                    system_and_tools = self._format_system_and_tools(system, tools)
+                    if system_and_tools is None:
+                        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+                        system_and_tools = self.format_system.apply(content=(system + tool_text))
+
+                    elements += system_and_tools
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
@@ -165,9 +192,15 @@ class Template:
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
+
+    def _process_rendered_messages(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> None:
+        r"""Apply model-specific changes to formatter output before tokenization."""
+        pass
 
     @staticmethod
     def _add_or_replace_eos_token(tokenizer: "PreTrainedTokenizer", eos_token: str) -> None:
@@ -336,45 +369,12 @@ class Template:
 @dataclass
 class MossVLTemplate(Template):
     @override
-    def _encode(
-        self,
-        tokenizer: "PreTrainedTokenizer",
-        messages: list[dict[str, str]],
-        system: Optional[str],
-        tools: Optional[str],
-    ) -> list[list[int]]:
-        system = system or self.default_system
-        encoded_messages = []
-        for i, message in enumerate(messages):
-            elements = []
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> "SLOTS":
+        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+        if tools and not system:
+            tool_text = tool_text.lstrip("\n")
 
-            if i == 0:
-                elements += self.format_prefix.apply()
-                if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    if tools and not system:
-                        tool_text = tool_text.lstrip("\n")
-
-                    elements += self.format_system.apply(content=(system + tool_text))
-
-            if message["role"] == Role.USER:
-                elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
-            elif message["role"] == Role.ASSISTANT:
-                elements += self.format_assistant.apply(content=message["content"])
-            elif message["role"] == Role.OBSERVATION:
-                elements += self.format_observation.apply(content=message["content"])
-            elif message["role"] == Role.FUNCTION:
-                elements += self.format_function.apply(
-                    content=message["content"],
-                    thought_words=self.thought_words,
-                    tool_call_words=self.tool_call_words,
-                )
-            else:
-                raise NotImplementedError("Unexpected role: {}".format(message["role"]))
-
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
-
-        return encoded_messages
+        return self.format_system.apply(content=(system + tool_text))
 
 
 @dataclass
@@ -382,15 +382,14 @@ class Llama2Template(Template):
     r"""A template that fuse the system message to first user message."""
 
     @override
-    def _encode(
+    def _render(
         self,
-        tokenizer: "PreTrainedTokenizer",
         messages: list[dict[str, str]],
         system: str,
         tools: str,
-    ) -> list[list[int]]:
+    ) -> list["SLOTS"]:
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
@@ -412,9 +411,9 @@ class Llama2Template(Template):
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
 
     def _get_jinja_template(self, tokenizer: "PreTrainedTokenizer") -> str:
         prefix = self._convert_slots_to_jinja(self.format_prefix.apply(), tokenizer)
@@ -451,6 +450,10 @@ class Llama2Template(Template):
 class ReasoningTemplate(Template):
     r"""A template that add thought to assistant message."""
 
+    def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
+        r"""Process model-specific historical reasoning and return whether it was handled."""
+        pass
+
     @override
     def encode_oneturn(
         self,
@@ -460,7 +463,7 @@ class ReasoningTemplate(Template):
         tools: Optional[str] = None,
     ) -> tuple[list[int], list[int]]:
         messages = deepcopy(messages)
-        if not self.preserve_thinking:
+        if not self.preserve_thinking and not self._process_history_thoughts(messages, is_inference=True):
             for i in range(1, len(messages) - 2, 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
@@ -493,7 +496,7 @@ class ReasoningTemplate(Template):
             for i in range(1, len(messages), 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
-        if discarding_history_cot:
+        if discarding_history_cot and not self._process_history_thoughts(messages, is_inference=False):
             for i in range(1, len(messages) - 2, 2):  # preserve the last cot
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -198,9 +198,7 @@ class Template:
 
         return rendered_messages
 
-    def _process_rendered_messages(
-        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
-    ) -> None:
+    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
         r"""Apply model-specific changes to formatter output before tokenization."""
         return None
 

--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -55,6 +55,15 @@ GLM4_MOE_TOOL_PROMPT = (
     "\n...\n</tool_call>\n"
 )
 
+HUNYUAN_TOOL_PROMPT = (
+    "# Tools\n\nYou may call one or more functions to assist with the user query.\n\n"
+    "You are provided with function signatures within <tools></tools> XML tags:\n<tools>\n{tool_text}"
+    "\n</tools>\n\nFor function call returns, you should first print <tool_calls>"
+    "For each function call, you should return object like:\n<tool_call>function_name"
+    "\n```json\nfunction_arguments_in_json_format\n```</tool_call>"
+    "At the end of function call returns, you should print </tool_calls>"
+)
+
 LLAMA3_TOOL_PROMPT = (
     "Cutting Knowledge Date: December 2023\nToday Date: {date}\n\n"
     "You have access to the following functions. To call a function, please respond with JSON for a function call. "
@@ -630,6 +639,49 @@ class QwenToolUtils(ToolUtils):
         return results
 
 
+class HunyuanToolUtils(ToolUtils):
+    r"""Hunyuan tool format used by its official chat template."""
+
+    @override
+    @staticmethod
+    def tool_formatter(tools: list[dict[str, Any]]) -> str:
+        tool_texts = []
+        for tool in tools:
+            wrapped_tool = tool if tool.get("type") == "function" else {"type": "function", "function": tool}
+            tool_texts.append(json.dumps(wrapped_tool, ensure_ascii=False))
+
+        return HUNYUAN_TOOL_PROMPT.format(tool_text="\n".join(tool_texts))
+
+    @override
+    @staticmethod
+    def function_formatter(functions: list["FunctionCall"]) -> str:
+        function_texts = []
+        for name, arguments in functions:
+            arguments = json.dumps(json.loads(arguments), ensure_ascii=False)
+            function_texts.append(f"<tool_call>{name}\n```json\n{arguments}\n```</tool_call>")
+
+        return "<tool_calls>" + "\n".join(function_texts) + "</tool_calls>"
+
+    @override
+    @staticmethod
+    def tool_extractor(content: str) -> Union[str, list["FunctionCall"]]:
+        wrapper = re.search(r"<tool_calls>(.*?)</tool_calls>", content, re.DOTALL)
+        if wrapper is None:
+            return content
+
+        pattern = re.compile(r"<tool_call>(.*?)\n```json\n(.*?)\n```</tool_call>", re.DOTALL)
+        results = []
+        for name, arguments in re.findall(pattern, wrapper.group(1)):
+            try:
+                parsed_arguments = json.loads(arguments)
+            except json.JSONDecodeError:
+                return content
+
+            results.append(FunctionCall(name.strip(), json.dumps(parsed_arguments, ensure_ascii=False)))
+
+        return results if results else content
+
+
 class Qwen35ToolUtils(ToolUtils):
     r"""Qwen 3.5 tool using template."""
 
@@ -885,6 +937,7 @@ TOOLS = {
     "default": DefaultToolUtils(),
     "gemma4": Gemma4ToolUtils(),
     "glm4": GLM4ToolUtils(),
+    "hunyuan": HunyuanToolUtils(),
     "llama3": Llama3ToolUtils(),
     "lfm2": LFM2ToolUtils(),
     "minimax1": MiniMaxM1ToolUtils(),

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -1244,10 +1244,24 @@ register_model_group(
             DownloadSource.DEFAULT: "tencent/Hunyuan-4B-Instruct",
             DownloadSource.MODELSCOPE: "Tencent-Hunyuan/Hunyuan-4B-Instruct",
         },
+    },
+    template="hunyuan_instruct",
+)
+
+
+register_model_group(
+    models={
         "Hunyuan-7B-Instruct": {
             DownloadSource.DEFAULT: "tencent/Hunyuan-7B-Instruct",
             DownloadSource.MODELSCOPE: "Tencent-Hunyuan/Hunyuan-7B-Instruct",
         },
+    },
+    template="hy_mt_7b",
+)
+
+
+register_model_group(
+    models={
         "Hunyuan-MT-7B-Instruct": {
             DownloadSource.DEFAULT: "tencent/Hunyuan-MT-7B",
             DownloadSource.MODELSCOPE: "Tencent-Hunyuan/Hunyuan-MT-7B",
@@ -1256,12 +1270,19 @@ register_model_group(
             DownloadSource.DEFAULT: "tencent/HY-MT1.5-7B",
             DownloadSource.MODELSCOPE: "Tencent-Hunyuan/HY-MT1.5-7B",
         },
+    },
+    template="hy_mt_7b",
+)
+
+
+register_model_group(
+    models={
         "Hunyuan-A13B-Instruct": {
             DownloadSource.DEFAULT: "tencent/Hunyuan-A13B-Instruct",
             DownloadSource.MODELSCOPE: "Tencent-Hunyuan/Hunyuan-A13B-Instruct",
         },
     },
-    template="hunyuan",
+    template="hy_mt_7b",
 )
 
 
@@ -1272,7 +1293,7 @@ register_model_group(
             DownloadSource.MODELSCOPE: "Tencent-Hunyuan/Hy-MT2-1.8B",
         },
     },
-    template="hy_dense_1_8b",
+    template="hy_mt_1_8b",
 )
 
 
@@ -1283,7 +1304,7 @@ register_model_group(
             DownloadSource.MODELSCOPE: "Tencent-Hunyuan/Hy-MT2-7B",
         },
     },
-    template="hy_dense_7b",
+    template="hy_mt_7b",
 )
 
 
@@ -1294,7 +1315,7 @@ register_model_group(
             DownloadSource.MODELSCOPE: "Tencent-Hunyuan/HY-MT1.5-1.8B",
         },
     },
-    template="hunyuan_small",
+    template="hy_mt_1_8b",
 )
 
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import pytest
@@ -95,6 +97,58 @@ def _check_template(
     assert content_str == prompt_str + answer_str
     assert content_ids == prompt_ids + answer_ids
     _check_tokenization(tokenizer, (prompt_ids, answer_ids), (prompt_str, answer_str))
+
+
+def test_rendering_refactor_preserves_existing_template_boundaries():
+    class ByteTokenizer:
+        bos_token_id = 1000
+        eos_token_id = 1001
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            return list(text.encode())
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    tokenizer = ByteTokenizer()
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+
+    standard = deepcopy(TEMPLATES["falcon_h1"])
+    prompt_ids, response_ids = standard.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<|im_start|>system\nsystem<|im_end|>\n"
+        "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    tools = json.dumps(
+        [
+            {
+                "name": "search",
+                "description": "Search documents.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            }
+        ]
+    )
+    moss_vl = deepcopy(TEMPLATES["moss_vl"])
+    prompt_ids, response_ids = moss_vl.encode_oneturn(tokenizer, messages, tools=tools)
+    tool_text = moss_vl.format_tools.apply(content=tools)[0].lstrip("\n")
+    assert prompt_ids == tokenizer.encode(
+        moss_vl.format_system.apply(content=tool_text)[0]
+        + "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    llama2 = deepcopy(TEMPLATES["gemma"])
+    prompt_ids, response_ids = llama2.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<start_of_turn>user\nsystem\n\nquestion<end_of_turn>\n<start_of_turn>model\n"
+    )
+    assert response_ids == tokenizer.encode("answer<end_of_turn>\n")
 
 
 def test_moss_vl_registration():

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -21,9 +21,11 @@ import pytest
 from transformers import AutoTokenizer
 
 from llamafactory.data import get_template_and_fix_tokenizer
+from llamafactory.data.processor.supervised import SupervisedDatasetProcessor
 from llamafactory.data.template import TEMPLATES, ReasoningTemplate, parse_template
 from llamafactory.extras.constants import (
     DEFAULT_TEMPLATE,
+    IGNORE_INDEX,
     MULTIMODAL_SUPPORTED_MODELS,
     SUPPORTED_MODELS,
     DownloadSource,
@@ -458,6 +460,221 @@ def test_qwen3_template(cot_messages: bool):
         messages = MESSAGES_WITH_THOUGHT
 
     _check_template("Qwen/Qwen3-8B", "qwen3", prompt_str, answer_str, messages=messages)
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_hunyuan_template_consistency():
+    expected_templates = {
+        "Hunyuan-0.5B-Instruct": "hunyuan_instruct",
+        "Hunyuan-1.8B-Instruct": "hunyuan_instruct",
+        "Hunyuan-4B-Instruct": "hunyuan_instruct",
+        "Hunyuan-7B-Instruct": "hy_mt_7b",
+        "Hunyuan-A13B-Instruct": "hy_mt_7b",
+        "Hunyuan-MT-7B-Instruct": "hy_mt_7b",
+        "HY-MT1.5-1.8B-Instruct": "hy_mt_1_8b",
+        "HY-MT1.5-7B-Instruct": "hy_mt_7b",
+        "Hy-MT2-1.8B-Instruct": "hy_mt_1_8b",
+        "Hy-MT2-7B-Instruct": "hy_mt_7b",
+    }
+    for model_name, template_name in expected_templates.items():
+        assert DEFAULT_TEMPLATE[model_name] == template_name
+
+    assert TEMPLATES["hy3"].format_assistant.slots == ["{{content}}<｜hy_eos｜>"]
+    assert TEMPLATES["hunyuan_small"].format_user.slots == ["<｜hy_User｜>{{content}}<｜hy_place▁holder▁no▁8｜>"]
+    assert TEMPLATES["hy_dense_1_8b"].efficient_eos
+    assert TEMPLATES["hy_dense_7b"].efficient_eos
+
+    hunyuan_template = TEMPLATES["hunyuan_instruct"]
+    assert hunyuan_template.thought_words == ("<think>", "</think>")
+    assert hunyuan_template.remove_thought("<think>foo</think>answer") == "answer"
+    extracted_calls = hunyuan_template.extract_tool(
+        '<tool_calls><tool_call>get_current_temperature\n```json\n{"city":"Paris"}\n```</tool_call></tool_calls>'
+    )
+    assert not isinstance(extracted_calls, str)
+    assert len(extracted_calls) == 1
+    assert extracted_calls[0].name == "get_current_temperature"
+    assert json.loads(extracted_calls[0].arguments) == {"city": "Paris"}
+
+    system = "You are a helpful weather assistant. Use the available tools when needed."
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_temperature",
+                "description": "Get the current temperature for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    function_call = '{"name":"get_current_temperature","arguments":{"city":"Paris"}}'
+    observation = '{"temperature_celsius":21}'
+    thought = "<think>\nI should use the weather tool.\n</think>"
+    history_messages = [
+        {"role": "user", "content": "A box has 12 red and 8 blue markers. How many markers are there?"},
+        {
+            "role": "assistant",
+            "content": "<think>\n12 + 8 = 20.\n</think>\n<answer>There are 20 markers.</answer>",
+        },
+        {"role": "user", "content": "If 5 markers are removed, how many remain?"},
+        {
+            "role": "assistant",
+            "content": "<think>\n20 - 5 = 15.\n</think>\n<answer>15 markers remain.</answer>",
+        },
+    ]
+    common_messages = [
+        {"role": "user", "content": "How many markers are in the box?"},
+        {"role": "assistant", "content": "There are 20 markers."},
+        {"role": "user", "content": "How many remain after removing 5 markers?"},
+        {"role": "assistant", "content": "15 markers remain."},
+    ]
+    common_official_messages = [{"role": "system", "content": system}, *common_messages[:-1]]
+    cases = [
+        {
+            "model_id": "tencent/Hunyuan-0.5B-Instruct",
+            "template": "hunyuan_instruct",
+            "enable_thinking": True,
+            "system": system,
+            "tools": tools,
+            "messages": [
+                {"role": "user", "content": "What is the current temperature in Paris?"},
+                {"role": "function", "content": thought + "\n\n" + function_call},
+                {"role": "observation", "content": observation},
+                {"role": "assistant", "content": thought + "\n\nIt is 21 degrees Celsius."},
+            ],
+            "official_messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": "What is the current temperature in Paris?"},
+                {
+                    "role": "assistant",
+                    "content": thought,
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "get_current_temperature",
+                                "arguments": '{"city": "Paris"}',
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "name": "get_current_temperature", "content": observation},
+            ],
+        },
+        {
+            "model_id": "tencent/Hunyuan-0.5B-Instruct",
+            "template": "hunyuan_instruct",
+            "enable_thinking": True,
+            "system": system,
+            "messages": history_messages,
+            "official_messages": [{"role": "system", "content": system}, *history_messages[:-1]],
+        },
+        {
+            "model_id": "tencent/HY-MT1.5-1.8B",
+            "template": "hy_mt_1_8b",
+            "enable_thinking": False,
+            "system": system,
+            "messages": common_messages,
+            "official_messages": common_official_messages,
+        },
+        {
+            "model_id": "tencent/Hunyuan-A13B-Instruct",
+            "template": "hy_mt_7b",
+            "enable_thinking": False,
+            "system": system,
+            "messages": common_messages,
+            "official_messages": common_official_messages,
+        },
+    ]
+    for case in cases:
+        tokenizer = AutoTokenizer.from_pretrained(case["model_id"])
+        reference_tokenizer = AutoTokenizer.from_pretrained(case["model_id"])
+        data_args = DataArguments(template=case["template"], enable_thinking=case["enable_thinking"])
+        template = get_template_and_fix_tokenizer(
+            tokenizer,
+            data_args,
+        )
+        prompt_ids, _ = template.encode_oneturn(
+            tokenizer,
+            case["messages"],
+            system=case["system"],
+            tools=json.dumps(case.get("tools"), ensure_ascii=False) if case.get("tools") else None,
+        )
+        reference_ids = reference_tokenizer.apply_chat_template(
+            case["official_messages"],
+            tools=case.get("tools"),
+            tokenize=True,
+            add_generation_prompt=True,
+            enable_thinking=case["enable_thinking"],
+        )
+        if is_transformers_version_greater_than("5.0.0"):
+            reference_ids = reference_ids["input_ids"]
+
+        assert prompt_ids == reference_ids, case["model_id"]
+
+        if case["template"].startswith("hy_mt_"):
+            encoded_pairs = template.encode_multiturn(tokenizer, case["messages"], system=case["system"])
+            processor = SupervisedDatasetProcessor(template, tokenizer, None, data_args)
+            input_ids, labels = processor._encode_data_example(
+                prompt=case["messages"][:-1],
+                response=case["messages"][-1:],
+                system=case["system"],
+                tools=None,
+                images=[],
+                videos=[],
+                audios=[],
+            )
+            assert input_ids == [token_id for pair in encoded_pairs for token_ids in pair for token_id in token_ids]
+
+            offset = 0
+            for turn_index, (source_ids, target_ids) in enumerate(encoded_pairs):
+                assert labels[offset : offset + len(source_ids)] == [IGNORE_INDEX] * len(source_ids)
+                offset += len(source_ids)
+                assert labels[offset : offset + len(target_ids)] == target_ids
+                assert target_ids[-1] == tokenizer.eos_token_id
+                offset += len(target_ids)
+                if case["template"] == "hy_mt_7b" and turn_index > 0:
+                    assert source_ids[0] == tokenizer.bos_token_id
+
+            train_on_prompt_args = DataArguments(
+                template=case["template"], enable_thinking=case["enable_thinking"], train_on_prompt=True
+            )
+            train_on_prompt_template = get_template_and_fix_tokenizer(tokenizer, train_on_prompt_args)
+            train_on_prompt_processor = SupervisedDatasetProcessor(
+                train_on_prompt_template, tokenizer, None, train_on_prompt_args
+            )
+            train_on_prompt_ids, train_on_prompt_labels = train_on_prompt_processor._encode_data_example(
+                prompt=case["messages"][:-1],
+                response=case["messages"][-1:],
+                system=case["system"],
+                tools=None,
+                images=[],
+                videos=[],
+                audios=[],
+            )
+            assert train_on_prompt_labels == train_on_prompt_ids
+
+    history_prompts = {}
+    for preserve_thinking in (False, True):
+        tokenizer = AutoTokenizer.from_pretrained("tencent/Hunyuan-0.5B-Instruct")
+        template = get_template_and_fix_tokenizer(
+            tokenizer,
+            DataArguments(
+                template="hunyuan_instruct",
+                enable_thinking=True,
+                preserve_thinking=preserve_thinking,
+            ),
+        )
+        prompt_ids, _ = template.encode_oneturn(tokenizer, history_messages, system=system)
+        history_prompts[preserve_thinking] = tokenizer.decode(prompt_ids, skip_special_tokens=False)
+
+    assert "12 + 8 = 20." not in history_prompts[False]
+    assert "<answer>" not in history_prompts[False]
+    assert "12 + 8 = 20." in history_prompts[True]
+    assert "<answer>There are 20 markers.</answer>" in history_prompts[True]
 
 
 @pytest.mark.runs_on(["cpu", "mps"])

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -462,6 +462,43 @@ def test_qwen3_template(cot_messages: bool):
     _check_template("Qwen/Qwen3-8B", "qwen3", prompt_str, answer_str, messages=messages)
 
 
+def test_hunyuan_hooks_preserve_active_tools_and_add_mt_turn_bos():
+    template = deepcopy(TEMPLATES["hunyuan_instruct"])
+    messages = [
+        {"role": "user", "content": "literal </think> user text"},
+        {
+            "role": "assistant",
+            "content": "<think>old reasoning</think><answer>old answer</answer>",
+        },
+        {"role": "user", "content": "new question"},
+        {"role": "function", "content": '<think>active reasoning</think>{"name":"search","arguments":{}}'},
+        {"role": "observation", "content": "literal </think> tool result"},
+        {"role": "assistant", "content": "final answer"},
+    ]
+
+    assert template._process_history_thoughts(messages, is_inference=True)
+    assert messages[0]["content"] == "literal </think> user text"
+    assert messages[1]["content"] == "old answer"
+    assert messages[3]["content"].startswith("<think>active reasoning</think>")
+    assert messages[4]["content"] == "literal </think> tool result"
+
+    mt_template = TEMPLATES["hy_mt_7b"]
+    mt_messages = [
+        {"role": "user", "content": "question 1"},
+        {"role": "assistant", "content": "answer 1"},
+        {"role": "user", "content": "question 2"},
+        {"role": "assistant", "content": "answer 2"},
+    ]
+    rendered_messages = [["user 1"], ["assistant 1"], ["user 2"], ["assistant 2"]]
+    mt_template._process_rendered_messages(rendered_messages, mt_messages)
+    assert rendered_messages == [
+        ["user 1"],
+        ["assistant 1"],
+        [{"bos_token"}, "user 2"],
+        ["assistant 2"],
+    ]
+
+
 @pytest.mark.runs_on(["cpu", "mps"])
 def test_hunyuan_template_consistency():
     expected_templates = {

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -120,8 +120,7 @@ def test_rendering_refactor_preserves_existing_template_boundaries():
     standard = deepcopy(TEMPLATES["falcon_h1"])
     prompt_ids, response_ids = standard.encode_oneturn(tokenizer, messages, system="system")
     assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
-        "<|im_start|>system\nsystem<|im_end|>\n"
-        "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+        "<|im_start|>system\nsystem<|im_end|>\n<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
     )
     assert response_ids == tokenizer.encode("answer<|im_end|>\n")
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -470,6 +470,8 @@ def test_hunyuan_hooks_preserve_active_tools_and_add_mt_turn_bos():
             "role": "assistant",
             "content": "<think>old reasoning</think><answer>old answer</answer>",
         },
+        {"role": "user", "content": "legacy question"},
+        {"role": "assistant", "content": "<think>legacy reasoning</think>legacy answer"},
         {"role": "user", "content": "new question"},
         {"role": "function", "content": '<think>active reasoning</think>{"name":"search","arguments":{}}'},
         {"role": "observation", "content": "literal </think> tool result"},
@@ -479,8 +481,9 @@ def test_hunyuan_hooks_preserve_active_tools_and_add_mt_turn_bos():
     assert template._process_history_thoughts(messages, is_inference=True)
     assert messages[0]["content"] == "literal </think> user text"
     assert messages[1]["content"] == "old answer"
-    assert messages[3]["content"].startswith("<think>active reasoning</think>")
-    assert messages[4]["content"] == "literal </think> tool result"
+    assert messages[3]["content"] == "legacy answer"
+    assert messages[5]["content"].startswith("<think>active reasoning</think>")
+    assert messages[6]["content"] == "literal </think> tool result"
 
     mt_template = TEMPLATES["hy_mt_7b"]
     mt_messages = [

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -21,7 +21,7 @@ import pytest
 from transformers import AutoTokenizer
 
 from llamafactory.data import get_template_and_fix_tokenizer
-from llamafactory.data.template import TEMPLATES, parse_template
+from llamafactory.data.template import TEMPLATES, ReasoningTemplate, parse_template
 from llamafactory.extras.constants import (
     DEFAULT_TEMPLATE,
     MULTIMODAL_SUPPORTED_MODELS,
@@ -149,6 +149,42 @@ def test_rendering_refactor_preserves_existing_template_boundaries():
         "<start_of_turn>user\nsystem\n\nquestion<end_of_turn>\n<start_of_turn>model\n"
     )
     assert response_ids == tokenizer.encode("answer<end_of_turn>\n")
+
+
+def test_thought_boundary_hook_reports_handled_responses():
+    class ByteTokenizer:
+        bos_token_id = 1000
+        eos_token_id = 1001
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            return list(text.encode())
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    class HookedReasoningTemplate(ReasoningTemplate):
+        def _process_thought_boundaries(self, rendered_messages, messages) -> set[int]:
+            response_index = len(rendered_messages) - 1
+            rendered_messages[response_index][0] = self.add_thought() + rendered_messages[response_index][0]
+            return {response_index}
+
+    template = HookedReasoningTemplate(**vars(deepcopy(TEMPLATES["qwen3"])))
+    template.enable_thinking = True
+    messages = [
+        {"role": "user", "content": "question 1"},
+        {"role": "assistant", "content": "answer 1"},
+        {"role": "user", "content": "question 2"},
+        {"role": "assistant", "content": "answer 2"},
+    ]
+
+    tokenizer = ByteTokenizer()
+    response_ids = template.encode_oneturn(tokenizer, messages)[1]
+    assert response_ids == list((template.add_thought() + "answer 2<|im_end|>\n").encode())
+
+    encoded_pairs = template.encode_multiturn(tokenizer, messages)
+    assert encoded_pairs[0][1] == list((template.add_thought() + "answer 1<|im_end|>\n").encode())
+    assert encoded_pairs[1][1] == list((template.add_thought() + "answer 2<|im_end|>\n").encode())
 
 
 def test_moss_vl_registration():


### PR DESCRIPTION
# What does this PR do?

Aligns the Hunyuan Instruct and machine-translation templates with their official Transformers chat templates. The changes correct model-to-template registrations, Hunyuan reasoning and tool-call formatting, assistant response boundaries, and the per-turn BOS/EOS behavior required by the 7B protocol.

### Affected Model Series and Templates

| Model series | Template |
| --- | --- |
| `Hunyuan-{0.5B,1.8B,4B}-Instruct` | `hunyuan_instruct` |
| `Hunyuan-{7B,A13B}-Instruct`; `Hunyuan-MT-7B-Instruct`; `HY-MT1.5-7B-Instruct`; `Hy-MT2-7B-Instruct` | `hy_mt_7b` |
| `HY-MT1.5-1.8B-Instruct`; `Hy-MT2-1.8B-Instruct` | `hy_mt_1_8b` |

This PR depends on #10784 for the shared pre-tokenization hooks. It adds only isolated Hunyuan-specific templates, mappings, hook overrides, tool utilities, and tests on top of that base; the existing `hy3`, `hunyuan_small`, `hy_dense_1_8b`, and `hy_dense_7b` templates remain unchanged.

I have added unit tests to this PR. All the models have been verified and modified through the unit tests and our consistency-checking mechanism script. There are no errors after the modification.



## Introduction

While reviewing issues recently, I found a large number of problems caused by inconsistencies between templates.

This made us realize that these inconsistencies are not isolated incidents, especially for less common models. When users use the official templates provided by these models, such inconsistencies can cause severe mismatches between training and inference, significantly affecting training speed and the inference accuracy of the trained models.

This work consists of two parts:

1. I will use a script to perform large-scale testing on all models using the examples described below. The test will compare the generated text/token sequences across LlamaFactory training, LlamaFactory inference, and vLLM inference using the standard Transformers `chat_template` interface. I will then fix the issues one by one. Since there are many models, the fixes will be submitted in multiple PRs organized by model family to make them easier to review.

2. I will add a consistency-checking mechanism that runs automatically before training. If inconsistencies are detected, it will issue a warning and save the corresponding test examples, but it will not block training. This mechanism will be submitted as a separate PR.

The most common problems can be roughly divided into the following categories:

1. The native LlamaFactory templates do not have sufficiently fine-grained coverage. For example, Qwen3 includes several model variants, such as the Qwen3-8B-Thinking series and the Qwen3-30B-A3B-Thinking-2507 series. Qwen2.5 also includes variants such as Coder and Math. These models have subtle differences: the Qwen3-8B-Thinking series supports both thinking and non-thinking modes, while Qwen3-30B-A3B-Thinking-2507 only supports thinking mode. The official templates for the Coder and Math series also use different system prompts. However, the native system does not distinguish between these variants and applies the same template to all of them.

2. The handling of thinking traces is inconsistent. LlamaFactory provides `mask_history` and `preserve_thinking` to control whether historical thinking traces are removed during training and inference, but it currently uses the generic `remove_thought()` function for all models. In practice, different models require different handling, for example:

   - DeepSeek-R1: remove historical thinking content while preserving the two newlines after the closing tag.
   - GLM-4.5: remove the thinking content while preserving an empty thinking block.
   - Qwen/QwQ: follow the tokenizer-specific rules for historical assistant/tool messages.
   - Hunyuan: preserve or generate the corresponding boundaries according to its tokenizer; a generic removal function cannot be used.

3. The handling of whether the `<think>` tag is generated by the model is inconsistent. In the DeepSeek-R1-*B-Distill series, the `<think>` tag is part of the model output during training and is included in loss computation. During inference, however, the template automatically adds the `<think>` tag as part of the prompt, so the model does not need to generate it.

4. There are also various minor bugs of this kind. I will analyze and fix these issues individually.

### Verified Correct Models

The following models completed template validation and already match their tokenizer chat templates. They do not require a template change in this series of PRs.

- GLM-4-0414-*B-Chat
- Kimi-Dev-*B-Instruct
- Llama-3.1-*B-Chinese-Chat
- Phi-4-*B-Instruct
- Qwen2.5-*B-Instruct (standard, AWQ, GPTQ-Int4, and GPTQ-Int8)
- Qwen2.5-Coder-*B-Instruct
- Qwen3-*-Instruct-2507
- Qwen3-*-Thinking* (excluding the 2507-only thinking series)
- Qwen3-Next-80B-A3B-Instruct
- Seed-Coder-*B-Instruct
- SmolLM-*-Instruct
- Yi-Coder-*B-Chat

### Submit PR List

| PR | Model family or scope | Status |
| --- | --- | --- |
| 1 | `DeepSeek-Coder-*B-Instruct`; `DeepSeek-R1*`; `DeepSeek-LLM-*B-Chat`; `DeepSeek-Math-*B-Instruct` | √ |
| 2 | `GLM-4-0414-*B-Chat`; `GLM-4.5-*Thinking`; `GLM-Z1-0414-*B-Chat` | √ |
| 3 (current PR) | `Hunyuan-*B-Instruct`; `Hunyuan-MT-*B-Instruct`; `HY-MT1.5-*B-Instruct`; `Hy-MT2-*B-Instruct` | √ |
| 4 | `Qwen2-*`; `Qwen2.5-*-Instruct-1M`; `Qwen2.5-Math-*-Instruct` | × |
| 5 | `Qwen3-*-Instruct-2507`; `Qwen3-*-Thinking*`; `Qwen3-Next-*-Instruct`; `Qwen3-Next-*-Thinking` | × |
| 6 | `QwQ-32B-Instruct`; `QwQ-32B-Preview-Instruct` | × |
| 7 | `Falcon-H1-*B-*Instruct` | × |
| 8 | `Granite-3.0-*B-A400M-Instruct` | × |
| 9 | `Llama-3-*B-Chinese-Chat` | × |
| 10 | `Yi-6B-Chat`; `Yi-34B-Chat` | × |
| 11 | Automatic pre-training consistency warning | × |

### Planned PR
The validation and correction work described above has already covered 80% of the models. Some model families, such as Qwen 3.5, Gemini, MiniCPM, and MiniMax, could not be completed immediately due to the workload and the need to merge other contributors’ PRs. They will be gradually addressed in follow-up work.


## Models Fixed Diff

### tencent/Hunyuan-*B-Instruct

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system` | <code>&lt;<mark>｜hy_begin▁</mark>of<mark>▁sen</mark>te<mark>nce｜&gt;&lt;｜hy_User｜</mark>&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;<mark>｜hy_Assis</mark>ta<mark>nt｜</mark>&gt;<mark>&lt;think&gt;<br><br>&lt;/think&gt;<br></mark></code> | <code>&lt;<mark>&#124;start</mark>ofte<mark>xt&#124;</mark>&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;<mark>&#124;ex</mark>t<mark>r</mark>a<mark>_0&#124;</mark>&gt;</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜hy_Assistant｜&gt;&lt;think&gt;<br><br>&lt;/think&gt;<br></code> |
| `single_turn_with_system` | <code>&lt;<mark>｜hy_begin▁</mark>of<mark>▁sen</mark>te<mark>nce｜</mark>&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;<mark>｜hy_plac</mark>e<mark>▁holde</mark>r<mark>▁no▁3｜&gt;&lt;｜hy</mark>_<mark>User｜</mark>&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;<mark>｜hy_Assis</mark>ta<mark>nt｜</mark>&gt;<mark>&lt;think&gt;<br><br>&lt;/think&gt;<br></mark></code> | <code>&lt;<mark>&#124;start</mark>ofte<mark>xt&#124;</mark>&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;<mark>&#124;</mark>e<mark>xt</mark>r<mark>a</mark>_<mark>4&#124;</mark>&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;<mark>&#124;ex</mark>t<mark>r</mark>a<mark>_0&#124;</mark>&gt;</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜hy_Assistant｜&gt;&lt;think&gt;<br><br>&lt;/think&gt;<br></code> |
| `multi_turn_with_system` | <code>&lt;<mark>｜hy_begin▁</mark>of<mark>▁sen</mark>te<mark>nce｜</mark>&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;<mark>｜hy_plac</mark>e<mark>▁holde</mark>r<mark>▁no▁3｜&gt;&lt;｜hy</mark>_<mark>User｜</mark>&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;<mark>｜hy_Assis</mark>ta<mark>nt｜</mark>&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;<mark>｜hy_plac</mark>e<mark>▁h</mark>o<mark>lder▁no▁2｜&gt;&lt;｜hy_U</mark>s<mark>er｜</mark>&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;<mark>｜hy_Assis</mark>ta<mark>nt｜</mark>&gt;<mark>&lt;think&gt;<br><br>&lt;/think&gt;<br></mark></code> | <code>&lt;<mark>&#124;start</mark>ofte<mark>xt&#124;</mark>&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;<mark>&#124;</mark>e<mark>xt</mark>r<mark>a</mark>_<mark>4&#124;</mark>&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;<mark>&#124;ex</mark>t<mark>r</mark>a<mark>_0&#124;</mark>&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;<mark>&#124;</mark>eos<mark>&#124;</mark>&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;<mark>&#124;ex</mark>t<mark>r</mark>a<mark>_0&#124;</mark>&gt;</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;｜hy_Assistant｜&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;｜hy_place▁holder▁no▁2｜&gt;&lt;｜hy_User｜&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;｜hy_Assistant｜&gt;&lt;think&gt;<br><br>&lt;/think&gt;<br></code> |
| `tool_call_multi_turn_with_system` | <code>&lt;<mark>｜hy_begin▁</mark>of<mark>▁sen</mark>te<mark>nce｜</mark>&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<mark><br><br>#&nbsp;Tools<br><br></mark>You&nbsp;<mark>m</mark>a<mark>y&nbsp;call&nbsp;on</mark>e&nbsp;<mark>or&nbsp;more&nbsp;fun</mark>c<mark>tion</mark>s&nbsp;to&nbsp;<mark>assist&nbsp;with&nbsp;</mark>the&nbsp;<mark>user&nbsp;query.<br><br>Y</mark>o<mark>u&nbsp;are&nbsp;pr</mark>o<mark>vided&nbsp;</mark>wi<mark>th&nbsp;fu</mark>n<mark>ction&nbsp;si</mark>g<mark>natures</mark>&nbsp;<mark>within&nbsp;&lt;</mark>tools&gt;<mark>&lt;/t</mark>ool<mark>s&gt;</mark>&nbsp;<mark>XML&nbsp;tags:<br>&lt;tools&gt;<br>{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;n</mark>ame<mark>&quot;</mark>:&nbsp;<mark>&quot;</mark>get_current_temperature<mark>&quot;,</mark>&nbsp;<mark>&quot;d</mark>escription<mark>&quot;</mark>:&nbsp;<mark>&quot;</mark>Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.<mark>&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;</mark>o<mark>bject&quot;,&nbsp;&quot;pr</mark>o<mark>perties&quot;:</mark>&nbsp;<mark>{&quot;</mark>city<mark>&quot;:</mark>&nbsp;<mark>{&quot;type&quot;:&nbsp;&quot;</mark>string<mark>&quot;}}</mark>,&nbsp;<mark>&quot;</mark>required<mark>&quot;</mark>:&nbsp;<mark>[&quot;city&quot;]}}}<br>&lt;/tools&gt;</mark><br><br><mark>For</mark>&nbsp;f<mark>unction&nbsp;call&nbsp;returns,&nbsp;you&nbsp;should&nbsp;first&nbsp;print&nbsp;&lt;to</mark>ol<mark>_ca</mark>l<mark>ls&gt;F</mark>o<mark>r&nbsp;each&nbsp;function&nbsp;call,&nbsp;you&nbsp;should&nbsp;return&nbsp;object&nbsp;like:<br>&lt;tool_call&gt;function_name<br>```json<br>function_arguments_</mark>in<mark>_json_</mark>format<mark><br>```&lt;/</mark>tool<mark>_call&gt;</mark>At&nbsp;t<mark>h</mark>e&nbsp;<mark>e</mark>n<mark>d</mark>&nbsp;of&nbsp;<mark>f</mark>unction&nbsp;<mark>call&nbsp;retur</mark>n<mark>s,&nbsp;you&nbsp;should&nbsp;</mark>p<mark>r</mark>int&nbsp;<mark>&lt;/</mark>tool<mark>_calls&gt;&lt;｜hy_place▁holder▁</mark>no<mark>▁3｜&gt;&lt;｜hy_U</mark>ser<mark>｜</mark>&gt;What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;<mark>｜hy_Assis</mark>ta<mark>nt｜&gt;&lt;tool</mark>_<mark>calls</mark>&gt;<mark>&lt;tool_</mark>c<mark>all&gt;</mark>get_current_temperature<br><mark>```js</mark>on<mark><br></mark>{&quot;city&quot;:&nbsp;&quot;Paris&quot;}<mark><br>```</mark>&lt;<mark>/tool_call&gt;&lt;/tool_calls&gt;&lt;｜hy_plac</mark>e<mark>▁h</mark>o<mark>lder▁no▁2｜&gt;&lt;｜hy_U</mark>s<mark>er｜&gt;&lt;tool_responses&gt;&lt;tool_response</mark>&gt;{&quot;temperature_celsius&quot;:21}&lt;<mark>/tool_r</mark>e<mark>sponse&gt;&lt;/</mark>t<mark>ool_</mark>r<mark>esponses&gt;&lt;｜hy_Assist</mark>a<mark>nt｜</mark>&gt;<mark>&lt;think&gt;<br><br>&lt;/think&gt;<br></mark></code> | <code>&lt;<mark>&#124;start</mark>ofte<mark>xt&#124;</mark>&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.You&nbsp;<mark>h</mark>a<mark>v</mark>e&nbsp;<mark>a</mark>c<mark>ces</mark>s&nbsp;to&nbsp;the&nbsp;<mark>f</mark>o<mark>ll</mark>owing&nbsp;tools<mark>:<br></mark>&gt;<mark>&nbsp;T</mark>ool&nbsp;<mark>N</mark>ame:&nbsp;get_current_temperature<mark><br>Tool</mark>&nbsp;<mark>D</mark>escription:&nbsp;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.<mark><br>T</mark>oo<mark>l</mark>&nbsp;<mark>Args:<br>&nbsp;&nbsp;-&nbsp;</mark>city&nbsp;<mark>(</mark>string,&nbsp;required<mark>)</mark>:&nbsp;<br><br><mark>Use&nbsp;the</mark>&nbsp;follo<mark>w</mark>in<mark>g&nbsp;</mark>format<mark>&nbsp;if&nbsp;using&nbsp;a&nbsp;</mark>tool<mark>:<br>```<br></mark>A<mark>c</mark>t<mark>ion:</mark>&nbsp;t<mark>ool&nbsp;nam</mark>e&nbsp;<mark>(o</mark>n<mark>e</mark>&nbsp;of&nbsp;<mark>[get_c</mark>u<mark>rre</mark>n<mark>t_temperature])<br>A</mark>ction&nbsp;<mark>I</mark>np<mark>ut:&nbsp;the&nbsp;</mark>in<mark>pu</mark>t&nbsp;<mark>to&nbsp;the&nbsp;</mark>tool<mark>,&nbsp;i</mark>n<mark>&nbsp;a&nbsp;JSON&nbsp;f</mark>o<mark>rmat&nbsp;repre</mark>se<mark>nting&nbsp;the&nbsp;kwa</mark>r<mark>gs&nbsp;(e.g.&nbsp;```{&quot;input&quot;:&nbsp;&quot;hello&nbsp;world&quot;,&nbsp;&quot;num_beams&quot;:&nbsp;5}```)<br>```<br>&lt;&#124;extra_4&#124;</mark>&gt;What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;<mark>&#124;ex</mark>t<mark>r</mark>a_<mark>0&#124;</mark>&gt;<mark>A</mark>c<mark>tion:&nbsp;</mark>get_current_temperature<br><mark>Acti</mark>on<mark>&nbsp;Input:&nbsp;</mark>{&quot;city&quot;:&nbsp;&quot;Paris&quot;}&lt;<mark>&#124;</mark>eos<mark>&#124;</mark>&gt;{&quot;temperature_celsius&quot;:21}&lt;<mark>&#124;</mark>e<mark>x</mark>tra<mark>_0&#124;</mark>&gt;</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<br><br>#&nbsp;Tools<br><br>You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;functions&nbsp;to&nbsp;assist&nbsp;with&nbsp;the&nbsp;user&nbsp;query.<br><br>You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;signatures&nbsp;within&nbsp;&lt;tools&gt;&lt;/tools&gt;&nbsp;XML&nbsp;tags:<br>&lt;tools&gt;<br>{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;object&quot;,&nbsp;&quot;properties&quot;:&nbsp;{&quot;city&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;string&quot;}},&nbsp;&quot;required&quot;:&nbsp;[&quot;city&quot;]}}}<br>&lt;/tools&gt;<br><br>For&nbsp;function&nbsp;call&nbsp;returns,&nbsp;you&nbsp;should&nbsp;first&nbsp;print&nbsp;&lt;tool_calls&gt;For&nbsp;each&nbsp;function&nbsp;call,&nbsp;you&nbsp;should&nbsp;return&nbsp;object&nbsp;like:<br>&lt;tool_call&gt;function_name<br>```json<br>function_arguments_in_json_format<br>```&lt;/tool_call&gt;At&nbsp;the&nbsp;end&nbsp;of&nbsp;function&nbsp;call&nbsp;returns,&nbsp;you&nbsp;should&nbsp;print&nbsp;&lt;/tool_calls&gt;&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;｜hy_Assistant｜&gt;&lt;tool_calls&gt;&lt;tool_call&gt;get_current_temperature<br>```json<br>{&quot;city&quot;:&nbsp;&quot;Paris&quot;}<br>```&lt;/tool_call&gt;&lt;/tool_calls&gt;&lt;｜hy_place▁holder▁no▁2｜&gt;&lt;｜hy_User｜&gt;&lt;tool_responses&gt;&lt;tool_response&gt;{&quot;temperature_celsius&quot;:21}&lt;/tool_response&gt;&lt;/tool_responses&gt;&lt;｜hy_Assistant｜&gt;&lt;think&gt;<br><br>&lt;/think&gt;<br></code> |

### tencent/Hunyuan-MT-*B

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `multi_turn_with_system` | <code>&lt;&#124;startoftext&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;extra_4&#124;&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;extra_0&#124;&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;eos&#124;&gt;<mark>&lt;&#124;startoftext&#124;&gt;</mark>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;extra_0&#124;&gt;</code> | <code>&lt;&#124;startoftext&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;extra_4&#124;&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;extra_0&#124;&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;eos&#124;&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;extra_0&#124;&gt;</code> | <code>&lt;&#124;startoftext&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;extra_4&#124;&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;extra_0&#124;&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;eos&#124;&gt;&lt;&#124;startoftext&#124;&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;extra_0&#124;&gt;</code> |

### tencent/HY-MT1.5-1.8B

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system` | <code>&lt;｜hy_begin▁of▁sentence｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜hy_<mark>Assist</mark>an<mark>t</mark>｜&gt;</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜hy_<mark>pl</mark>a<mark>ce▁holder▁</mark>n<mark>o▁8</mark>｜&gt;</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜hy_Assistant｜&gt;</code> |
| `single_turn_with_system` | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜hy_<mark>Assist</mark>an<mark>t</mark>｜&gt;</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜hy_<mark>pl</mark>a<mark>ce▁holder▁</mark>n<mark>o▁8</mark>｜&gt;</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜hy_Assistant｜&gt;</code> |
| `multi_turn_with_system` | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;｜hy_<mark>Assist</mark>an<mark>t</mark>｜&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;｜hy_place▁holder▁no▁2｜&gt;&lt;｜hy_User｜&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;｜hy_<mark>Assist</mark>an<mark>t</mark>｜&gt;</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;｜hy_<mark>pl</mark>a<mark>ce▁holder▁</mark>n<mark>o▁8</mark>｜&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;｜hy_place▁holder▁no▁2｜&gt;&lt;｜hy_User｜&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;｜hy_<mark>pl</mark>a<mark>ce▁holder▁</mark>n<mark>o▁8</mark>｜&gt;</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;｜hy_Assistant｜&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;｜hy_place▁holder▁no▁2｜&gt;&lt;｜hy_User｜&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;｜hy_Assistant｜&gt;</code> |

### tencent/HY-MT1.5-7B

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `multi_turn_with_system` | <code>&lt;&#124;startoftext&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;extra_4&#124;&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;extra_0&#124;&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;eos&#124;&gt;<mark>&lt;&#124;startoftext&#124;&gt;</mark>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;extra_0&#124;&gt;</code> | <code>&lt;&#124;startoftext&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;extra_4&#124;&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;extra_0&#124;&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;eos&#124;&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;extra_0&#124;&gt;</code> | <code>&lt;&#124;startoftext&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;extra_4&#124;&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;extra_0&#124;&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;eos&#124;&gt;&lt;&#124;startoftext&#124;&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;extra_0&#124;&gt;</code> |

### tencent/Hy-MT2-1.8B

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system` | <code>&lt;｜hy_begin▁of▁sentence｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?<mark>&lt;｜hy_Assistant｜&gt;</mark></code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜hy_Assistant｜&gt;</code> |
| `single_turn_with_system` | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?<mark>&lt;｜hy_Assistant｜&gt;</mark></code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;｜hy_Assistant｜&gt;</code> |
| `multi_turn_with_system` | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;｜hy_Assistant｜&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;｜hy_<mark>place▁holder▁no▁2｜&gt;&lt;｜hy_</mark>User｜&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?<mark>&lt;｜hy_Assistant｜&gt;</mark></code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;｜hy_Assistant｜&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;｜hy_User｜&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?</code> | <code>&lt;｜hy_begin▁of▁sentence｜&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;｜hy_place▁holder▁no▁3｜&gt;&lt;｜hy_User｜&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;｜hy_Assistant｜&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;｜hy_place▁holder▁no▁2｜&gt;&lt;｜hy_User｜&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;｜hy_Assistant｜&gt;</code> |

### tencent/Hy-MT2-7B

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `multi_turn_with_system` | <code>&lt;&#124;startoftext&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;extra_4&#124;&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;extra_0&#124;&gt;There&nbsp;are&nbsp;20&nbsp;markers.<mark>&lt;&#124;eos&#124;&gt;&lt;&#124;startoftext&#124;&gt;</mark>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;extra_0&#124;&gt;</code> | <code>&lt;&#124;startoftext&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;extra_4&#124;&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;extra_0&#124;&gt;There&nbsp;are&nbsp;20&nbsp;markers.If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;extra_0&#124;&gt;</code> | <code>&lt;&#124;startoftext&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;extra_4&#124;&gt;A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;extra_0&#124;&gt;There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;eos&#124;&gt;&lt;&#124;startoftext&#124;&gt;If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;extra_0&#124;&gt;</code> |


## Models Fixed in This PR

**Hunyuan-\*B-Instruct Series**

**Affected Model Names**

- Hunyuan-0.5B-Instruct
- Hunyuan-1.8B-Instruct
- Hunyuan-4B-Instruct
- Hunyuan-7B-Instruct
- Hunyuan-A13B-Instruct

**Background**

The 0.5B, 1.8B, and 4B tokenizers use Hunyuan-specific reasoning, system/tool separation, function-call serialization, observation roles, and assistant terminators. Their historical assistant messages may contain `<think>...</think><answer>...</answer>`, where removing historical reasoning must retain the visible answer. The 7B and A13B tokenizers instead use the 7B protocol described below.

**Root Cause**

The affected models shared legacy templates whose behavior could not be changed safely for only these tokenizer variants. The generic reasoning-history path also did not understand Hunyuan's `<answer>` wrapper, and the default tool utilities did not emit or parse the tokenizer-defined Hunyuan tool protocol.

**Solution**

1. In `src/llamafactory/data/tool_utils.py`, add `HunyuanToolUtils` for the official tool description, function-call serialization, and generated-call extraction.
2. In `src/llamafactory/data/template.py`, add the isolated `hunyuan_instruct` registration with the official user, assistant, system, function, observation, tool, prefix, and stop-token boundaries. It uses the existing `FunctionFormatter` with the new Hunyuan tool utilities.
3. Add `HunyuanReasoningTemplate` with bare `("<think>", "</think>")` boundaries. Its reasoning formatter supplies the required newlines; its history hook retains visible `<answer>` content and removes bare-tag reasoning from other historical assistant messages; and active function/observation messages remain untouched.
4. Format the system message and tool instructions with the official separator, and map only the 0.5B, 1.8B, and 4B Instruct models to `hunyuan_instruct`.
5. Map Hunyuan-7B-Instruct and Hunyuan-A13B-Instruct to the isolated `hy_mt_7b` template without modifying the existing `hy3` or dense templates.

**Hunyuan-MT-\*B-Instruct Series**

**Affected Model Names**

- Hunyuan-MT-7B-Instruct

**Background**

The tokenizer uses the 7B multi-turn protocol: each completed assistant response ends with EOS, and every user turn after the first begins with BOS. Emitting BOS only at the start of the conversation changes later-turn token IDs and supervised turn boundaries.

**Root Cause**

The previous mapping selected a legacy template that did not express a BOS prefix for individual rendered messages. The existing `hy_dense_7b` behavior could not be changed because other models rely on its `efficient_eos=True` contract.

**Solution**

1. In `src/llamafactory/data/template.py`, add `hy_mt_7b` with an explicit EOS in completed assistant slots.
2. Add `HunyuanMT7BTemplate._process_rendered_messages()` to insert BOS into every later user message after formatter rendering and before tokenization.
3. Map Hunyuan-MT-7B-Instruct to `hy_mt_7b`, while leaving `hy_dense_7b` unchanged.

**HY-MT1.5-\*B-Instruct Series**

**Affected Model Names**

- HY-MT1.5-1.8B-Instruct
- HY-MT1.5-7B-Instruct

**Background**

The 1.8B tokenizer places `<｜hy_Assistant｜>` at the end of each user prompt and `<｜hy_place▁holder▁no▁2｜>` after each completed assistant response. The 7B tokenizer uses the repeated BOS/EOS protocol above.

**Root Cause**

The 1.8B and 7B mappings selected legacy templates with different prompt/response boundaries. Updating those shared registrations would change existing users that are outside this PR's model scope.

**Solution**

1. In `src/llamafactory/data/template.py`, add the isolated `hy_mt_1_8b` template with the assistant marker on the prompt side and the completed-assistant terminator on the response side.
2. Map HY-MT1.5-1.8B-Instruct to `hy_mt_1_8b` and HY-MT1.5-7B-Instruct to `hy_mt_7b`.
3. Keep `hunyuan_small`, `hy_dense_1_8b`, and `hy_dense_7b` unchanged.

**Hy-MT2-\*B-Instruct Series**

**Affected Model Names**

- Hy-MT2-1.8B-Instruct
- Hy-MT2-7B-Instruct

**Background**

The Hy-MT2 1.8B and 7B tokenizers use the same respective message-boundary protocols as the HY-MT1.5 variants: assistant-prefix and terminator boundaries for 1.8B, and explicit repeated BOS/EOS boundaries for 7B.

**Root Cause**

Their previous mappings selected the shared dense templates, whose prompt/response and later-turn boundaries intentionally remain unchanged for existing models.

**Solution**

1. Map Hy-MT2-1.8B-Instruct to the isolated `hy_mt_1_8b` template.
2. Map Hy-MT2-7B-Instruct to the isolated `hy_mt_7b` template.
3. Reuse the same tokenizer-specific implementations without changing either shared dense template.

## Unit Tests

`tests/data/test_template.py` adds `test_hunyuan_hooks_preserve_active_tools_and_add_mt_turn_bos()` and `test_hunyuan_template_consistency()`. They verify that the existing Hunyuan registrations retain their original behavior; historical reasoning removal preserves visible answers with and without `<answer>` wrappers without modifying active tool-chain messages; later 7B user turns receive BOS; all ten model mappings select the isolated templates; Hunyuan tool calls can be extracted; and representative official tokenizer prompt IDs match LlamaFactory. The coverage also checks supervised prompt/label boundaries, `train_on_prompt`, and both `preserve_thinking` settings.

```bash
pytest -q \
  tests/data/test_template.py::test_hunyuan_hooks_preserve_active_tools_and_add_mt_turn_bos \
  tests/data/test_template.py::test_hunyuan_template_consistency
```


## About Test Samples

Models are classified as reasoning-only, non-reasoning-only, or dual-mode. Reasoning-only models use the reasoning sample, non-reasoning-only models use the non-reasoning sample, and dual-mode models use both. Each sample covers a single turn without a system prompt, a single turn with a system prompt, multi-turn dialogue with a system prompt, and multi-turn tool use with a system prompt. 

Specific test examples will be elaborated in the consistency-checking mechanism PR.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
