### PR TITLE
fix: align Falcon-H1 chat templates with Transformers

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -453,6 +453,24 @@ class Llama2Template(Template):
 
 
 @dataclass
+class FalconH1Template(Template):
+    r"""Falcon-H1 keeps tool instructions in an unterminated system turn."""
+
+    @override
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
+        if not tools:
+            return None
+
+        tool_text = self.format_tools.apply(content=tools)[0]
+        elements = ["<|im_start|>system\n"]
+        if system:
+            elements.append(system + "\n\n")
+
+        elements.append(tool_text)
+        return elements
+
+
+@dataclass
 class ReasoningTemplate(Template):
     r"""A template that add thought to assistant message."""
 
@@ -1010,9 +1028,12 @@ register_template(
     format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
     format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),
     format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
+    format_function=FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="falcon_h1"),
     format_observation=StringFormatter(slots=["<|im_start|>tool\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
+    format_tools=ToolFormatter(tool_format="falcon_h1"),
     format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
     stop_words=["<|im_end|>", "<|end_of_text|>"],
+    template_class=FalconH1Template,
 )
 
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -65,7 +65,7 @@ class Template:
         tools: Optional[str] = None,
     ) -> tuple[list[int], list[int]]:
         r"""Return a single pair of token ids representing prompt and response respectively."""
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, _ = self._encode(tokenizer, messages, system, tools)
         prompt_ids = []
         for encoded_ids in encoded_messages[:-1]:
             prompt_ids += encoded_ids
@@ -82,7 +82,7 @@ class Template:
         discarding_history_cot: bool = False,  # only effect reasoning template
     ) -> list[tuple[list[int], list[int]]]:
         r"""Return multiple pairs of token ids representing prompts and responses respectively."""
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, _ = self._encode(tokenizer, messages, system, tools)
         return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(0, len(encoded_messages), 2)]
 
     def extract_tool(self, content: str) -> Union[str, list["FunctionCall"]]:
@@ -135,7 +135,7 @@ class Template:
         messages: list[dict[str, str]],
         system: Optional[str],
         tools: Optional[str],
-    ) -> list[list[int]]:
+    ) -> tuple[list[list[int]], set[int]]:
         r"""Encode formatted inputs to pairs of token ids.
 
         Turn 0: prefix + system + query        resp
@@ -147,15 +147,17 @@ class Template:
 
         rendered_messages = self._render(messages, system, tools)
         self._process_rendered_messages(rendered_messages, messages)
-        return [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+        processed_response_indices = self._process_thought_boundaries(rendered_messages, messages)
+        encoded_messages = [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+        return encoded_messages, processed_response_indices
 
     def _process_messages(self, messages: list[dict[str, str]]) -> Optional[list[dict[str, str]]]:
         r"""Return model-specific messages before rendering, or use the original messages."""
-        pass
+        return None
 
     def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
         r"""Return model-specific system and tool elements, or use the default formatter."""
-        pass
+        return None
 
     def _render(
         self,
@@ -200,7 +202,13 @@ class Template:
         self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
     ) -> None:
         r"""Apply model-specific changes to formatter output before tokenization."""
-        pass
+        return None
+
+    def _process_thought_boundaries(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> set[int]:
+        r"""Process model-specific thought boundaries and return the handled response indices."""
+        return set()
 
     @staticmethod
     def _add_or_replace_eos_token(tokenizer: "PreTrainedTokenizer", eos_token: str) -> None:
@@ -452,7 +460,7 @@ class ReasoningTemplate(Template):
 
     def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
         r"""Process model-specific historical reasoning and return whether it was handled."""
-        pass
+        return False
 
     @override
     def encode_oneturn(
@@ -470,8 +478,14 @@ class ReasoningTemplate(Template):
         if self.enable_thinking is False:  # remove all cot
             messages[-1]["content"] = self.remove_thought(messages[-1]["content"])
 
-        prompt_ids, response_ids = super().encode_oneturn(tokenizer, messages, system, tools)
-        if (
+        encoded_messages, processed_response_indices = self._encode(tokenizer, messages, system, tools)
+        prompt_ids = []
+        for encoded_ids in encoded_messages[:-1]:
+            prompt_ids += encoded_ids
+
+        response_index = len(encoded_messages) - 1
+        response_ids = encoded_messages[response_index]
+        if response_index not in processed_response_indices and (
             self.thought_words[0].strip() not in messages[-1]["content"]
             and self.thought_words[1].strip() not in messages[-1]["content"]
         ):  # add empty cot
@@ -500,14 +514,14 @@ class ReasoningTemplate(Template):
             for i in range(1, len(messages) - 2, 2):  # preserve the last cot
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, processed_response_indices = self._encode(tokenizer, messages, system, tools)
         if discarding_history_cot:
             turn_indices = [len(messages) - 2]
         else:
             turn_indices = range(0, len(messages), 2)
 
         for i in turn_indices:
-            if (
+            if i + 1 not in processed_response_indices and (
                 self.thought_words[0].strip() not in messages[i + 1]["content"]
                 and self.thought_words[1].strip() not in messages[i + 1]["content"]
             ):  # add empty cot

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -141,16 +141,43 @@ class Template:
         Turn 0: prefix + system + query        resp
         Turn t: query                          resp.
         """
