### PR TITLE
fix: align Qwen3 chat templates with Transformers

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -545,16 +545,23 @@ class QwenNothinkTemplate(Template):
         return messages
 
     @override
-    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
-        response_index = len(rendered_messages) - 1
-        if response_index == 0 or messages[response_index]["role"] not in {Role.ASSISTANT, Role.FUNCTION}:
-            return
+    def _process_thought_boundaries(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> set[int]:
+        processed_response_indices = set()
+        for response_index in range(1, len(rendered_messages), 2):
+            if messages[response_index]["role"] not in {Role.ASSISTANT, Role.FUNCTION}:
+                continue
 
-        prompt_elements = rendered_messages[response_index - 1]
-        if prompt_elements and isinstance(prompt_elements[-1], str):
-            prompt_elements[-1] += self.add_thought()
-        else:
-            prompt_elements.append(self.add_thought())
+            prompt_elements = rendered_messages[response_index - 1]
+            if prompt_elements and isinstance(prompt_elements[-1], str):
+                prompt_elements[-1] += self.add_thought()
+            else:
+                prompt_elements.append(self.add_thought())
+
+            processed_response_indices.add(response_index)
+
+        return processed_response_indices
 
 
 class QwenThinkingHistoryMixin:
@@ -562,7 +569,10 @@ class QwenThinkingHistoryMixin:
 
     @override
     def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
-        last_user_index = max(index for index, message in enumerate(messages[:-1]) if message["role"] == Role.USER)
+        last_user_index = max(
+            (index for index, message in enumerate(messages[:-1]) if message["role"] == Role.USER),
+            default=-1,
+        )
         for index, message in enumerate(messages[:-1]):
             if message["role"] in {Role.ASSISTANT, Role.FUNCTION} and (
                 self.enable_thinking is False or index < last_user_index
@@ -577,10 +587,13 @@ class QwenReasoningTemplate(QwenThinkingHistoryMixin, ReasoningTemplate):
     r"""Render the dual-mode Qwen3 thinking protocol before tokenization."""
 
     @override
-    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
+    def _process_thought_boundaries(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> set[int]:
+        processed_response_indices = set()
         response_index = len(rendered_messages) - 1
         if response_index == 0 or messages[response_index]["role"] not in {Role.ASSISTANT, Role.FUNCTION}:
-            return
+            return processed_response_indices
 
         content = messages[response_index]["content"]
         has_thought = self.thought_words[0].strip() in content or self.thought_words[1].strip() in content
@@ -591,12 +604,14 @@ class QwenReasoningTemplate(QwenThinkingHistoryMixin, ReasoningTemplate):
             else:
                 prompt_elements.append(self.add_thought())
 
-            messages[response_index]["content"] = self.add_thought() + content
+            processed_response_indices.add(response_index)
         elif content and not has_thought:
             response_elements = rendered_messages[response_index]
             if response_elements and isinstance(response_elements[0], str):
                 response_elements[0] = self.add_thought() + response_elements[0]
-                messages[response_index]["content"] = self.add_thought() + content
+                processed_response_indices.add(response_index)
+
+        return processed_response_indices
 
 
 @dataclass
@@ -604,9 +619,12 @@ class QwenPrefilledThinkingTemplate(QwenThinkingHistoryMixin, ReasoningTemplate)
     r"""Place Qwen's opening thinking tag in the prompt before tokenization."""
 
     @override
-    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
+    def _process_thought_boundaries(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> set[int]:
+        processed_response_indices = set()
         if not self.enable_thinking:
-            return
+            return processed_response_indices
 
         last_response_index = len(rendered_messages) - 1
         for response_index in range(1, len(rendered_messages), 2):
@@ -639,9 +657,10 @@ class QwenPrefilledThinkingTemplate(QwenThinkingHistoryMixin, ReasoningTemplate)
                 response_elements[0] = response_content[len(matched_prefix) :]
             elif messages[response_index]["content"]:
                 response_elements[0] = self.thought_words[1] + response_content
-                messages[response_index]["content"] = self.thought_words[0] + messages[response_index]["content"]
-            else:
-                messages[response_index]["content"] = self.thought_words[0]
+
+            processed_response_indices.add(response_index)
+
+        return processed_response_indices
 
 
 @dataclass

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -532,6 +532,119 @@ class ReasoningTemplate(Template):
 
 
 @dataclass
+class QwenNothinkTemplate(Template):
+    r"""Render the dual-mode Qwen3 protocol with thinking disabled."""
+
+    @override
+    def _process_messages(self, messages: list[dict[str, str]]) -> list[dict[str, str]]:
+        messages = deepcopy(messages)
+        for message in messages:
+            if message["role"] in {Role.ASSISTANT, Role.FUNCTION}:
+                message["content"] = self.remove_thought(message["content"])
+
+        return messages
+
+    @override
+    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
+        response_index = len(rendered_messages) - 1
+        if response_index == 0 or messages[response_index]["role"] not in {Role.ASSISTANT, Role.FUNCTION}:
+            return
+
+        prompt_elements = rendered_messages[response_index - 1]
+        if prompt_elements and isinstance(prompt_elements[-1], str):
+            prompt_elements[-1] += self.add_thought()
+        else:
+            prompt_elements.append(self.add_thought())
+
+
+class QwenThinkingHistoryMixin:
+    r"""Preserve reasoning in the active tool chain after the final user message."""
+
+    @override
+    def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
+        last_user_index = max(index for index, message in enumerate(messages[:-1]) if message["role"] == Role.USER)
+        for index, message in enumerate(messages[:-1]):
+            if message["role"] in {Role.ASSISTANT, Role.FUNCTION} and (
+                self.enable_thinking is False or index < last_user_index
+            ):
+                message["content"] = self.remove_thought(message["content"])
+
+        return True
+
+
+@dataclass
+class QwenReasoningTemplate(QwenThinkingHistoryMixin, ReasoningTemplate):
+    r"""Render the dual-mode Qwen3 thinking protocol before tokenization."""
+
+    @override
+    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
+        response_index = len(rendered_messages) - 1
+        if response_index == 0 or messages[response_index]["role"] not in {Role.ASSISTANT, Role.FUNCTION}:
+            return
+
+        content = messages[response_index]["content"]
+        has_thought = self.thought_words[0].strip() in content or self.thought_words[1].strip() in content
+        if self.enable_thinking is False:
+            prompt_elements = rendered_messages[response_index - 1]
+            if prompt_elements and isinstance(prompt_elements[-1], str):
+                prompt_elements[-1] += self.add_thought()
+            else:
+                prompt_elements.append(self.add_thought())
+
+            messages[response_index]["content"] = self.add_thought() + content
+        elif content and not has_thought:
+            response_elements = rendered_messages[response_index]
+            if response_elements and isinstance(response_elements[0], str):
+                response_elements[0] = self.add_thought() + response_elements[0]
+                messages[response_index]["content"] = self.add_thought() + content
+
+
+@dataclass
+class QwenPrefilledThinkingTemplate(QwenThinkingHistoryMixin, ReasoningTemplate):
+    r"""Place Qwen's opening thinking tag in the prompt before tokenization."""
+
+    @override
+    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
+        if not self.enable_thinking:
+            return
+
+        last_response_index = len(rendered_messages) - 1
+        for response_index in range(1, len(rendered_messages), 2):
+            if messages[response_index]["role"] not in {Role.ASSISTANT, Role.FUNCTION}:
+                continue
+
+            response_elements = rendered_messages[response_index]
+            if not response_elements or not isinstance(response_elements[0], str):
+                continue
+
+            response_content = response_elements[0]
+            matched_prefix = next(
+                (
+                    prefix
+                    for prefix in (self.thought_words[0], self.thought_words[0].strip())
+                    if response_content.startswith(prefix)
+                ),
+                None,
+            )
+            if matched_prefix is None and response_index != last_response_index:
+                continue
+
+            prompt_elements = rendered_messages[response_index - 1]
+            if prompt_elements and isinstance(prompt_elements[-1], str):
+                prompt_elements[-1] += self.thought_words[0]
+            else:
+                prompt_elements.append(self.thought_words[0])
+
+            if matched_prefix is not None:
+                response_elements[0] = response_content[len(matched_prefix) :]
+            elif messages[response_index]["content"]:
+                response_elements[0] = self.thought_words[1] + response_content
+                messages[response_index]["content"] = self.thought_words[0] + messages[response_index]["content"]
+            else:
+                messages[response_index]["content"] = self.thought_words[0]
+
+
+@dataclass
 class Glm47ReasoningTemplate(ReasoningTemplate):
     r"""GLM-4.7 uses only the closing </think> tag for empty thinking blocks."""
 
@@ -2082,7 +2195,40 @@ register_template(
     format_tools=ToolFormatter(tool_format="qwen"),
     stop_words=["<|im_end|>"],
     replace_eos=True,
-    template_class=ReasoningTemplate,
+    template_class=QwenReasoningTemplate,
+)
+
+
+# copied from qwen3 template
+register_template(
+    name="qwen_thinking",
+    format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),
+    format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
+    format_function=FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="qwen"),
+    format_observation=StringFormatter(
+        slots=["<|im_start|>user\n<tool_response>\n{{content}}\n</tool_response><|im_end|>\n<|im_start|>assistant\n"]
+    ),
+    format_tools=ToolFormatter(tool_format="qwen"),
+    stop_words=["<|im_end|>"],
+    replace_eos=True,
+    template_class=QwenPrefilledThinkingTemplate,
+)
+
+
+# copied from qwen3 template
+register_template(
+    name="qwen3_instruct",
+    format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),
+    format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
+    format_function=FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="qwen"),
+    format_observation=StringFormatter(
+        slots=["<|im_start|>user\n<tool_response>\n{{content}}\n</tool_response><|im_end|>\n<|im_start|>assistant\n"]
+    ),
+    format_tools=ToolFormatter(tool_format="qwen"),
+    stop_words=["<|im_end|>"],
+    replace_eos=True,
 )
 
 
