### PR TITLE
fix: align Qwen2 chat templates with Transformers

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -2056,6 +2056,40 @@ register_template(
 
 # copied from qwen template
 register_template(
+    name="qwen2",
+    format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),
+    format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
+    format_function=FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="qwen"),
+    format_observation=StringFormatter(
+        slots=["<|im_start|>user\n<tool_response>\n{{content}}\n</tool_response><|im_end|>\n<|im_start|>assistant\n"]
+    ),
+    format_tools=ToolFormatter(tool_format="qwen"),
+    default_system="You are a helpful assistant.",
+    stop_words=["<|im_end|>"],
+    replace_eos=True,
+)
+
+
+# copied from qwen template
+register_template(
+    name="qwen2_5_math",
+    format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),
+    format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
+    format_function=FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="qwen"),
+    format_observation=StringFormatter(
+        slots=["<|im_start|>user\n<tool_response>\n{{content}}\n</tool_response><|im_end|>\n<|im_start|>assistant\n"]
+    ),
+    format_tools=ToolFormatter(tool_format="qwen"),
+    default_system="Please reason step by step, and put your final answer within \\boxed{}.",
+    stop_words=["<|im_end|>"],
+    replace_eos=True,
+)
+
+
+# copied from qwen template
+register_template(
     name="qwen3",
     format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
     format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -2567,7 +2567,7 @@ register_model_group(
             DownloadSource.MODELSCOPE: "Qwen/Qwen2-Math-72B-Instruct",
         },
     },
-    template="qwen",
+    template="qwen2",
 )
 
 