+        processed_messages = self._process_messages(messages)
+        if processed_messages is not None:
+            messages = processed_messages
+
+        rendered_messages = self._render(messages, system, tools)
+        self._process_rendered_messages(rendered_messages, messages)
+        return [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+
+    def _process_messages(self, messages: list[dict[str, str]]) -> Optional[list[dict[str, str]]]:
+        r"""Return model-specific messages before rendering, or use the original messages."""
+        pass
+
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
+        r"""Return model-specific system and tool elements, or use the default formatter."""
+        pass
+
+    def _render(
+        self,
+        messages: list[dict[str, str]],
+        system: Optional[str],
+        tools: Optional[str],
+    ) -> list["SLOTS"]:
+        r"""Render messages into formatter elements before tokenization."""
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
             if i == 0:
                 elements += self.format_prefix.apply()
                 if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    elements += self.format_system.apply(content=(system + tool_text))
+                    system_and_tools = self._format_system_and_tools(system, tools)
+                    if system_and_tools is None:
+                        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+                        system_and_tools = self.format_system.apply(content=(system + tool_text))
+
+                    elements += system_and_tools
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
@@ -165,9 +192,15 @@ class Template:
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
+
+    def _process_rendered_messages(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> None:
+        r"""Apply model-specific changes to formatter output before tokenization."""
+        pass
 
     @staticmethod
     def _add_or_replace_eos_token(tokenizer: "PreTrainedTokenizer", eos_token: str) -> None:
@@ -336,45 +369,12 @@ class Template:
 @dataclass
 class MossVLTemplate(Template):
     @override
-    def _encode(
-        self,
-        tokenizer: "PreTrainedTokenizer",
-        messages: list[dict[str, str]],
-        system: Optional[str],
-        tools: Optional[str],
-    ) -> list[list[int]]:
-        system = system or self.default_system
-        encoded_messages = []
-        for i, message in enumerate(messages):
-            elements = []
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> "SLOTS":
+        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+        if tools and not system:
+            tool_text = tool_text.lstrip("\n")
 
-            if i == 0:
-                elements += self.format_prefix.apply()
-                if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    if tools and not system:
-                        tool_text = tool_text.lstrip("\n")
-
-                    elements += self.format_system.apply(content=(system + tool_text))
-
-            if message["role"] == Role.USER:
-                elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
-            elif message["role"] == Role.ASSISTANT:
-                elements += self.format_assistant.apply(content=message["content"])
-            elif message["role"] == Role.OBSERVATION:
-                elements += self.format_observation.apply(content=message["content"])
-            elif message["role"] == Role.FUNCTION:
-                elements += self.format_function.apply(
-                    content=message["content"],
-                    thought_words=self.thought_words,
-                    tool_call_words=self.tool_call_words,
-                )
-            else:
-                raise NotImplementedError("Unexpected role: {}".format(message["role"]))
-
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
-
-        return encoded_messages
+        return self.format_system.apply(content=(system + tool_text))
 
 
 @dataclass
@@ -382,15 +382,14 @@ class Llama2Template(Template):
     r"""A template that fuse the system message to first user message."""
 
     @override
-    def _encode(
+    def _render(
         self,
-        tokenizer: "PreTrainedTokenizer",
         messages: list[dict[str, str]],
         system: str,
         tools: str,
-    ) -> list[list[int]]:
+    ) -> list["SLOTS"]:
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
@@ -412,9 +411,9 @@ class Llama2Template(Template):
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
 
     def _get_jinja_template(self, tokenizer: "PreTrainedTokenizer") -> str:
         prefix = self._convert_slots_to_jinja(self.format_prefix.apply(), tokenizer)
@@ -451,6 +450,10 @@ class Llama2Template(Template):
 class ReasoningTemplate(Template):
     r"""A template that add thought to assistant message."""
 
+    def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
+        r"""Process model-specific historical reasoning and return whether it was handled."""
+        pass
+
     @override
     def encode_oneturn(
         self,
@@ -460,7 +463,7 @@ class ReasoningTemplate(Template):
         tools: Optional[str] = None,
     ) -> tuple[list[int], list[int]]:
         messages = deepcopy(messages)
-        if not self.preserve_thinking:
+        if not self.preserve_thinking and not self._process_history_thoughts(messages, is_inference=True):
             for i in range(1, len(messages) - 2, 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
@@ -493,7 +496,7 @@ class ReasoningTemplate(Template):
             for i in range(1, len(messages), 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
-        if discarding_history_cot:
+        if discarding_history_cot and not self._process_history_thoughts(messages, is_inference=False):
             for i in range(1, len(messages) - 2, 2):  # preserve the last cot
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -198,9 +198,7 @@ class Template:
 
         return rendered_messages
 
-    def _process_rendered_messages(
-        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
-    ) -> None:
+    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
         r"""Apply model-specific changes to formatter output before tokenization."""
         return None
 

--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -644,12 +644,10 @@ class FalconH1ToolUtils(QwenToolUtils):
     @override
     @staticmethod
     def tool_formatter(tools: list[dict[str, Any]]) -> str:
-        tool_texts = []
-        for tool in tools:
-            wrapped_tool = tool if tool.get("type") == "function" else {"type": "function", "function": tool}
-            tool_texts.append(f"[{json.dumps(wrapped_tool, ensure_ascii=False)}]")
-
-        return FALCON_H1_TOOL_PROMPT.format(tool_text="".join(tool_texts))
+        wrapped_tools = [
+            tool if tool.get("type") == "function" else {"type": "function", "function": tool} for tool in tools
+        ]
+        return FALCON_H1_TOOL_PROMPT.format(tool_text=json.dumps(wrapped_tools, ensure_ascii=False))
 
     @override
     @staticmethod

--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -38,6 +38,14 @@ DEFAULT_TOOL_PROMPT = (
     "```\n"
 )
 
+FALCON_H1_TOOL_PROMPT = (
+    "You are a function calling AI model. You are provided with function signature within <tools> </tools> XML tags. "
+    "You may call one or more functions to assist with the user query. Don't make assumptions about what values to "
+    "plug into functions.\n<tools>\n{tool_text}\n</tools>\nFor each function call, return a json object with function "
+    "name and arguments within <tool_call> </tool_call> tags with the following schema:\n<tool_call>\n"
+    "{{'arguments': <args-dict>, 'name': <function-name>}}\n</tool_call>\n"
+)
+
 GLM4_TOOL_PROMPT = (
     "你是一个名为 ChatGLM 的人工智能助手。你是基于智谱 AI 公司训练的语言模型 GLM-4 模型开发的，"
     "你的任务是针对用户的问题和要求提供适当的答复和支持。\n\n# 可用工具{tool_text}"
@@ -630,6 +638,29 @@ class QwenToolUtils(ToolUtils):
         return results
 
 
+class FalconH1ToolUtils(QwenToolUtils):
+    r"""Falcon-H1 tool format used by its official chat template."""
+
+    @override
+    @staticmethod
+    def tool_formatter(tools: list[dict[str, Any]]) -> str:
+        tool_texts = []
+        for tool in tools:
+            wrapped_tool = tool if tool.get("type") == "function" else {"type": "function", "function": tool}
+            tool_texts.append(f"[{json.dumps(wrapped_tool, ensure_ascii=False)}]")
+
+        return FALCON_H1_TOOL_PROMPT.format(tool_text="".join(tool_texts))
+
+    @override
+    @staticmethod
+    def function_formatter(functions: list["FunctionCall"]) -> str:
+        function_texts = [
+            json.dumps({"arguments": json.loads(arguments), "name": name}, ensure_ascii=False)
+            for name, arguments in functions
+        ]
+        return "\n".join([f"<tool_call>\n{text}\n</tool_call>" for text in function_texts])
+
+
 class Qwen35ToolUtils(ToolUtils):
     r"""Qwen 3.5 tool using template."""
 
@@ -883,6 +914,7 @@ class LFM2ToolUtils(ToolUtils):
 
 TOOLS = {
     "default": DefaultToolUtils(),
+    "falcon_h1": FalconH1ToolUtils(),
     "gemma4": Gemma4ToolUtils(),
     "glm4": GLM4ToolUtils(),
     "llama3": Llama3ToolUtils(),

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import pytest
@@ -95,6 +97,58 @@ def _check_template(
     assert content_str == prompt_str + answer_str
     assert content_ids == prompt_ids + answer_ids
     _check_tokenization(tokenizer, (prompt_ids, answer_ids), (prompt_str, answer_str))
+
+
+def test_rendering_refactor_preserves_existing_template_boundaries():
+    class ByteTokenizer:
+        bos_token_id = 1000
+        eos_token_id = 1001
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            return list(text.encode())
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    tokenizer = ByteTokenizer()
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+
+    standard = deepcopy(TEMPLATES["falcon_h1"])
+    prompt_ids, response_ids = standard.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<|im_start|>system\nsystem<|im_end|>\n"
+        "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    tools = json.dumps(
+        [
+            {
+                "name": "search",
+                "description": "Search documents.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            }
+        ]
+    )
+    moss_vl = deepcopy(TEMPLATES["moss_vl"])
+    prompt_ids, response_ids = moss_vl.encode_oneturn(tokenizer, messages, tools=tools)
+    tool_text = moss_vl.format_tools.apply(content=tools)[0].lstrip("\n")
+    assert prompt_ids == tokenizer.encode(
+        moss_vl.format_system.apply(content=tool_text)[0]
+        + "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    llama2 = deepcopy(TEMPLATES["gemma"])
+    prompt_ids, response_ids = llama2.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<start_of_turn>user\nsystem\n\nquestion<end_of_turn>\n<start_of_turn>model\n"
+    )
+    assert response_ids == tokenizer.encode("answer<end_of_turn>\n")
 
 
 def test_moss_vl_registration():

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -428,6 +428,106 @@ def test_phi4_template():
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_falcon_h1_template_consistency():
+    instruct_models = [
+        "Falcon-H1-0.5B-Instruct",
+        "Falcon-H1-1.5B-Instruct",
+        "Falcon-H1-1.5B-Deep-Instruct",
+        "Falcon-H1-3B-Instruct",
+        "Falcon-H1-7B-Instruct",
+        "Falcon-H1-34B-Instruct",
+    ]
+    base_models = [
+        "Falcon-H1-0.5B-Base",
+        "Falcon-H1-1.5B-Base",
+        "Falcon-H1-1.5B-Deep-Base",
+        "Falcon-H1-3B-Base",
+        "Falcon-H1-7B-Base",
+        "Falcon-H1-34B-Base",
+    ]
+    for model_name in instruct_models:
+        assert DEFAULT_TEMPLATE[model_name] == "falcon_h1"
+    for model_name in base_models:
+        assert model_name not in DEFAULT_TEMPLATE
+
+    assert TEMPLATES["falcon_h1"].__class__.__name__ == "FalconH1Template"
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_temperature",
+                "description": "Get the current temperature for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    system = "You are a helpful weather assistant. Use the available tools when needed."
+    observation = '{"temperature_celsius":21}'
+    function_call = '<tool_call>{"name":"get_current_temperature","arguments":{"city":"Paris"}}</tool_call>'
+    no_tool_messages = [
+        {"role": "user", "content": "What is 17 multiplied by 24?"},
+        {"role": "assistant", "content": "408"},
+    ]
+    tool_messages = [
+        {"role": "user", "content": "What is the current temperature in Paris?"},
+        {"role": "function", "content": function_call},
+        {"role": "observation", "content": observation},
+        {"role": "assistant", "content": "It is 21 degrees Celsius."},
+    ]
+    tool_call_text = '<tool_call>\n{"arguments": {"city": "Paris"}, "name": "get_current_temperature"}\n</tool_call>'
+    cases = [
+        (
+            no_tool_messages,
+            [
+                {"role": "system", "content": system},
+                {"role": "user", "content": "What is 17 multiplied by 24?"},
+            ],
+            None,
+        ),
+        (
+            tool_messages,
+            [
+                {"role": "system", "content": system},
+                {"role": "user", "content": "What is the current temperature in Paris?"},
+                {"role": "assistant", "content": tool_call_text},
+                {"role": "tool", "content": observation},
+            ],
+            tools,
+        ),
+    ]
+
+    tokenizer = AutoTokenizer.from_pretrained("tiiuae/Falcon-H1-0.5B-Instruct")
+    reference_tokenizer = AutoTokenizer.from_pretrained("tiiuae/Falcon-H1-0.5B-Instruct")
+    template = get_template_and_fix_tokenizer(tokenizer, DataArguments(template="falcon_h1"))
+    extracted_calls = template.extract_tool(tool_call_text)
+    assert len(extracted_calls) == 1
+    assert extracted_calls[0].name == "get_current_temperature"
+    assert json.loads(extracted_calls[0].arguments) == {"city": "Paris"}
+    for messages, reference_messages, case_tools in cases:
+        prompt_ids, _ = template.encode_oneturn(
+            tokenizer,
+            messages,
+            system=system,
+            tools=json.dumps(case_tools, ensure_ascii=False) if case_tools else None,
+        )
+        reference_ids = reference_tokenizer.apply_chat_template(
+            reference_messages,
+            tools=case_tools,
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+        if is_transformers_version_greater_than("5.0.0"):
+            reference_ids = reference_ids["input_ids"]
+
+        assert prompt_ids == reference_ids, bool(case_tools)
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 @pytest.mark.xfail(not HF_TOKEN, reason="Authorization.")
 def test_qwen2_5_template():
     prompt_str = (

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -120,8 +120,7 @@ def test_rendering_refactor_preserves_existing_template_boundaries():
     standard = deepcopy(TEMPLATES["falcon_h1"])
     prompt_ids, response_ids = standard.encode_oneturn(tokenizer, messages, system="system")
     assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
-        "<|im_start|>system\nsystem<|im_end|>\n"
-        "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+        "<|im_start|>system\nsystem<|im_end|>\n<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
     )
     assert response_ids == tokenizer.encode("answer<|im_end|>\n")
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -21,7 +21,7 @@ import pytest
 from transformers import AutoTokenizer
 
 from llamafactory.data import get_template_and_fix_tokenizer
-from llamafactory.data.template import TEMPLATES, parse_template
+from llamafactory.data.template import TEMPLATES, ReasoningTemplate, parse_template
 from llamafactory.extras.constants import (
     DEFAULT_TEMPLATE,
     MULTIMODAL_SUPPORTED_MODELS,
@@ -149,6 +149,42 @@ def test_rendering_refactor_preserves_existing_template_boundaries():
         "<start_of_turn>user\nsystem\n\nquestion<end_of_turn>\n<start_of_turn>model\n"
     )
     assert response_ids == tokenizer.encode("answer<end_of_turn>\n")
+
+
+def test_thought_boundary_hook_reports_handled_responses():
+    class ByteTokenizer:
+        bos_token_id = 1000
+        eos_token_id = 1001
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            return list(text.encode())
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    class HookedReasoningTemplate(ReasoningTemplate):
+        def _process_thought_boundaries(self, rendered_messages, messages) -> set[int]:
+            response_index = len(rendered_messages) - 1
+            rendered_messages[response_index][0] = self.add_thought() + rendered_messages[response_index][0]
+            return {response_index}
+
+    template = HookedReasoningTemplate(**vars(deepcopy(TEMPLATES["qwen3"])))
+    template.enable_thinking = True
+    messages = [
+        {"role": "user", "content": "question 1"},
+        {"role": "assistant", "content": "answer 1"},
+        {"role": "user", "content": "question 2"},
+        {"role": "assistant", "content": "answer 2"},
+    ]
+
+    tokenizer = ByteTokenizer()
+    response_ids = template.encode_oneturn(tokenizer, messages)[1]
+    assert response_ids == list((template.add_thought() + "answer 2<|im_end|>\n").encode())
+
+    encoded_pairs = template.encode_multiturn(tokenizer, messages)
+    assert encoded_pairs[0][1] == list((template.add_thought() + "answer 1<|im_end|>\n").encode())
+    assert encoded_pairs[1][1] == list((template.add_thought() + "answer 2<|im_end|>\n").encode())
 
 
 def test_moss_vl_registration():

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -508,6 +508,17 @@ def test_falcon_h1_template_consistency():
     assert len(extracted_calls) == 1
     assert extracted_calls[0].name == "get_current_temperature"
     assert json.loads(extracted_calls[0].arguments) == {"city": "Paris"}
+    second_tool = {
+        "type": "function",
+        "function": {
+            "name": "get_current_time",
+            "description": "Get the current time for a city.",
+            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+        },
+    }
+    rendered_tools = template.format_tools.apply(content=json.dumps([*tools, second_tool], ensure_ascii=False))[0]
+    serialized_tools = rendered_tools.split("<tools>\n", maxsplit=1)[1].split("\n</tools>", maxsplit=1)[0]
+    assert json.loads(serialized_tools) == [*tools, second_tool]
     for messages, reference_messages, case_tools in cases:
         prompt_ids, _ = template.encode_oneturn(
             tokenizer,


### PR DESCRIPTION
# What does this PR do?

Aligns Falcon-H1 Instruct tool-use prompts with the official Transformers chat template while preserving the existing no-tool ChatML path.

### Affected Model Series and Templates

| Model series | Template |
| --- | --- |
| `Falcon-H1-{0.5B,1.5B,1.5B-Deep,3B,7B,34B}-Instruct` | `falcon_h1` |

Falcon-H1 Base models remain without a default template.

This PR depends on #10784 for the shared system-and-tools rendering hook. It adds only the Falcon-H1-specific override, tool formatter, registration changes, and tests on top of that base.

The regression test compares no-tool and tool-enabled prompt IDs with the official Falcon-H1 tokenizer and verifies native tool-call extraction.

## Introduction

While reviewing issues recently, I found a large number of problems caused by inconsistencies between templates.

This made us realize that these inconsistencies are not isolated incidents, especially for less common models. When users use the official templates provided by these models, such inconsistencies can cause severe mismatches between training and inference, significantly affecting training speed and the inference accuracy of the trained models.

This work consists of two parts:

1. I will use a script to perform large-scale testing on all models using the examples described below. The test will compare the generated text/token sequences across LlamaFactory training, LlamaFactory inference, and vLLM inference using the standard Transformers `chat_template` interface. I will then fix the issues one by one. Since there are many models, the fixes will be submitted in multiple PRs organized by model family to make them easier to review.

2. I will add a consistency-checking mechanism that runs automatically before training. If inconsistencies are detected, it will issue a warning and save the corresponding test examples, but it will not block training. This mechanism will be submitted as a separate PR.

The most common problems can be roughly divided into the following categories:

1. The native LlamaFactory templates do not have sufficiently fine-grained coverage. For example, Qwen3 includes several model variants, such as the Qwen3-8B-Thinking series and the Qwen3-30B-A3B-Thinking-2507 series. Qwen2.5 also includes variants such as Coder and Math. These models have subtle differences: the Qwen3-8B-Thinking series supports both thinking and non-thinking modes, while Qwen3-30B-A3B-Thinking-2507 only supports thinking mode. The official templates for the Coder and Math series also use different system prompts. However, the native system does not distinguish between these variants and applies the same template to all of them.

2. The handling of thinking traces is inconsistent. LlamaFactory provides `mask_history` and `preserve_thinking` to control whether historical thinking traces are removed during training and inference, but it currently uses the generic `remove_thought()` function for all models. In practice, different models require different handling, for example:

   - DeepSeek-R1: remove historical thinking content while preserving the two newlines after the closing tag.
   - GLM-4.5: remove the thinking content while preserving an empty thinking block.
   - Qwen/QwQ: follow the tokenizer-specific rules for historical assistant/tool messages.
   - Hunyuan: preserve or generate the corresponding boundaries according to its tokenizer; a generic removal function cannot be used.

3. The handling of whether the `<think>` tag is generated by the model is inconsistent. In the DeepSeek-R1-*B-Distill series, the `<think>` tag is part of the model output during training and is included in loss computation. During inference, however, the template automatically adds the `<think>` tag as part of the prompt, so the model does not need to generate it.

4. There are also various minor bugs of this kind. I will analyze and fix these issues individually.

### Verified Correct Models

The following models completed template validation and already match their tokenizer chat templates. They do not require a template change in this series of PRs.

- GLM-4-0414-*B-Chat
- Kimi-Dev-*B-Instruct
- Llama-3.1-*B-Chinese-Chat
- Phi-4-*B-Instruct
- Qwen2.5-*B-Instruct (standard, AWQ, GPTQ-Int4, and GPTQ-Int8)
- Qwen2.5-Coder-*B-Instruct
- Qwen3-*-Instruct-2507
- Qwen3-*-Thinking* (excluding the 2507-only thinking series)
- Qwen3-Next-80B-A3B-Instruct
- Seed-Coder-*B-Instruct
- SmolLM-*-Instruct
- Yi-Coder-*B-Chat

### Submit PR List

| PR | Model family or scope | Status |
| --- | --- | --- |
| 1 | `DeepSeek-Coder-*B-Instruct`; `DeepSeek-R1*`; `DeepSeek-LLM-*B-Chat`; `DeepSeek-Math-*B-Instruct` | √ |
| 2 | `GLM-4-0414-*B-Chat`; `GLM-4.5-*Thinking`; `GLM-Z1-0414-*B-Chat` | √ |
| 3 | `Hunyuan-*B-Instruct`; `Hunyuan-MT-*B-Instruct`; `HY-MT1.5-*B-Instruct`; `Hy-MT2-*B-Instruct` | √ |
| 4 | `Qwen2-*`; `Qwen2.5-*-Instruct-1M`; `Qwen2.5-Math-*-Instruct` | √ |
| 5 | `Qwen3-*-Instruct-2507`; `Qwen3-*-Thinking*`; `Qwen3-Next-*-Instruct`; `Qwen3-Next-*-Thinking` | √ |
| 6 | `QwQ-32B-Instruct`; `QwQ-32B-Preview-Instruct` | √ |
| 7 (current PR) | `Falcon-H1-*B-*Instruct` | √ |
| 8 | `Granite-3.0-{1B-A400M,3B-A800M,2B,8B}-Instruct` | × |
| 9 | `Llama-3-*B-Chinese-Chat` | × |
| 10 | `Yi-6B-Chat`; `Yi-34B-Chat` | × |
| 11 | Automatic pre-training consistency warning | × |

### Planned PR
The validation and correction work described above has already covered 80% of the models. Some model families, such as Qwen 3.5, Gemini, MiniCPM, and MiniMax, could not be completed immediately due to the workload and the need to merge other contributors’ PRs. They will be gradually addressed in follow-up work.

## Models Fixed Diff

### tiiuae/Falcon-H1-0.5B-Instruct

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `tool_call_multi_turn_with_system` | <code>&lt;&#124;begin_of_text&#124;&gt;&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<span style="background-color: #e6ffec;"><br><br></span>You&nbsp;a<span style="background-color: #e6ffec;">r</span>e&nbsp;a<span style="background-color: #e6ffec;">&nbsp;fun</span>c<span style="background-color: #e6ffec;">tion&nbsp;</span>c<span style="background-color: #e6ffec;">alling&nbsp;AI&nbsp;mod</span>e<span style="background-color: #e6ffec;">l.&nbsp;You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;</span>s<span style="background-color: #e6ffec;">ignature&nbsp;within&nbsp;&lt;tools&gt;&nbsp;&lt;/tools&gt;&nbsp;XML&nbsp;tags.&nbsp;You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;function</span>s&nbsp;to&nbsp;<span style="background-color: #e6ffec;">assist&nbsp;with&nbsp;</span>the&nbsp;<span style="background-color: #e6ffec;">user&nbsp;query.&nbsp;D</span>o<span style="background-color: #e6ffec;">n&#x27;t&nbsp;make&nbsp;assumptions&nbsp;about&nbsp;what&nbsp;va</span>l<span style="background-color: #e6ffec;">ues&nbsp;to&nbsp;p</span>l<span style="background-color: #e6ffec;">ug&nbsp;</span>in<span style="background-color: #e6ffec;">to</span>&nbsp;<span style="background-color: #e6ffec;">functions.<br>&lt;</span>tools<span style="background-color: #e6ffec;">&gt;<br>[{&quot;type&quot;</span>:&nbsp;<span style="background-color: #e6ffec;">&quot;functi</span>o<span style="background-color: #e6ffec;">n&quot;,&nbsp;&quot;functi</span>o<span style="background-color: #e6ffec;">n&quot;:</span>&nbsp;<span style="background-color: #e6ffec;">{&quot;n</span>ame<span style="background-color: #e6ffec;">&quot;</span>:&nbsp;<span style="background-color: #e6ffec;">&quot;</span>get_current_temperature<span style="background-color: #e6ffec;">&quot;,</span>&nbsp;<span style="background-color: #e6ffec;">&quot;d</span>escription<span style="background-color: #e6ffec;">&quot;</span>:&nbsp;<span style="background-color: #e6ffec;">&quot;</span>Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.<span style="background-color: #e6ffec;">&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;</span>o<span style="background-color: #e6ffec;">bject&quot;,&nbsp;&quot;pr</span>o<span style="background-color: #e6ffec;">perties&quot;:</span>&nbsp;<span style="background-color: #e6ffec;">{&quot;</span>city<span style="background-color: #e6ffec;">&quot;:</span>&nbsp;<span style="background-color: #e6ffec;">{&quot;type&quot;:&nbsp;&quot;</span>string<span style="background-color: #e6ffec;">&quot;}}</span>,&nbsp;<span style="background-color: #e6ffec;">&quot;</span>required<span style="background-color: #e6ffec;">&quot;</span>:&nbsp;<span style="background-color: #e6ffec;">[&quot;city&quot;]}}}]</span><br><span style="background-color: #e6ffec;">&lt;/tools&gt;</span><br><span style="background-color: #e6ffec;">For&nbsp;each&nbsp;function&nbsp;call,&nbsp;return&nbsp;a&nbsp;j</span>s<span style="background-color: #e6ffec;">on&nbsp;obj</span>e<span style="background-color: #e6ffec;">ct&nbsp;with&nbsp;function&nbsp;name&nbsp;and&nbsp;arguments&nbsp;within&nbsp;&lt;tool_call&gt;&nbsp;&lt;/tool_call&gt;&nbsp;tags&nbsp;with</span>&nbsp;the&nbsp;following&nbsp;<span style="background-color: #e6ffec;">sche</span>ma<span style="background-color: #e6ffec;">:<br>&lt;</span>tool<span style="background-color: #e6ffec;">_call&gt;<br>{&#x27;arguments&#x27;</span>:<span style="background-color: #e6ffec;">&nbsp;&lt;args-dict&gt;,&nbsp;&#x27;name&#x27;:&nbsp;&lt;fun</span>ction<span style="background-color: #e6ffec;">-name&gt;}<br>&lt;/</span>tool_call&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>Action:&nbsp;get_current_temperature<br>Action&nbsp;Input:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;tool<br>{&quot;temperature_celsius&quot;:21}&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;begin_of_text&#124;&gt;&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.You&nbsp;<span style="background-color: #ffebe9;">h</span>a<span style="background-color: #ffebe9;">v</span>e&nbsp;access&nbsp;to&nbsp;the&nbsp;<span style="background-color: #ffebe9;">f</span>oll<span style="background-color: #ffebe9;">ow</span>in<span style="background-color: #ffebe9;">g</span>&nbsp;tools:<span style="background-color: #ffebe9;"><br>&gt;</span>&nbsp;<span style="background-color: #ffebe9;">T</span>oo<span style="background-color: #ffebe9;">l</span>&nbsp;<span style="background-color: #ffebe9;">N</span>ame:&nbsp;get_current_temperature<span style="background-color: #ffebe9;"><br>Tool</span>&nbsp;<span style="background-color: #ffebe9;">D</span>escription:&nbsp;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.<span style="background-color: #ffebe9;"><br>T</span>oo<span style="background-color: #ffebe9;">l</span>&nbsp;<span style="background-color: #ffebe9;">Args:<br>&nbsp;&nbsp;-&nbsp;</span>city&nbsp;<span style="background-color: #ffebe9;">(</span>string,&nbsp;required<span style="background-color: #ffebe9;">)</span>:&nbsp;<br><br><span style="background-color: #ffebe9;">U</span>se&nbsp;the&nbsp;following&nbsp;<span style="background-color: #ffebe9;">for</span>ma<span style="background-color: #ffebe9;">t&nbsp;if&nbsp;using&nbsp;a&nbsp;</span>tool:<span style="background-color: #ffebe9;"><br>```<br>A</span>ction<span style="background-color: #ffebe9;">:&nbsp;</span>tool<span style="background-color: #ffebe9;">&nbsp;name&nbsp;(one&nbsp;of&nbsp;[get</span>_c<span style="background-color: #ffebe9;">urrent_temper</span>a<span style="background-color: #ffebe9;">ture])<br>Action&nbsp;Input:&nbsp;the&nbsp;input&nbsp;to&nbsp;the&nbsp;tool,&nbsp;in&nbsp;a&nbsp;JSON&nbsp;format&nbsp;representing&nbsp;the&nbsp;kwargs&nbsp;(e.g.&nbsp;```{&quot;input&quot;:&nbsp;&quot;he</span>ll<span style="background-color: #ffebe9;">o&nbsp;world&quot;,&nbsp;&quot;num_beams&quot;:&nbsp;5}```)<br>```<br>&lt;&#124;im_end&#124;</span>&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>Action:&nbsp;get_current_temperature<br>Action&nbsp;Input:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;tool<br>{&quot;temperature_celsius&quot;:21}&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> | <code>&lt;&#124;begin_of_text&#124;&gt;&lt;&#124;im_start&#124;&gt;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<br><br>You&nbsp;are&nbsp;a&nbsp;function&nbsp;calling&nbsp;AI&nbsp;model.&nbsp;You&nbsp;are&nbsp;provided&nbsp;with&nbsp;function&nbsp;signature&nbsp;within&nbsp;&lt;tools&gt;&nbsp;&lt;/tools&gt;&nbsp;XML&nbsp;tags.&nbsp;You&nbsp;may&nbsp;call&nbsp;one&nbsp;or&nbsp;more&nbsp;functions&nbsp;to&nbsp;assist&nbsp;with&nbsp;the&nbsp;user&nbsp;query.&nbsp;Don&#x27;t&nbsp;make&nbsp;assumptions&nbsp;about&nbsp;what&nbsp;values&nbsp;to&nbsp;plug&nbsp;into&nbsp;functions.<br>&lt;tools&gt;<br>[{&quot;type&quot;:&nbsp;&quot;function&quot;,&nbsp;&quot;function&quot;:&nbsp;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,&nbsp;&quot;parameters&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;object&quot;,&nbsp;&quot;properties&quot;:&nbsp;{&quot;city&quot;:&nbsp;{&quot;type&quot;:&nbsp;&quot;string&quot;}},&nbsp;&quot;required&quot;:&nbsp;[&quot;city&quot;]}}}]<br>&lt;/tools&gt;<br>For&nbsp;each&nbsp;function&nbsp;call,&nbsp;return&nbsp;a&nbsp;json&nbsp;object&nbsp;with&nbsp;function&nbsp;name&nbsp;and&nbsp;arguments&nbsp;within&nbsp;&lt;tool_call&gt;&nbsp;&lt;/tool_call&gt;&nbsp;tags&nbsp;with&nbsp;the&nbsp;following&nbsp;schema:<br>&lt;tool_call&gt;<br>{&#x27;arguments&#x27;:&nbsp;&lt;args-dict&gt;,&nbsp;&#x27;name&#x27;:&nbsp;&lt;function-name&gt;}<br>&lt;/tool_call&gt;<br>&lt;&#124;im_start&#124;&gt;user<br>What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br>&lt;tool_call&gt;<br>{&quot;arguments&quot;:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;},&nbsp;&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;}<br>&lt;/tool_call&gt;&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;tool<br>{&quot;temperature_celsius&quot;:21}&lt;&#124;im_end&#124;&gt;<br>&lt;&#124;im_start&#124;&gt;assistant<br></code> |

## Models Fixed in This PR

**Falcon-H1 Instruct Series**

**Background**

No-tool conversations already match Falcon-H1 ChatML. With tools, the official tokenizer keeps the tool instructions inside an unterminated system turn, uses a dedicated XML tools section, serializes assistant calls with `arguments` before `name`, and returns observations through the `tool` role.

**Root Cause**

The `falcon_h1` registration had no model-specific function or tool formatter and therefore used LlamaFactory's generic `Action/Action Input` protocol. Its system-and-tools assembly also closed the system turn before the tool instructions.

**Solution**

1. Add `FalconH1ToolUtils` for the official tool instructions and native `<tool_call>` JSON format. Tool definitions are serialized as one valid JSON array, including multi-tool inputs, rather than as separately bracketed objects concatenated together.
2. Override only `FalconH1Template._format_system_and_tools()` from #10784 to build the unterminated tool-system turn. The shared role dispatch remains unchanged and continues to pass `thought_words` and `tool_call_words` to the function formatter.
3. Configure `falcon_h1` with the dedicated function and tool formatters.
4. Keep the no-tool path unchanged and leave Falcon-H1 Base models without default templates.

## Unit Tests

`test_falcon_h1_template_consistency()` checks all Instruct and Base mappings, verifies native tool-call extraction and multi-tool JSON serialization, and compares both no-tool and tool-enabled prompts with the official Falcon-H1-0.5B tokenizer.

```bash
pytest -q tests/data/test_template.py::test_falcon_h1_template_consistency
```

## About Test Samples

Models are classified as reasoning-only, non-reasoning-only, or dual-mode. Reasoning-only models use the reasoning sample, non-reasoning-only models use the non-reasoning sample, and dual-mode models use both. Each sample covers a single turn without a system prompt, a single turn with a system prompt, multi-turn dialogue with a system prompt, and multi-turn tool use with a system prompt.

Specific test examples will be elaborated in the consistency-checking mechanism PR.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