@@ -2099,6 +2245,7 @@ register_template(
     format_tools=ToolFormatter(tool_format="qwen"),
     stop_words=["<|im_end|>"],
     replace_eos=True,
+    template_class=QwenNothinkTemplate,
 )
 
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -65,7 +65,7 @@ class Template:
         tools: Optional[str] = None,
     ) -> tuple[list[int], list[int]]:
         r"""Return a single pair of token ids representing prompt and response respectively."""
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, _ = self._encode(tokenizer, messages, system, tools)
         prompt_ids = []
         for encoded_ids in encoded_messages[:-1]:
             prompt_ids += encoded_ids
@@ -82,7 +82,7 @@ class Template:
         discarding_history_cot: bool = False,  # only effect reasoning template
     ) -> list[tuple[list[int], list[int]]]:
         r"""Return multiple pairs of token ids representing prompts and responses respectively."""
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, _ = self._encode(tokenizer, messages, system, tools)
         return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(0, len(encoded_messages), 2)]
 
     def extract_tool(self, content: str) -> Union[str, list["FunctionCall"]]:
@@ -135,7 +135,7 @@ class Template:
         messages: list[dict[str, str]],
         system: Optional[str],
         tools: Optional[str],
-    ) -> list[list[int]]:
+    ) -> tuple[list[list[int]], set[int]]:
         r"""Encode formatted inputs to pairs of token ids.
 
         Turn 0: prefix + system + query        resp
@@ -147,15 +147,17 @@ class Template:
 
         rendered_messages = self._render(messages, system, tools)
         self._process_rendered_messages(rendered_messages, messages)
-        return [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+        processed_response_indices = self._process_thought_boundaries(rendered_messages, messages)
+        encoded_messages = [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+        return encoded_messages, processed_response_indices
 
     def _process_messages(self, messages: list[dict[str, str]]) -> Optional[list[dict[str, str]]]:
         r"""Return model-specific messages before rendering, or use the original messages."""
-        pass
+        return None
 
     def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
         r"""Return model-specific system and tool elements, or use the default formatter."""
-        pass
+        return None
 
     def _render(
         self,
@@ -200,7 +202,13 @@ class Template:
         self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
     ) -> None:
         r"""Apply model-specific changes to formatter output before tokenization."""
-        pass
+        return None
+
+    def _process_thought_boundaries(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> set[int]:
+        r"""Process model-specific thought boundaries and return the handled response indices."""
+        return set()
 
     @staticmethod
     def _add_or_replace_eos_token(tokenizer: "PreTrainedTokenizer", eos_token: str) -> None:
@@ -452,7 +460,7 @@ class ReasoningTemplate(Template):
 
     def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
         r"""Process model-specific historical reasoning and return whether it was handled."""
-        pass
+        return False
 
     @override
     def encode_oneturn(
@@ -470,8 +478,14 @@ class ReasoningTemplate(Template):
         if self.enable_thinking is False:  # remove all cot
             messages[-1]["content"] = self.remove_thought(messages[-1]["content"])
 
-        prompt_ids, response_ids = super().encode_oneturn(tokenizer, messages, system, tools)
-        if (
+        encoded_messages, processed_response_indices = self._encode(tokenizer, messages, system, tools)
+        prompt_ids = []
+        for encoded_ids in encoded_messages[:-1]:
+            prompt_ids += encoded_ids
+
+        response_index = len(encoded_messages) - 1
+        response_ids = encoded_messages[response_index]
+        if response_index not in processed_response_indices and (
             self.thought_words[0].strip() not in messages[-1]["content"]
             and self.thought_words[1].strip() not in messages[-1]["content"]
         ):  # add empty cot
@@ -500,14 +514,14 @@ class ReasoningTemplate(Template):
             for i in range(1, len(messages) - 2, 2):  # preserve the last cot
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, processed_response_indices = self._encode(tokenizer, messages, system, tools)
         if discarding_history_cot:
             turn_indices = [len(messages) - 2]
         else:
             turn_indices = range(0, len(messages), 2)
 
         for i in turn_indices:
-            if (
+            if i + 1 not in processed_response_indices and (
                 self.thought_words[0].strip() not in messages[i + 1]["content"]
                 and self.thought_words[1].strip() not in messages[i + 1]["content"]
             ):  # add empty cot

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -141,16 +141,43 @@ class Template:
         Turn 0: prefix + system + query        resp
         Turn t: query                          resp.
         """