@@ -2628,14 +2628,6 @@ register_model_group(
         "Qwen2.5-72B-Instruct": {
             DownloadSource.DEFAULT: "Qwen/Qwen2.5-72B-Instruct",
             DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-72B-Instruct",
-        },
-        "Qwen2.5-7B-Instruct-1M": {
-            DownloadSource.DEFAULT: "Qwen/Qwen2.5-7B-Instruct-1M",
-            DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-7B-Instruct-1M",
-        },
-        "Qwen2.5-14B-Instruct-1M": {
-            DownloadSource.DEFAULT: "Qwen/Qwen2.5-14B-Instruct-1M",
-            DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-14B-Instruct-1M",
         },
         "Qwen2.5-0.5B-Instruct-GPTQ-Int8": {
             DownloadSource.DEFAULT: "Qwen/Qwen2.5-0.5B-Instruct-GPTQ-Int8",
@@ -2781,18 +2773,6 @@ register_model_group(
             DownloadSource.DEFAULT: "Qwen/Qwen2.5-Math-72B",
             DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-Math-72B",
         },
-        "Qwen2.5-Math-1.5B-Instruct": {
-            DownloadSource.DEFAULT: "Qwen/Qwen2.5-Math-1.5B-Instruct",
-            DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-Coder-1.5B-Instruct",
-        },
-        "Qwen2.5-Math-7B-Instruct": {
-            DownloadSource.DEFAULT: "Qwen/Qwen2.5-Math-7B-Instruct",
-            DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-Coder-7B-Instruct",
-        },
-        "Qwen2.5-Math-72B-Instruct": {
-            DownloadSource.DEFAULT: "Qwen/Qwen2.5-Math-72B-Instruct",
-            DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-Coder-72B-Instruct",
-        },
         "QwQ-32B-Preview-Instruct": {
             DownloadSource.DEFAULT: "Qwen/QwQ-32B-Preview",
             DownloadSource.MODELSCOPE: "Qwen/QwQ-32B-Preview",
@@ -2803,6 +2783,40 @@ register_model_group(
         },
     },
     template="qwen",
+)
+
+
+register_model_group(
+    models={
+        "Qwen2.5-7B-Instruct-1M": {
+            DownloadSource.DEFAULT: "Qwen/Qwen2.5-7B-Instruct-1M",
+            DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-7B-Instruct-1M",
+        },
+        "Qwen2.5-14B-Instruct-1M": {
+            DownloadSource.DEFAULT: "Qwen/Qwen2.5-14B-Instruct-1M",
+            DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-14B-Instruct-1M",
+        },
+    },
+    template="qwen2",
+)
+
+
+register_model_group(
+    models={
+        "Qwen2.5-Math-1.5B-Instruct": {
+            DownloadSource.DEFAULT: "Qwen/Qwen2.5-Math-1.5B-Instruct",
+            DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-Math-1.5B-Instruct",
+        },
+        "Qwen2.5-Math-7B-Instruct": {
+            DownloadSource.DEFAULT: "Qwen/Qwen2.5-Math-7B-Instruct",
+            DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-Math-7B-Instruct",
+        },
+        "Qwen2.5-Math-72B-Instruct": {
+            DownloadSource.DEFAULT: "Qwen/Qwen2.5-Math-72B-Instruct",
+            DownloadSource.MODELSCOPE: "Qwen/Qwen2.5-Math-72B-Instruct",
+        },
+    },
+    template="qwen2_5_math",
 )
 
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -353,6 +353,72 @@ def test_qwen2_5_template():
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_qwen2_template_consistency():
+    qwen2_models = [
+        "Qwen2-0.5B-Instruct",
+        "Qwen2-0.5B-Instruct-GPTQ-Int8",
+        "Qwen2-0.5B-Instruct-GPTQ-Int4",
+        "Qwen2-0.5B-Instruct-AWQ",
+        "Qwen2-1.5B-Instruct",
+        "Qwen2-1.5B-Instruct-GPTQ-Int8",
+        "Qwen2-1.5B-Instruct-GPTQ-Int4",
+        "Qwen2-1.5B-Instruct-AWQ",
+        "Qwen2-7B-Instruct",
+        "Qwen2-7B-Instruct-GPTQ-Int8",
+        "Qwen2-7B-Instruct-GPTQ-Int4",
+        "Qwen2-7B-Instruct-AWQ",
+        "Qwen2-72B-Instruct",
+        "Qwen2-72B-Instruct-GPTQ-Int8",
+        "Qwen2-72B-Instruct-GPTQ-Int4",
+        "Qwen2-72B-Instruct-AWQ",
+        "Qwen2-MoE-57B-A14B-Instruct",
+        "Qwen2-57B-A14B-Instruct-GPTQ-Int4",
+        "Qwen2-Math-1.5B-Instruct",
+        "Qwen2-Math-7B-Instruct",
+        "Qwen2-Math-72B-Instruct",
+        "Qwen2.5-7B-Instruct-1M",
+        "Qwen2.5-14B-Instruct-1M",
+    ]
+    for model_name in qwen2_models:
+        assert DEFAULT_TEMPLATE[model_name] == "qwen2"
+
+    math_models = [
+        "Qwen2.5-Math-1.5B-Instruct",
+        "Qwen2.5-Math-7B-Instruct",
+        "Qwen2.5-Math-72B-Instruct",
+    ]
+    for model_name in math_models:
+        assert DEFAULT_TEMPLATE[model_name] == "qwen2_5_math"
+        assert SUPPORTED_MODELS[model_name][DownloadSource.MODELSCOPE] == f"Qwen/{model_name}"
+
+    cases = [
+        ("Qwen/Qwen2-0.5B-Instruct", "qwen2"),
+        ("Qwen/Qwen2.5-7B-Instruct-1M", "qwen2"),
+        ("Qwen/Qwen2.5-Math-1.5B-Instruct", "qwen2_5_math"),
+    ]
+    custom_system = "Answer accurately and concisely."
+    for model_id, template_name in cases:
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        reference_tokenizer = AutoTokenizer.from_pretrained(model_id)
+        template = get_template_and_fix_tokenizer(tokenizer, DataArguments(template=template_name))
+        for system in (None, custom_system):
+            prompt_ids, _ = template.encode_oneturn(tokenizer, MESSAGES, system=system)
+            reference_messages = MESSAGES[:-1]
+            if system is not None:
+                reference_messages = [{"role": "system", "content": system}, *reference_messages]
+
+            reference_ids = reference_tokenizer.apply_chat_template(
+                reference_messages,
+                tokenize=True,
+                add_generation_prompt=True,
+            )
+            if is_transformers_version_greater_than("5.0.0"):
+                reference_ids = reference_ids["input_ids"]
+
+            assert prompt_ids == reference_ids, (model_id, system)
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 @pytest.mark.parametrize("cot_messages", [True, False])
 def test_qwen3_template(cot_messages: bool):
     prompt_str = (


### PR DESCRIPTION
# What does this PR do?

Aligns the default system prompts used by Qwen2 Instruct, Qwen2.5 Instruct-1M, and Qwen2.5-Math Instruct models with their official Transformers chat templates. The changes introduce two narrowly scoped template registrations while preserving the existing Qwen message and tool-call protocol.

I have added unit tests to this PR. All the models have been verified and modified through the unit tests and our consistency-checking mechanism script. There are no errors after the modification.



## Introduction

While reviewing issues recently, I found a large number of problems caused by inconsistencies between templates.

This made us realize that these inconsistencies are not isolated incidents, especially for less common models. When users use the official templates provided by these models, such inconsistencies can cause severe mismatches between training and inference, significantly affecting training speed and the inference accuracy of the trained models.

This work consists of two parts:

1. I will use a script to perform large-scale testing on all models using the examples described below. The test will compare the generated text/token sequences across LlamaFactory training, LlamaFactory inference, and vLLM inference using the standard Transformers `chat_template` interface. I will then fix the issues one by one. Since there are many models, the fixes will be submitted in multiple PRs organized by model family to make them easier to review.

2. I will add a consistency-checking mechanism that runs automatically before training. If inconsistencies are detected, it will issue a warning and save the corresponding test examples, but it will not block training. This mechanism will be submitted as a separate PR.

The most common problems can be roughly divided into the following categories:

1. The native LlamaFactory templates do not have sufficiently fine-grained coverage. For example, Qwen3 includes several model variants, such as the Qwen3-8B-Thinking series and the Qwen3-30B-A3B-Thinking-2507 series. Qwen2.5 also includes variants such as Coder and Math. These models have subtle differences: the Qwen3-8B-Thinking series supports both thinking and non-thinking modes, while Qwen3-30B-A3B-Thinking-2507 only supports thinking mode. The official templates for the Coder and Math series also use different system prompts. However, the native system does not distinguish between these variants and applies the same template to all of them.

2. The handling of thinking traces is inconsistent. LlamaFactory provides `mask_history` and `preserve_thinking` to control whether historical thinking traces are removed during training and inference, but it currently uses the generic `remove_thought()` function for all models. In practice, different models require different handling, for example:

   - DeepSeek-R1: remove historical thinking content while preserving the two newlines after the closing tag.
   - GLM-4.5: remove the thinking content while preserving an empty thinking block.
   - Qwen/QwQ: follow the tokenizer-specific rules for historical assistant/tool messages.
   - Hunyuan: preserve or generate the corresponding boundaries according to its tokenizer; a generic removal function cannot be used.

3. The handling of whether the `<think>` tag is generated by the model is inconsistent. In the DeepSeek-R1-*B-Distill series, the `<think>` tag is part of the model output during training and is included in loss computation. During inference, however, the template automatically adds the `<think>` tag as part of the prompt, so the model does not need to generate it.

4. There are also various minor bugs of this kind. I will analyze and fix these issues individually.

### Verified Correct Models

The following models completed template validation and already match their tokenizer chat templates. They do not require a template change in this series of PRs.

- GLM-4-0414-*B-Chat
- Kimi-Dev-*B-Instruct
- Llama-3.1-*B-Chinese-Chat
- Phi-4-*B-Instruct
- Qwen2.5-*B-Instruct (standard, AWQ, GPTQ-Int4, and GPTQ-Int8)
- Qwen2.5-Coder-*B-Instruct
- Qwen3-*-Instruct-2507
- Qwen3-*-Thinking* (excluding the 2507-only thinking series)
- Qwen3-Next-80B-A3B-Instruct
- Seed-Coder-*B-Instruct
- SmolLM-*-Instruct
- Yi-Coder-*B-Chat

### Submit PR List

| PR | Model family or scope | Status |
| --- | --- | --- |
| 1 | `DeepSeek-Coder-*B-Instruct`; `DeepSeek-R1*`; `DeepSeek-LLM-*B-Chat`; `DeepSeek-Math-*B-Instruct` | √ |
| 2 | `GLM-4-0414-*B-Chat`; `GLM-4.5-*Thinking`; `GLM-Z1-0414-*B-Chat` | √ |
| 3 | `Hunyuan-*B-Instruct`; `Hunyuan-MT-*B-Instruct`; `HY-MT1.5-*B-Instruct`; `Hy-MT2-*B-Instruct` | √ |
| 4 (current PR) | `Qwen2-*`; `Qwen2.5-*-Instruct-1M`; `Qwen2.5-Math-*-Instruct` | √ |
| 5 | `Qwen3-*-Instruct-2507`; `Qwen3-*-Thinking*`; `Qwen3-Next-*-Instruct`; `Qwen3-Next-*-Thinking` | × |
| 6 | `QwQ-32B-Instruct`; `QwQ-32B-Preview-Instruct` | × |
| 7 | `Falcon-H1-*B-*Instruct` | × |
| 8 | `Granite-3.0-*B-A400M-Instruct` | × |
| 9 | `Llama-3-*B-Chinese-Chat` | × |
| 10 | `Yi-6B-Chat`; `Yi-34B-Chat` | × |
| 11 | Automatic pre-training consistency warning | × |

### Planned PR
The validation and correction work described above has already covered 80% of the models. Some model families, such as Qwen 3.5, Gemini, MiniCPM, and MiniMax, could not be completed immediately due to the workload and the need to merge other contributors’ PRs. They will be gradually addressed in follow-up work.


## Models Fixed Diff

### moonshotai/Kimi-Dev-*B

The original template was already consistent.

### Qwen/Qwen2-*B-Instruct

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system` | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;assistant.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br><mark>You&nbsp;are&nbsp;Qwen,&nbsp;created&nbsp;by&nbsp;Alibaba&nbsp;Cloud.&nbsp;</mark>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;assistant.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;assistant.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> |

### Qwen/Qwen2.5-*B-Instruct

The original template was already consistent.

### Qwen/Qwen2.5-*B-Instruct-1M

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system` | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;assistant.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br><mark>You&nbsp;are&nbsp;Qwen,&nbsp;created&nbsp;by&nbsp;Alibaba&nbsp;Cloud.&nbsp;</mark>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;assistant.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;assistant.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> |

### Qwen/Qwen2.5-Coder-*B-Instruct

The original template was already consistent.

### Qwen/Qwen2.5-Math-*B-Instruct

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system` | <code>&lt;&#124;im_start&#124;&gt;system<br><mark>Ple</mark>a<mark>s</mark>e&nbsp;rea<mark>son&nbsp;s</mark>te<mark>p</mark>&nbsp;by&nbsp;<mark>step,&nbsp;</mark>a<mark>nd</mark>&nbsp;<mark>put&nbsp;y</mark>ou<mark>r</mark>&nbsp;<mark>fin</mark>al&nbsp;a<mark>n</mark>s<mark>wer&nbsp;w</mark>it<mark>hi</mark>n<mark>&nbsp;\boxed{}</mark>.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br><mark>You&nbsp;</mark>a<mark>r</mark>e&nbsp;<mark>Qwen,&nbsp;c</mark>reate<mark>d</mark>&nbsp;by&nbsp;<mark>Alib</mark>a<mark>ba</mark>&nbsp;<mark>Cl</mark>ou<mark>d.</mark>&nbsp;<mark>You&nbsp;</mark>a<mark>re&nbsp;a&nbsp;helpfu</mark>l&nbsp;as<mark>s</mark>i<mark>s</mark>t<mark>a</mark>n<mark>t</mark>.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>Please&nbsp;reason&nbsp;step&nbsp;by&nbsp;step,&nbsp;and&nbsp;put&nbsp;your&nbsp;final&nbsp;answer&nbsp;within&nbsp;\boxed{}.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> |


## Models Fixed in This PR

**Qwen2-\*B-Instruct Series**

**Affected Model Names**

- Qwen2-0.5B-Instruct, including AWQ, GPTQ-Int4, and GPTQ-Int8
- Qwen2-1.5B-Instruct, including AWQ, GPTQ-Int4, and GPTQ-Int8
- Qwen2-7B-Instruct, including AWQ, GPTQ-Int4, and GPTQ-Int8
- Qwen2-72B-Instruct, including AWQ, GPTQ-Int4, and GPTQ-Int8
- Qwen2-MoE-57B-A14B-Instruct
- Qwen2-57B-A14B-Instruct-GPTQ-Int4
- Qwen2-Math-1.5B-Instruct
- Qwen2-Math-7B-Instruct
- Qwen2-Math-72B-Instruct

**Background**

Qwen2 uses the same role and tool boundaries as the existing Qwen formatter, but its tokenizer inserts `You are a helpful assistant.` when no system message is supplied. The shared `qwen` template inserts the longer Alibaba Cloud identity message.

**Root Cause**

The Qwen2 model group in `src/llamafactory/extras/constants.py` used `template="qwen"`, whose `default_system` in `src/llamafactory/data/template.py` targets standard Qwen2.5 rather than Qwen2.

**Solution**

1. In `src/llamafactory/data/template.py`, add `qwen2` with the existing Qwen user, assistant, system, function, observation, and tool formatters.
2. Set `qwen2.default_system` to `You are a helpful assistant.`.
3. In `src/llamafactory/extras/constants.py`, map the Qwen2 Instruct group to `qwen2` while leaving base entries without a chat template.

**Qwen2.5-\*B-Instruct-1M Series**

**Affected Model Names**

- Qwen2.5-7B-Instruct-1M
- Qwen2.5-14B-Instruct-1M

**Background**

These long-context tokenizers use the concise Qwen2 default system message, while standard Qwen2.5 Instruct tokenizers use the longer Qwen identity message.

**Root Cause**

Both 1M entries were inside the standard Qwen2.5 model group in `src/llamafactory/extras/constants.py` and therefore inherited `qwen.default_system`.

**Solution**

1. In `src/llamafactory/extras/constants.py`, remove both 1M entries from the standard Qwen2.5 group.
2. Register them in a separate group using `qwen2` from `src/llamafactory/data/template.py`.

**Qwen2.5-Math-\*B-Instruct Series**

**Affected Model Names**

- Qwen2.5-Math-1.5B-Instruct
- Qwen2.5-Math-7B-Instruct
- Qwen2.5-Math-72B-Instruct

**Background**

These tokenizers use a math-specific default instruction that requests step-by-step reasoning and a boxed final answer. They also have Qwen2.5-Math ModelScope repositories, not Qwen2.5-Coder repositories.

**Root Cause**

The entries in `src/llamafactory/extras/constants.py` shared `qwen`, so they received the wrong default system message, and their ModelScope sources pointed to Qwen2.5-Coder.

**Solution**

1. In `src/llamafactory/data/template.py`, add `qwen2_5_math` with the existing Qwen formatters.
2. Set its `default_system` to the tokenizer-defined step-by-step and boxed-answer instruction.
3. In `src/llamafactory/extras/constants.py`, move the three Math Instruct entries to `qwen2_5_math`.
4. Correct their ModelScope sources to the corresponding Qwen2.5-Math repositories.

## Unit Tests

`tests/data/test_template.py` adds `test_qwen2_template_consistency()`. It checks the 23 `qwen2` mappings, three Math mappings and corrected ModelScope sources, then compares default-system and custom-system prompts for one representative tokenizer from each protocol.

```bash
pytest -q tests/data/test_template.py::test_qwen2_template_consistency
```

## About Test Samples

Models are classified as reasoning-only, non-reasoning-only, or dual-mode. Reasoning-only models use the reasoning sample, non-reasoning-only models use the non-reasoning sample, and dual-mode models use both. Each sample covers a single turn without a system prompt, a single turn with a system prompt, multi-turn dialogue with a system prompt, and multi-turn tool use with a system prompt. 

Specific test examples will be elaborated in the consistency-checking mechanism PR.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