+        processed_messages = self._process_messages(messages)
+        if processed_messages is not None:
+            messages = processed_messages
+
+        rendered_messages = self._render(messages, system, tools)
+        self._process_rendered_messages(rendered_messages, messages)
+        return [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+
+    def _process_messages(self, messages: list[dict[str, str]]) -> Optional[list[dict[str, str]]]:
+        r"""Return model-specific messages before rendering, or use the original messages."""
+        pass
+
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
+        r"""Return model-specific system and tool elements, or use the default formatter."""
+        pass
+
+    def _render(
+        self,
+        messages: list[dict[str, str]],
+        system: Optional[str],
+        tools: Optional[str],
+    ) -> list["SLOTS"]:
+        r"""Render messages into formatter elements before tokenization."""
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
             if i == 0:
                 elements += self.format_prefix.apply()
                 if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    elements += self.format_system.apply(content=(system + tool_text))
+                    system_and_tools = self._format_system_and_tools(system, tools)
+                    if system_and_tools is None:
+                        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+                        system_and_tools = self.format_system.apply(content=(system + tool_text))
+
+                    elements += system_and_tools
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
@@ -165,9 +192,15 @@ class Template:
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
+
+    def _process_rendered_messages(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> None:
+        r"""Apply model-specific changes to formatter output before tokenization."""
+        pass
 
     @staticmethod
     def _add_or_replace_eos_token(tokenizer: "PreTrainedTokenizer", eos_token: str) -> None:
@@ -336,45 +369,12 @@ class Template:
 @dataclass
 class MossVLTemplate(Template):
     @override
-    def _encode(
-        self,
-        tokenizer: "PreTrainedTokenizer",
-        messages: list[dict[str, str]],
-        system: Optional[str],
-        tools: Optional[str],
-    ) -> list[list[int]]:
-        system = system or self.default_system
-        encoded_messages = []
-        for i, message in enumerate(messages):
-            elements = []
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> "SLOTS":
+        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+        if tools and not system:
+            tool_text = tool_text.lstrip("\n")
 
-            if i == 0:
-                elements += self.format_prefix.apply()
-                if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    if tools and not system:
-                        tool_text = tool_text.lstrip("\n")
-
-                    elements += self.format_system.apply(content=(system + tool_text))
-
-            if message["role"] == Role.USER:
-                elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
-            elif message["role"] == Role.ASSISTANT:
-                elements += self.format_assistant.apply(content=message["content"])
-            elif message["role"] == Role.OBSERVATION:
-                elements += self.format_observation.apply(content=message["content"])
-            elif message["role"] == Role.FUNCTION:
-                elements += self.format_function.apply(
-                    content=message["content"],
-                    thought_words=self.thought_words,
-                    tool_call_words=self.tool_call_words,
-                )
-            else:
-                raise NotImplementedError("Unexpected role: {}".format(message["role"]))
-
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
-
-        return encoded_messages
+        return self.format_system.apply(content=(system + tool_text))
 
 
 @dataclass
@@ -382,15 +382,14 @@ class Llama2Template(Template):
     r"""A template that fuse the system message to first user message."""
 
     @override
-    def _encode(
+    def _render(
         self,
-        tokenizer: "PreTrainedTokenizer",
         messages: list[dict[str, str]],
         system: str,
         tools: str,
-    ) -> list[list[int]]:
+    ) -> list["SLOTS"]:
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
@@ -412,9 +411,9 @@ class Llama2Template(Template):
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
 
     def _get_jinja_template(self, tokenizer: "PreTrainedTokenizer") -> str:
         prefix = self._convert_slots_to_jinja(self.format_prefix.apply(), tokenizer)
@@ -451,6 +450,10 @@ class Llama2Template(Template):
 class ReasoningTemplate(Template):
     r"""A template that add thought to assistant message."""
 
+    def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
+        r"""Process model-specific historical reasoning and return whether it was handled."""
+        pass
+
     @override
     def encode_oneturn(
         self,
@@ -460,7 +463,7 @@ class ReasoningTemplate(Template):
         tools: Optional[str] = None,
     ) -> tuple[list[int], list[int]]:
         messages = deepcopy(messages)
-        if not self.preserve_thinking:
+        if not self.preserve_thinking and not self._process_history_thoughts(messages, is_inference=True):
             for i in range(1, len(messages) - 2, 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
@@ -493,7 +496,7 @@ class ReasoningTemplate(Template):
             for i in range(1, len(messages), 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
-        if discarding_history_cot:
+        if discarding_history_cot and not self._process_history_thoughts(messages, is_inference=False):
             for i in range(1, len(messages) - 2, 2):  # preserve the last cot
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -198,9 +198,7 @@ class Template:
 
         return rendered_messages
 
-    def _process_rendered_messages(
-        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
-    ) -> None:
+    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
         r"""Apply model-specific changes to formatter output before tokenization."""
         return None
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -548,20 +548,17 @@ class QwenNothinkTemplate(Template):
     def _process_thought_boundaries(
         self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
     ) -> set[int]:
-        processed_response_indices = set()
-        for response_index in range(1, len(rendered_messages), 2):
-            if messages[response_index]["role"] not in {Role.ASSISTANT, Role.FUNCTION}:
-                continue
+        response_index = len(rendered_messages) - 1
+        if response_index == 0 or messages[response_index]["role"] not in {Role.ASSISTANT, Role.FUNCTION}:
+            return set()
 
-            prompt_elements = rendered_messages[response_index - 1]
-            if prompt_elements and isinstance(prompt_elements[-1], str):
-                prompt_elements[-1] += self.add_thought()
-            else:
-                prompt_elements.append(self.add_thought())
+        prompt_elements = rendered_messages[response_index - 1]
+        if prompt_elements and isinstance(prompt_elements[-1], str):
+            prompt_elements[-1] += self.add_thought()
+        else:
+            prompt_elements.append(self.add_thought())
 
-            processed_response_indices.add(response_index)
-
-        return processed_response_indices
+        return {response_index}
 
 
 class QwenThinkingHistoryMixin:

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -2844,10 +2844,6 @@ register_model_group(
             DownloadSource.DEFAULT: "Qwen/Qwen3-4B",
             DownloadSource.MODELSCOPE: "Qwen/Qwen3-4B",
         },
-        "Qwen3-4B-Thinking-2507": {
-            DownloadSource.DEFAULT: "Qwen/Qwen3-4B-Thinking-2507",
-            DownloadSource.MODELSCOPE: "Qwen/Qwen3-4B-Thinking-2507",
-        },
         "Qwen3-8B-Thinking": {
             DownloadSource.DEFAULT: "Qwen/Qwen3-8B",
             DownloadSource.MODELSCOPE: "Qwen/Qwen3-8B",
@@ -2864,17 +2860,9 @@ register_model_group(
             DownloadSource.DEFAULT: "Qwen/Qwen3-30B-A3B",
             DownloadSource.MODELSCOPE: "Qwen/Qwen3-30B-A3B",
         },
-        "Qwen3-30B-A3B-Thinking-2507": {
-            DownloadSource.DEFAULT: "Qwen/Qwen3-30B-A3B-Thinking-2507",
-            DownloadSource.MODELSCOPE: "Qwen/Qwen3-30B-A3B-Thinking-2507",
-        },
         "Qwen3-235B-A22B-Thinking": {
             DownloadSource.DEFAULT: "Qwen/Qwen3-235B-A22B",
             DownloadSource.MODELSCOPE: "Qwen/Qwen3-235B-A22B",
-        },
-        "Qwen3-235B-A22B-Thinking-2507": {
-            DownloadSource.DEFAULT: "Qwen/Qwen3-235B-A22B-Thinking-2507",
-            DownloadSource.MODELSCOPE: "Qwen/Qwen3-235B-A22B-Thinking-2507",
         },
         "Qwen3-0.6B-Thinking-GPTQ-Int8": {
             DownloadSource.DEFAULT: "Qwen/Qwen3-0.6B-GPTQ-Int8",
@@ -2908,12 +2896,31 @@ register_model_group(
             DownloadSource.DEFAULT: "Qwen/Qwen3-235B-A22B-GPTQ-Int4",
             DownloadSource.MODELSCOPE: "Qwen/Qwen3-235B-A22B-GPTQ-Int4",
         },
-        "Qwen/Qwen3-Next-80B-A3B-Thinking": {
+    },
+    template="qwen3",
+)
+
+
+register_model_group(
+    models={
+        "Qwen3-4B-Thinking-2507": {
+            DownloadSource.DEFAULT: "Qwen/Qwen3-4B-Thinking-2507",
+            DownloadSource.MODELSCOPE: "Qwen/Qwen3-4B-Thinking-2507",
+        },
+        "Qwen3-30B-A3B-Thinking-2507": {
+            DownloadSource.DEFAULT: "Qwen/Qwen3-30B-A3B-Thinking-2507",
+            DownloadSource.MODELSCOPE: "Qwen/Qwen3-30B-A3B-Thinking-2507",
+        },
+        "Qwen3-235B-A22B-Thinking-2507": {
+            DownloadSource.DEFAULT: "Qwen/Qwen3-235B-A22B-Thinking-2507",
+            DownloadSource.MODELSCOPE: "Qwen/Qwen3-235B-A22B-Thinking-2507",
+        },
+        "Qwen3-Next-80B-A3B-Thinking": {
             DownloadSource.DEFAULT: "Qwen/Qwen3-Next-80B-A3B-Thinking",
             DownloadSource.MODELSCOPE: "Qwen/Qwen3-Next-80B-A3B-Thinking",
         },
     },
-    template="qwen3",
+    template="qwen_thinking",
 )
 
 
@@ -2931,12 +2938,19 @@ register_model_group(
             DownloadSource.DEFAULT: "Qwen/Qwen3-235B-A22B-Instruct-2507",
             DownloadSource.MODELSCOPE: "Qwen/Qwen3-235B-A22B-Instruct-2507",
         },
+    },
+    template="qwen3_instruct",
+)
+
+
+register_model_group(
+    models={
         "Qwen3-Next-80B-A3B-Instruct": {
             DownloadSource.DEFAULT: "Qwen/Qwen3-Next-80B-A3B-Instruct",
             DownloadSource.MODELSCOPE: "Qwen/Qwen3-Next-80B-A3B-Instruct",
         },
     },
-    template="qwen3_nothink",
+    template="qwen3_instruct",
 )
 
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import pytest
@@ -95,6 +97,58 @@ def _check_template(
     assert content_str == prompt_str + answer_str
     assert content_ids == prompt_ids + answer_ids
     _check_tokenization(tokenizer, (prompt_ids, answer_ids), (prompt_str, answer_str))
+
+
+def test_rendering_refactor_preserves_existing_template_boundaries():
+    class ByteTokenizer:
+        bos_token_id = 1000
+        eos_token_id = 1001
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            return list(text.encode())
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    tokenizer = ByteTokenizer()
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+
+    standard = deepcopy(TEMPLATES["falcon_h1"])
+    prompt_ids, response_ids = standard.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<|im_start|>system\nsystem<|im_end|>\n"
+        "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    tools = json.dumps(
+        [
+            {
+                "name": "search",
+                "description": "Search documents.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            }
+        ]
+    )
+    moss_vl = deepcopy(TEMPLATES["moss_vl"])
+    prompt_ids, response_ids = moss_vl.encode_oneturn(tokenizer, messages, tools=tools)
+    tool_text = moss_vl.format_tools.apply(content=tools)[0].lstrip("\n")
+    assert prompt_ids == tokenizer.encode(
+        moss_vl.format_system.apply(content=tool_text)[0]
+        + "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    llama2 = deepcopy(TEMPLATES["gemma"])
+    prompt_ids, response_ids = llama2.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<start_of_turn>user\nsystem\n\nquestion<end_of_turn>\n<start_of_turn>model\n"
+    )
+    assert response_ids == tokenizer.encode("answer<end_of_turn>\n")
 
 
 def test_moss_vl_registration():

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -460,6 +460,23 @@ def test_qwen3_template(cot_messages: bool):
     _check_template("Qwen/Qwen3-8B", "qwen3", prompt_str, answer_str, messages=messages)
 
 
+def test_qwen3_nothink_processes_every_response_boundary():
+    template = deepcopy(TEMPLATES["qwen3_nothink"])
+    messages = [
+        {"role": "user", "content": "question 1"},
+        {"role": "assistant", "content": "answer 1"},
+        {"role": "user", "content": "question 2"},
+        {"role": "assistant", "content": "answer 2"},
+    ]
+    rendered_messages = template._render(messages, system=None, tools=None)
+
+    processed_response_indices = template._process_thought_boundaries(rendered_messages, messages)
+
+    assert processed_response_indices == {1, 3}
+    assert rendered_messages[0][-1].endswith(template.add_thought())
+    assert rendered_messages[2][-1].endswith(template.add_thought())
+
+
 @pytest.mark.runs_on(["cpu", "mps"])
 def test_qwen3_family_template_consistency():
     qwen3_models = [

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -460,7 +460,7 @@ def test_qwen3_template(cot_messages: bool):
     _check_template("Qwen/Qwen3-8B", "qwen3", prompt_str, answer_str, messages=messages)
 
 
-def test_qwen3_nothink_processes_every_response_boundary():
+def test_qwen3_nothink_processes_only_generation_boundary():
     template = deepcopy(TEMPLATES["qwen3_nothink"])
     messages = [
         {"role": "user", "content": "question 1"},
@@ -472,8 +472,8 @@ def test_qwen3_nothink_processes_every_response_boundary():
 
     processed_response_indices = template._process_thought_boundaries(rendered_messages, messages)
 
-    assert processed_response_indices == {1, 3}
-    assert rendered_messages[0][-1].endswith(template.add_thought())
+    assert processed_response_indices == {3}
+    assert not rendered_messages[0][-1].endswith(template.add_thought())
     assert rendered_messages[2][-1].endswith(template.add_thought())
 
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -461,6 +461,195 @@ def test_qwen3_template(cot_messages: bool):
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_qwen3_family_template_consistency():
+    qwen3_models = [
+        "Qwen3-0.6B-Thinking",
+        "Qwen3-1.7B-Thinking",
+        "Qwen3-4B-Thinking",
+        "Qwen3-8B-Thinking",
+        "Qwen3-14B-Thinking",
+        "Qwen3-32B-Thinking",
+        "Qwen3-30B-A3B-Thinking",
+        "Qwen3-235B-A22B-Thinking",
+        "Qwen3-0.6B-Thinking-GPTQ-Int8",
+        "Qwen3-1.7B-Thinking-GPTQ-Int8",
+        "Qwen3-4B-Thinking-AWQ",
+        "Qwen3-8B-Thinking-AWQ",
+        "Qwen3-14B-Thinking-AWQ",
+        "Qwen3-32B-Thinking-AWQ",
+        "Qwen3-30B-A3B-Thinking-GPTQ-Int4",
+        "Qwen3-235B-A22B-Thinking-GPTQ-Int4",
+    ]
+    for model_name in qwen3_models:
+        assert DEFAULT_TEMPLATE[model_name] == "qwen3"
+
+    reasoning_only_models = [
+        "Qwen3-4B-Thinking-2507",
+        "Qwen3-30B-A3B-Thinking-2507",
+        "Qwen3-235B-A22B-Thinking-2507",
+        "Qwen3-Next-80B-A3B-Thinking",
+    ]
+    for model_name in reasoning_only_models:
+        assert DEFAULT_TEMPLATE[model_name] == "qwen_thinking"
+
+    instruct_models = [
+        "Qwen3-4B-Instruct-2507",
+        "Qwen3-30B-A3B-Instruct-2507",
+        "Qwen3-235B-A22B-Instruct-2507",
+        "Qwen3-Next-80B-A3B-Instruct",
+    ]
+    for model_name in instruct_models:
+        assert DEFAULT_TEMPLATE[model_name] == "qwen3_instruct"
+
+    assert "Qwen/Qwen3-Next-80B-A3B-Thinking" not in SUPPORTED_MODELS
+    assert TEMPLATES["qwen3_nothink"].__class__.__name__ == "QwenNothinkTemplate"
+
+    system = "You are a helpful weather assistant. Use the available tools when needed."
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_temperature",
+                "description": "Get the current temperature for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    function_call = '{"name":"get_current_temperature","arguments":{"city":"Paris"}}'
+    observation = '{"temperature_celsius":21}'
+    history_thought = "<think>\n12 + 8 = 20.\n</think>\n\n"
+    tool_thought = "<think>\nI should use the weather tool.\n</think>\n\n"
+    thinking_messages = [
+        {"role": "user", "content": "How many markers are in the box?"},
+        {"role": "assistant", "content": history_thought + "There are 20 markers."},
+        {"role": "user", "content": "What is the current temperature in Paris?"},
+        {"role": "function", "content": tool_thought + function_call},
+        {"role": "observation", "content": observation},
+        {"role": "assistant", "content": tool_thought + "It is 21 degrees Celsius."},
+    ]
+    no_thinking_messages = [
+        {"role": "user", "content": "How many markers are in the box?"},
+        {"role": "assistant", "content": "There are 20 markers."},
+        {"role": "user", "content": "What is the current temperature in Paris?"},
+        {"role": "function", "content": function_call},
+        {"role": "observation", "content": observation},
+        {"role": "assistant", "content": "It is 21 degrees Celsius."},
+    ]
+    thinking_reference = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": "How many markers are in the box?"},
+        {"role": "assistant", "content": history_thought + "There are 20 markers."},
+        {"role": "user", "content": "What is the current temperature in Paris?"},
+        {
+            "role": "assistant",
+            "content": tool_thought.rstrip(),
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {"name": "get_current_temperature", "arguments": {"city": "Paris"}},
+                }
+            ],
+        },
+        {"role": "tool", "name": "get_current_temperature", "content": observation},
+    ]
+    no_thinking_reference = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": "How many markers are in the box?"},
+        {"role": "assistant", "content": "There are 20 markers."},
+        {"role": "user", "content": "What is the current temperature in Paris?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {"name": "get_current_temperature", "arguments": {"city": "Paris"}},
+                }
+            ],
+        },
+        {"role": "tool", "name": "get_current_temperature", "content": observation},
+    ]
+    cases = [
+        ("Qwen/Qwen3-4B", "qwen3", True, thinking_messages, thinking_reference),
+        ("Qwen/Qwen3-4B", "qwen3", False, no_thinking_messages, no_thinking_reference),
+        ("Qwen/Qwen3-4B", "qwen3_nothink", False, no_thinking_messages, no_thinking_reference),
+        ("Qwen/Qwen3-4B-Thinking-2507", "qwen_thinking", True, thinking_messages, thinking_reference),
+        ("Qwen/Qwen3-Next-80B-A3B-Thinking", "qwen_thinking", True, thinking_messages, thinking_reference),
+        ("Qwen/Qwen3-4B-Instruct-2507", "qwen3_instruct", False, no_thinking_messages, no_thinking_reference),
+        ("Qwen/Qwen3-Next-80B-A3B-Instruct", "qwen3_instruct", False, no_thinking_messages, no_thinking_reference),
+    ]
+    tokenizers = {}
+    for model_id, template_name, enable_thinking, messages, reference_messages in cases:
+        if model_id not in tokenizers:
+            tokenizers[model_id] = (
+                AutoTokenizer.from_pretrained(model_id),
+                AutoTokenizer.from_pretrained(model_id),
+            )
+
+        tokenizer, reference_tokenizer = tokenizers[model_id]
+        template = get_template_and_fix_tokenizer(
+            tokenizer,
+            DataArguments(template=template_name, enable_thinking=enable_thinking),
+        )
+        prompt_ids, response_ids = template.encode_oneturn(
+            tokenizer,
+            messages,
+            system=system,
+            tools=json.dumps(tools, ensure_ascii=False),
+        )
+        reference_prompt_ids = reference_tokenizer.apply_chat_template(
+            reference_messages,
+            tools=tools,
+            tokenize=True,
+            add_generation_prompt=True,
+            enable_thinking=enable_thinking,
+        )
+        reference_full_ids = reference_tokenizer.apply_chat_template(
+            [*reference_messages, {"role": "assistant", "content": messages[-1]["content"]}],
+            tools=tools,
+            tokenize=True,
+            add_generation_prompt=False,
+            enable_thinking=enable_thinking,
+        )
+        if is_transformers_version_greater_than("5.0.0"):
+            reference_prompt_ids = reference_prompt_ids["input_ids"]
+            reference_full_ids = reference_full_ids["input_ids"]
+
+        assert prompt_ids == reference_prompt_ids, (model_id, template_name, enable_thinking, "prompt")
+        assert prompt_ids + response_ids == reference_full_ids, (model_id, template_name, enable_thinking, "full")
+
+    history_prompts = {}
+    for template_name, model_id in (
+        ("qwen3", "Qwen/Qwen3-4B"),
+        ("qwen_thinking", "Qwen/Qwen3-4B-Thinking-2507"),
+    ):
+        tokenizer = tokenizers[model_id][0]
+        for preserve_thinking in (False, True):
+            template = get_template_and_fix_tokenizer(
+                tokenizer,
+                DataArguments(
+                    template=template_name,
+                    enable_thinking=True,
+                    preserve_thinking=preserve_thinking,
+                ),
+            )
+            prompt_ids, _ = template.encode_oneturn(
+                tokenizer,
+                thinking_messages,
+                system=system,
+                tools=json.dumps(tools, ensure_ascii=False),
+            )
+            history_prompts[template_name, preserve_thinking] = tokenizer.decode(prompt_ids, skip_special_tokens=False)
+
+        assert "12 + 8 = 20." not in history_prompts[template_name, False]
+        assert "12 + 8 = 20." in history_prompts[template_name, True]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 def test_parse_llama3_template():
     tokenizer = AutoTokenizer.from_pretrained(TINY_LLAMA3)
     template = parse_template(tokenizer)

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -120,8 +120,7 @@ def test_rendering_refactor_preserves_existing_template_boundaries():
     standard = deepcopy(TEMPLATES["falcon_h1"])
     prompt_ids, response_ids = standard.encode_oneturn(tokenizer, messages, system="system")
     assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
-        "<|im_start|>system\nsystem<|im_end|>\n"
-        "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+        "<|im_start|>system\nsystem<|im_end|>\n<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
     )
     assert response_ids == tokenizer.encode("answer<|im_end|>\n")
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -21,7 +21,7 @@ import pytest
 from transformers import AutoTokenizer
 
 from llamafactory.data import get_template_and_fix_tokenizer
-from llamafactory.data.template import TEMPLATES, parse_template
+from llamafactory.data.template import TEMPLATES, ReasoningTemplate, parse_template
 from llamafactory.extras.constants import (
     DEFAULT_TEMPLATE,
     MULTIMODAL_SUPPORTED_MODELS,
@@ -149,6 +149,42 @@ def test_rendering_refactor_preserves_existing_template_boundaries():
         "<start_of_turn>user\nsystem\n\nquestion<end_of_turn>\n<start_of_turn>model\n"
     )
     assert response_ids == tokenizer.encode("answer<end_of_turn>\n")
+
+
+def test_thought_boundary_hook_reports_handled_responses():
+    class ByteTokenizer:
+        bos_token_id = 1000
+        eos_token_id = 1001
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            return list(text.encode())
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    class HookedReasoningTemplate(ReasoningTemplate):
+        def _process_thought_boundaries(self, rendered_messages, messages) -> set[int]:
+            response_index = len(rendered_messages) - 1
+            rendered_messages[response_index][0] = self.add_thought() + rendered_messages[response_index][0]
+            return {response_index}
+
+    template = HookedReasoningTemplate(**vars(deepcopy(TEMPLATES["qwen3"])))
+    template.enable_thinking = True
+    messages = [
+        {"role": "user", "content": "question 1"},
+        {"role": "assistant", "content": "answer 1"},
+        {"role": "user", "content": "question 2"},
+        {"role": "assistant", "content": "answer 2"},
+    ]
+
+    tokenizer = ByteTokenizer()
+    response_ids = template.encode_oneturn(tokenizer, messages)[1]
+    assert response_ids == list((template.add_thought() + "answer 2<|im_end|>\n").encode())
+
+    encoded_pairs = template.encode_multiturn(tokenizer, messages)
+    assert encoded_pairs[0][1] == list((template.add_thought() + "answer 1<|im_end|>\n").encode())
+    assert encoded_pairs[1][1] == list((template.add_thought() + "answer 2<|im_end|>\n").encode())
 
 
 def test_moss_vl_registration():


### PR DESCRIPTION
# What does this PR do?

Aligns the dual-mode Qwen3, Qwen3 Thinking-2507, Qwen3 Instruct-2507, and Qwen3-Next templates with their official Transformers chat templates. The changes separate reasoning-only, non-reasoning, and dual-mode protocols and correct their thinking prefill, prompt/response boundary, and tool-history behavior.

### Affected Model Series and Templates

| Model series | Template |
| --- | --- |
| Dual-mode `Qwen3-*-Thinking` (excluding Thinking-2507) | `qwen3`; `qwen3_nothink` |
| `Qwen3-*-Thinking-2507` | `qwen_thinking` |
| `Qwen3-*-Instruct-2507` | `qwen3_instruct` |
| `Qwen3-Next-80B-A3B-Thinking` | `qwen_thinking` |
| `Qwen3-Next-80B-A3B-Instruct` | `qwen3_instruct` |

This PR depends on #10784 for the shared pre-tokenization hooks. The base defines how model overrides report handled response indices and how `ReasoningTemplate` uses those indices; this PR adds only the Qwen3-specific boundary and history implementations, template registrations, model mappings, and tests.

The regression test compares both the generation-prompt token IDs and the complete prompt-plus-response token IDs with each model's official Transformers `apply_chat_template()` output.

## Introduction

While reviewing issues recently, I found a large number of problems caused by inconsistencies between templates.

This made us realize that these inconsistencies are not isolated incidents, especially for less common models. When users use the official templates provided by these models, such inconsistencies can cause severe mismatches between training and inference, significantly affecting training speed and the inference accuracy of the trained models.

This work consists of two parts:

1. I will use a script to perform large-scale testing on all models using the examples described below. The test will compare the generated text/token sequences across LlamaFactory training, LlamaFactory inference, and vLLM inference using the standard Transformers `chat_template` interface. I will then fix the issues one by one. Since there are many models, the fixes will be submitted in multiple PRs organized by model family to make them easier to review.

2. I will add a consistency-checking mechanism that runs automatically before training. If inconsistencies are detected, it will issue a warning and save the corresponding test examples, but it will not block training. This mechanism will be submitted as a separate PR.

The most common problems can be roughly divided into the following categories:

1. The native LlamaFactory templates do not have sufficiently fine-grained coverage. For example, Qwen3 includes several model variants, such as the Qwen3-8B-Thinking series and the Qwen3-30B-A3B-Thinking-2507 series. Qwen2.5 also includes variants such as Coder and Math. These models have subtle differences: the Qwen3-8B-Thinking series supports both thinking and non-thinking modes, while Qwen3-30B-A3B-Thinking-2507 only supports thinking mode. The official templates for the Coder and Math series also use different system prompts. However, the native system does not distinguish between these variants and applies the same template to all of them.

2. The handling of thinking traces is inconsistent. LlamaFactory provides `mask_history` and `preserve_thinking` to control whether historical thinking traces are removed during training and inference, but it currently uses the generic `remove_thought()` function for all models. In practice, different models require different handling, for example:

   - DeepSeek-R1: remove historical thinking content while preserving the two newlines after the closing tag.
   - GLM-4.5: remove the thinking content while preserving an empty thinking block.
   - Qwen/QwQ: follow the tokenizer-specific rules for historical assistant/tool messages.
   - Hunyuan: preserve or generate the corresponding boundaries according to its tokenizer; a generic removal function cannot be used.

3. The handling of whether the `<think>` tag is generated by the model is inconsistent. In the DeepSeek-R1-*B-Distill series, the `<think>` tag is part of the model output during training and is included in loss computation. During inference, however, the template automatically adds the `<think>` tag as part of the prompt, so the model does not need to generate it.

4. There are also various minor bugs of this kind. I will analyze and fix these issues individually.

### Verified Correct Models

The following models completed template validation and already match their tokenizer chat templates. They do not require a template change in this series of PRs.

- GLM-4-0414-*B-Chat
- Kimi-Dev-*B-Instruct
- Llama-3.1-*B-Chinese-Chat
- Phi-4-*B-Instruct
- Qwen2.5-*B-Instruct (standard, AWQ, GPTQ-Int4, and GPTQ-Int8)
- Qwen2.5-Coder-*B-Instruct
- Seed-Coder-*B-Instruct
- SmolLM-*-Instruct
- Yi-Coder-*B-Chat

### Submit PR List

| PR | Model family or scope | Status |
| --- | --- | --- |
| 1 | `DeepSeek-Coder-*B-Instruct`; `DeepSeek-R1*`; `DeepSeek-LLM-*B-Chat`; `DeepSeek-Math-*B-Instruct` | √ |
| 2 | `GLM-4-0414-*B-Chat`; `GLM-4.5-*Thinking`; `GLM-Z1-0414-*B-Chat` | √ |
| 3 | `Hunyuan-*B-Instruct`; `Hunyuan-MT-*B-Instruct`; `HY-MT1.5-*B-Instruct`; `Hy-MT2-*B-Instruct` | √ |
| 4 | `Qwen2-*`; `Qwen2.5-*-Instruct-1M`; `Qwen2.5-Math-*-Instruct` | √ |
| 5 (current PR) | `Qwen3-*-Instruct-2507`; `Qwen3-*-Thinking*`; `Qwen3-Next-*-Instruct`; `Qwen3-Next-*-Thinking` | √ |
| 6 | `QwQ-32B-Instruct`; `QwQ-32B-Preview-Instruct` | × |
| 7 | `Falcon-H1-*B-*Instruct` | × |
| 8 | `Granite-3.0-*B-A400M-Instruct` | × |
| 9 | `Llama-3-*B-Chinese-Chat` | × |
| 10 | `Yi-6B-Chat`; `Yi-34B-Chat` | × |
| 11 | Automatic pre-training consistency warning | × |

### Planned PR
The validation and correction work described above has already covered 80% of the models. Some model families, such as Qwen 3.5, Gemini, MiniCPM, and MiniMax, could not be completed immediately due to the workload and the need to merge other contributors’ PRs. They will be gradually addressed in follow-up work.


## Models Fixed Diff

### Qwen/Qwen3-*B-Instruct-2507

The original template was already consistent.

### Qwen/Qwen3-*B-Thinking-2507

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system_with_thinking` | <code>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br><span style="background-color: #e6ffec;">&lt;think&gt;<br></span></code> | <code>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;think&gt;<br></code> |
| `single_turn_with_system_and_thinking` | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br><span style="background-color: #e6ffec;">&lt;think&gt;<br></span></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;think&gt;<br></code> |
| `multi_turn_with_system_and_thinking` | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br><span style="background-color: #e6ffec;">&lt;think&gt;<br></span></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;think&gt;<br></code> |
| `tool_call_multi_turn_with_system_and_thinking` | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<br><br>#&nbsp;Tools<br><br>You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;functions&nbsp;to&nbsp;assist&nbsp;with&nbsp;the&nbsp;user&nbsp;query.<br><br>You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;signatures&nbsp;within&nbsp;&lt;tools&gt;&lt;/tools&gt;&nbsp;XML&nbsp;tags:<br>&lt;tools&gt;<br>{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;object&quot;,&nbsp;&quot;properties&quot;:&nbsp;{&quot;city&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;string&quot;}},&nbsp;&quot;required&quot;:&nbsp;[&quot;city&quot;]}}}<br>&lt;/tools&gt;<br><br>For&nbsp;each&nbsp;function&nbsp;call,&nbsp;return&nbsp;a&nbsp;json&nbsp;object&nbsp;with&nbsp;function&nbsp;name&nbsp;and&nbsp;arguments&nbsp;within&nbsp;&lt;tool_call&gt;&lt;/tool_call&gt;&nbsp;XML&nbsp;tags:<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&lt;function-name&gt;,&nbsp;&quot;arguments&quot;:&nbsp;&lt;args-json-object&gt;}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;t<span style="background-color: #e6ffec;">hink&gt;<br>I&nbsp;should&nbsp;use&nbsp;the&nbsp;weather&nbsp;tool&nbsp;for&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris.<br>&lt;/think&gt;<br><br>&lt;t</span>ool_call&gt;<br>{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;arguments&quot;:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>&lt;tool_response&gt;<br>{&quot;temperature_celsius&quot;:21}<br>&lt;/tool_response&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br><span style="background-color: #e6ffec;">&lt;think&gt;<br></span></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<br><br>#&nbsp;Tools<br><br>You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;functions&nbsp;to&nbsp;assist&nbsp;with&nbsp;the&nbsp;user&nbsp;query.<br><br>You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;signatures&nbsp;within&nbsp;&lt;tools&gt;&lt;/tools&gt;&nbsp;XML&nbsp;tags:<br>&lt;tools&gt;<br>{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;object&quot;,&nbsp;&quot;properties&quot;:&nbsp;{&quot;city&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;string&quot;}},&nbsp;&quot;required&quot;:&nbsp;[&quot;city&quot;]}}}<br>&lt;/tools&gt;<br><br>For&nbsp;each&nbsp;function&nbsp;call,&nbsp;return&nbsp;a&nbsp;json&nbsp;object&nbsp;with&nbsp;function&nbsp;name&nbsp;and&nbsp;arguments&nbsp;within&nbsp;&lt;tool_call&gt;&lt;/tool_call&gt;&nbsp;XML&nbsp;tags:<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&lt;function-name&gt;,&nbsp;&quot;arguments&quot;:&nbsp;&lt;args-json-object&gt;}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;arguments&quot;:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>&lt;tool_response&gt;<br>{&quot;temperature_celsius&quot;:21}<br>&lt;/tool_response&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<br><br>#&nbsp;Tools<br><br>You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;functions&nbsp;to&nbsp;assist&nbsp;with&nbsp;the&nbsp;user&nbsp;query.<br><br>You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;signatures&nbsp;within&nbsp;&lt;tools&gt;&lt;/tools&gt;&nbsp;XML&nbsp;tags:<br>&lt;tools&gt;<br>{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;object&quot;,&nbsp;&quot;properties&quot;:&nbsp;{&quot;city&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;string&quot;}},&nbsp;&quot;required&quot;:&nbsp;[&quot;city&quot;]}}}<br>&lt;/tools&gt;<br><br>For&nbsp;each&nbsp;function&nbsp;call,&nbsp;return&nbsp;a&nbsp;json&nbsp;object&nbsp;with&nbsp;function&nbsp;name&nbsp;and&nbsp;arguments&nbsp;within&nbsp;&lt;tool_call&gt;&lt;/tool_call&gt;&nbsp;XML&nbsp;tags:<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&lt;function-name&gt;,&nbsp;&quot;arguments&quot;:&nbsp;&lt;args-json-object&gt;}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;think&gt;<br>I&nbsp;should&nbsp;use&nbsp;the&nbsp;weather&nbsp;tool&nbsp;for&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris.<br>&lt;/think&gt;<br><br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;arguments&quot;:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>&lt;tool_response&gt;<br>{&quot;temperature_celsius&quot;:21}<br>&lt;/tool_response&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;think&gt;<br></code> |

### Qwen/Qwen3-*B

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `tool_call_multi_turn_with_system_and_thinking` | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<br><br>#&nbsp;Tools<br><br>You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;functions&nbsp;to&nbsp;assist&nbsp;with&nbsp;the&nbsp;user&nbsp;query.<br><br>You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;signatures&nbsp;within&nbsp;&lt;tools&gt;&lt;/tools&gt;&nbsp;XML&nbsp;tags:<br>&lt;tools&gt;<br>{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;object&quot;,&nbsp;&quot;properties&quot;:&nbsp;{&quot;city&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;string&quot;}},&nbsp;&quot;required&quot;:&nbsp;[&quot;city&quot;]}}}<br>&lt;/tools&gt;<br><br>For&nbsp;each&nbsp;function&nbsp;call,&nbsp;return&nbsp;a&nbsp;json&nbsp;object&nbsp;with&nbsp;function&nbsp;name&nbsp;and&nbsp;arguments&nbsp;within&nbsp;&lt;tool_call&gt;&lt;/tool_call&gt;&nbsp;XML&nbsp;tags:<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&lt;function-name&gt;,&nbsp;&quot;arguments&quot;:&nbsp;&lt;args-json-object&gt;}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;t<span style="background-color: #e6ffec;">hink&gt;<br>I&nbsp;should&nbsp;use&nbsp;the&nbsp;weather&nbsp;tool&nbsp;for&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris.<br>&lt;/think&gt;<br><br>&lt;t</span>ool_call&gt;<br>{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;arguments&quot;:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>&lt;tool_response&gt;<br>{&quot;temperature_celsius&quot;:21}<br>&lt;/tool_response&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<br><br>#&nbsp;Tools<br><br>You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;functions&nbsp;to&nbsp;assist&nbsp;with&nbsp;the&nbsp;user&nbsp;query.<br><br>You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;signatures&nbsp;within&nbsp;&lt;tools&gt;&lt;/tools&gt;&nbsp;XML&nbsp;tags:<br>&lt;tools&gt;<br>{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;object&quot;,&nbsp;&quot;properties&quot;:&nbsp;{&quot;city&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;string&quot;}},&nbsp;&quot;required&quot;:&nbsp;[&quot;city&quot;]}}}<br>&lt;/tools&gt;<br><br>For&nbsp;each&nbsp;function&nbsp;call,&nbsp;return&nbsp;a&nbsp;json&nbsp;object&nbsp;with&nbsp;function&nbsp;name&nbsp;and&nbsp;arguments&nbsp;within&nbsp;&lt;tool_call&gt;&lt;/tool_call&gt;&nbsp;XML&nbsp;tags:<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&lt;function-name&gt;,&nbsp;&quot;arguments&quot;:&nbsp;&lt;args-json-object&gt;}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;arguments&quot;:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>&lt;tool_response&gt;<br>{&quot;temperature_celsius&quot;:21}<br>&lt;/tool_response&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<br><br>#&nbsp;Tools<br><br>You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;functions&nbsp;to&nbsp;assist&nbsp;with&nbsp;the&nbsp;user&nbsp;query.<br><br>You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;signatures&nbsp;within&nbsp;&lt;tools&gt;&lt;/tools&gt;&nbsp;XML&nbsp;tags:<br>&lt;tools&gt;<br>{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;object&quot;,&nbsp;&quot;properties&quot;:&nbsp;{&quot;city&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;string&quot;}},&nbsp;&quot;required&quot;:&nbsp;[&quot;city&quot;]}}}<br>&lt;/tools&gt;<br><br>For&nbsp;each&nbsp;function&nbsp;call,&nbsp;return&nbsp;a&nbsp;json&nbsp;object&nbsp;with&nbsp;function&nbsp;name&nbsp;and&nbsp;arguments&nbsp;within&nbsp;&lt;tool_call&gt;&lt;/tool_call&gt;&nbsp;XML&nbsp;tags:<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&lt;function-name&gt;,&nbsp;&quot;arguments&quot;:&nbsp;&lt;args-json-object&gt;}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;think&gt;<br>I&nbsp;should&nbsp;use&nbsp;the&nbsp;weather&nbsp;tool&nbsp;for&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris.<br>&lt;/think&gt;<br><br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;arguments&quot;:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>&lt;tool_response&gt;<br>{&quot;temperature_celsius&quot;:21}<br>&lt;/tool_response&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> |

### Qwen/Qwen3-Next-*-Instruct

The original template was already consistent.

### Qwen/Qwen3-Next-*-Thinking

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system_with_thinking` | <code>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br><span style="background-color: #e6ffec;">&lt;think&gt;<br></span></code> | <code>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;think&gt;<br></code> |
| `single_turn_with_system_and_thinking` | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br><span style="background-color: #e6ffec;">&lt;think&gt;<br></span></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;think&gt;<br></code> |
| `multi_turn_with_system_and_thinking` | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br><span style="background-color: #e6ffec;">&lt;think&gt;<br></span></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;think&gt;<br></code> |
| `tool_call_multi_turn_with_system_and_thinking` | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<br><br>#&nbsp;Tools<br><br>You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;functions&nbsp;to&nbsp;assist&nbsp;with&nbsp;the&nbsp;user&nbsp;query.<br><br>You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;signatures&nbsp;within&nbsp;&lt;tools&gt;&lt;/tools&gt;&nbsp;XML&nbsp;tags:<br>&lt;tools&gt;<br>{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;object&quot;,&nbsp;&quot;properties&quot;:&nbsp;{&quot;city&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;string&quot;}},&nbsp;&quot;required&quot;:&nbsp;[&quot;city&quot;]}}}<br>&lt;/tools&gt;<br><br>For&nbsp;each&nbsp;function&nbsp;call,&nbsp;return&nbsp;a&nbsp;json&nbsp;object&nbsp;with&nbsp;function&nbsp;name&nbsp;and&nbsp;arguments&nbsp;within&nbsp;&lt;tool_call&gt;&lt;/tool_call&gt;&nbsp;XML&nbsp;tags:<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&lt;function-name&gt;,&nbsp;&quot;arguments&quot;:&nbsp;&lt;args-json-object&gt;}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;t<span style="background-color: #e6ffec;">hink&gt;<br>I&nbsp;should&nbsp;use&nbsp;the&nbsp;weather&nbsp;tool&nbsp;for&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris.<br>&lt;/think&gt;<br><br>&lt;t</span>ool_call&gt;<br>{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;arguments&quot;:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>&lt;tool_response&gt;<br>{&quot;temperature_celsius&quot;:21}<br>&lt;/tool_response&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br><span style="background-color: #e6ffec;">&lt;think&gt;<br></span></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<br><br>#&nbsp;Tools<br><br>You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;functions&nbsp;to&nbsp;assist&nbsp;with&nbsp;the&nbsp;user&nbsp;query.<br><br>You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;signatures&nbsp;within&nbsp;&lt;tools&gt;&lt;/tools&gt;&nbsp;XML&nbsp;tags:<br>&lt;tools&gt;<br>{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;object&quot;,&nbsp;&quot;properties&quot;:&nbsp;{&quot;city&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;string&quot;}},&nbsp;&quot;required&quot;:&nbsp;[&quot;city&quot;]}}}<br>&lt;/tools&gt;<br><br>For&nbsp;each&nbsp;function&nbsp;call,&nbsp;return&nbsp;a&nbsp;json&nbsp;object&nbsp;with&nbsp;function&nbsp;name&nbsp;and&nbsp;arguments&nbsp;within&nbsp;&lt;tool_call&gt;&lt;/tool_call&gt;&nbsp;XML&nbsp;tags:<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&lt;function-name&gt;,&nbsp;&quot;arguments&quot;:&nbsp;&lt;args-json-object&gt;}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;arguments&quot;:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>&lt;tool_response&gt;<br>{&quot;temperature_celsius&quot;:21}<br>&lt;/tool_response&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<br><br>#&nbsp;Tools<br><br>You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;functions&nbsp;to&nbsp;assist&nbsp;with&nbsp;the&nbsp;user&nbsp;query.<br><br>You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;signatures&nbsp;within&nbsp;&lt;tools&gt;&lt;/tools&gt;&nbsp;XML&nbsp;tags:<br>&lt;tools&gt;<br>{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;object&quot;,&nbsp;&quot;properties&quot;:&nbsp;{&quot;city&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;string&quot;}},&nbsp;&quot;required&quot;:&nbsp;[&quot;city&quot;]}}}<br>&lt;/tools&gt;<br><br>For&nbsp;each&nbsp;function&nbsp;call,&nbsp;return&nbsp;a&nbsp;json&nbsp;object&nbsp;with&nbsp;function&nbsp;name&nbsp;and&nbsp;arguments&nbsp;within&nbsp;&lt;tool_call&gt;&lt;/tool_call&gt;&nbsp;XML&nbsp;tags:<br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&lt;function-name&gt;,&nbsp;&quot;arguments&quot;:&nbsp;&lt;args-json-object&gt;}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;think&gt;<br>I&nbsp;should&nbsp;use&nbsp;the&nbsp;weather&nbsp;tool&nbsp;for&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris.<br>&lt;/think&gt;<br><br>&lt;tool_call&gt;<br>{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;arguments&quot;:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>&lt;tool_response&gt;<br>{&quot;temperature_celsius&quot;:21}<br>&lt;/tool_response&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;think&gt;<br></code> |


## Models Fixed in This PR

**Standard Dual-Mode Qwen3 Series**

**Affected Model Names**

- Qwen3-0.6B-Thinking
- Qwen3-1.7B-Thinking
- Qwen3-4B-Thinking
- Qwen3-8B-Thinking
- Qwen3-14B-Thinking
- Qwen3-32B-Thinking
- Qwen3-30B-A3B-Thinking
- Qwen3-235B-A22B-Thinking
- Qwen3-0.6B-Thinking-GPTQ-Int8
- Qwen3-1.7B-Thinking-GPTQ-Int8
- Qwen3-4B-Thinking-AWQ
- Qwen3-8B-Thinking-AWQ
- Qwen3-14B-Thinking-AWQ
- Qwen3-32B-Thinking-AWQ
- Qwen3-30B-A3B-Thinking-GPTQ-Int4
- Qwen3-235B-A22B-Thinking-GPTQ-Int4

**Background**

In a completed history, Qwen3 removes reasoning before the final user turn but preserves reasoning in the active function-call chain after that user. When a dual-mode tokenizer runs without thinking, it pre-fills an empty thinking block.

**Root Cause**

The generic history cleanup removed reasoning by fixed message positions and could not distinguish completed history from the active tool chain. The previous `qwen3_nothink` implementation also tried to infer empty-thinking prefill behavior by inspecting the tokenizer's Jinja text, which made the result depend on the tokenizer file rather than the selected template.

**Solution**

1. `QwenThinkingHistoryMixin` overrides the shared history hook from #10784 so `qwen3` removes reasoning before the final user while retaining reasoning in the active tool chain. Its latest-user lookup uses `default=-1`, so conversations without a user message have no inferred history boundary and cannot raise `ValueError`. The user's `data_args.preserve_thinking` remains the only effective configuration.
2. `qwen3_nothink` does not support thinking and pre-fills an empty thinking block only at the generation boundary, without adding one to completed historical responses. `qwen3_instruct` does not support thinking and does not add a thinking block.
3. `qwen3` follows the user's `enable_thinking` setting. With `True`, thinking remains part of the model response and no empty block is prefilled in the prompt. With `False`, reasoning is removed and an empty thinking block is prefilled in the prompt.
4. The Qwen templates modify rendered formatter elements before tokenization and return the response indices whose thought boundaries they handled. `ReasoningTemplate` applies its default empty-thinking insertion only to response indices not returned by the override; the Qwen implementations no longer write markers into the source messages to control that decision.
5. These behaviors are selected by the LlamaFactory template and user configuration without inspecting or storing the tokenizer's Jinja template.

**Qwen3-\*B-Thinking-2507 Series**

**Affected Model Names**

- Qwen3-4B-Thinking-2507
- Qwen3-30B-A3B-Thinking-2507
- Qwen3-235B-A22B-Thinking-2507

**Background**

Thinking-2507 tokenizers are reasoning-only. They place the opening thinking marker in the generation prompt and use the same active-tool-chain history rule as Qwen3.

**Root Cause**

These entries in `src/llamafactory/extras/constants.py` shared the dual-mode `qwen3` template, which left the opening marker in the response target.

**Solution**

1. `QwenPrefilledThinkingTemplate` moves the opening thinking marker from the assistant response formatter slot to the preceding prompt slot before tokenization and returns the handled response index. No token IDs are decoded or re-encoded.
2. Register the reasoning-only `qwen_thinking` template with the same active-tool-chain history handling as Qwen3.
3. In `src/llamafactory/extras/constants.py`, move all three Thinking-2507 entries to `qwen_thinking`.

**Qwen3-\*B-Instruct-2507 Series**

**Affected Model Names**

- Qwen3-4B-Instruct-2507
- Qwen3-30B-A3B-Instruct-2507
- Qwen3-235B-A22B-Instruct-2507

**Background**

Instruct-2507 tokenizers are non-reasoning-only and emit neither an opening marker nor an empty thinking block.

**Root Cause**

The entries in `src/llamafactory/extras/constants.py` used `qwen3_nothink`, which must also support the disabled-thinking mode of dual-mode Qwen3 tokenizers.

**Solution**

1. In `src/llamafactory/data/template.py`, add the plain `qwen3_instruct` registration with the existing Qwen role and tool formatters.
2. In `src/llamafactory/extras/constants.py`, move all three Instruct-2507 entries to `qwen3_instruct`.
3. Keep this non-reasoning template separate from the explicit empty-thinking behavior of `qwen3_nothink`.

**Qwen3-Next-80B-A3B Series**

**Affected Model Names**

- Qwen3-Next-80B-A3B-Thinking
- Qwen3-Next-80B-A3B-Instruct

**Background**

The Thinking model is reasoning-only and requires prompt prefill plus active-tool-chain history handling. The Instruct model is non-reasoning-only. The supported-model key for the Thinking entry also incorrectly contained the repository namespace.

**Root Cause**

`src/llamafactory/extras/constants.py` assigned the Thinking model to `qwen3`, the Instruct model to the shared disabled-thinking path, and used `Qwen/Qwen3-Next-80B-A3B-Thinking` as the display key.

**Solution**

1. Map Qwen3-Next-Thinking to `qwen_thinking` in `src/llamafactory/extras/constants.py`.
2. Map Qwen3-Next-Instruct to `qwen3_instruct`.
3. Rename the Thinking display key to `Qwen3-Next-80B-A3B-Thinking` while keeping the repository source unchanged.

## Unit Tests

`test_qwen3_nothink_processes_only_generation_boundary()` verifies that the empty-thinking prefill is added only to the generation boundary and not to completed historical responses. `test_qwen3_family_template_consistency()` verifies the model-to-template mappings and compares representative tool conversations with thinking enabled and disabled. For every representative model, it checks both the generation-prompt IDs and `prompt_ids + response_ids` against the official Transformers encoding, so the prompt/label boundary and the full token sequence are covered. It also verifies Qwen3 history handling with `preserve_thinking` enabled and disabled.

```bash
pytest -q \
  tests/data/test_template.py::test_qwen3_nothink_processes_only_generation_boundary \
  tests/data/test_template.py::test_qwen3_family_template_consistency
```


## About Test Samples

Models are classified as reasoning-only, non-reasoning-only, or dual-mode. Reasoning-only models use the reasoning sample, non-reasoning-only models use the non-reasoning sample, and dual-mode models use both. Each sample covers a single turn without a system prompt, a single turn with a system prompt, multi-turn dialogue with a system prompt, and multi-turn tool use with a system prompt. 

Specific test examples will be elaborated in the consistency-checking mechanism PR.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
