### PR TITLE
fix: align Granite chat templates with Transformers

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -141,16 +141,43 @@ class Template:
         Turn 0: prefix + system + query        resp
         Turn t: query                          resp.
         """
+        processed_messages = self._process_messages(messages)
+        if processed_messages is not None:
+            messages = processed_messages
+
+        rendered_messages = self._render(messages, system, tools)
+        self._process_rendered_messages(rendered_messages, messages)
+        return [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+
+    def _process_messages(self, messages: list[dict[str, str]]) -> Optional[list[dict[str, str]]]:
+        r"""Return model-specific messages before rendering, or use the original messages."""
+        pass
+
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
+        r"""Return model-specific system and tool elements, or use the default formatter."""
+        pass
+
+    def _render(
+        self,
+        messages: list[dict[str, str]],
+        system: Optional[str],
+        tools: Optional[str],
+    ) -> list["SLOTS"]:
+        r"""Render messages into formatter elements before tokenization."""
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
             if i == 0:
                 elements += self.format_prefix.apply()
                 if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    elements += self.format_system.apply(content=(system + tool_text))
+                    system_and_tools = self._format_system_and_tools(system, tools)
+                    if system_and_tools is None:
+                        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+                        system_and_tools = self.format_system.apply(content=(system + tool_text))
+
+                    elements += system_and_tools
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
@@ -165,9 +192,15 @@ class Template:
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
+
+    def _process_rendered_messages(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> None:
+        r"""Apply model-specific changes to formatter output before tokenization."""
+        pass
 
     @staticmethod
     def _add_or_replace_eos_token(tokenizer: "PreTrainedTokenizer", eos_token: str) -> None:
@@ -336,45 +369,12 @@ class Template:
 @dataclass
 class MossVLTemplate(Template):
     @override
-    def _encode(
-        self,
-        tokenizer: "PreTrainedTokenizer",
-        messages: list[dict[str, str]],
-        system: Optional[str],
-        tools: Optional[str],
-    ) -> list[list[int]]:
-        system = system or self.default_system
-        encoded_messages = []
-        for i, message in enumerate(messages):
-            elements = []
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> "SLOTS":
+        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+        if tools and not system:
+            tool_text = tool_text.lstrip("\n")
 
-            if i == 0:
-                elements += self.format_prefix.apply()
-                if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    if tools and not system:
-                        tool_text = tool_text.lstrip("\n")
-
-                    elements += self.format_system.apply(content=(system + tool_text))
-
-            if message["role"] == Role.USER:
-                elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
-            elif message["role"] == Role.ASSISTANT:
-                elements += self.format_assistant.apply(content=message["content"])
-            elif message["role"] == Role.OBSERVATION:
-                elements += self.format_observation.apply(content=message["content"])
-            elif message["role"] == Role.FUNCTION:
-                elements += self.format_function.apply(
-                    content=message["content"],
-                    thought_words=self.thought_words,
-                    tool_call_words=self.tool_call_words,
-                )
-            else:
-                raise NotImplementedError("Unexpected role: {}".format(message["role"]))
-
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
-
-        return encoded_messages
+        return self.format_system.apply(content=(system + tool_text))
 
 
 @dataclass
@@ -382,15 +382,14 @@ class Llama2Template(Template):
     r"""A template that fuse the system message to first user message."""
 
     @override
-    def _encode(
+    def _render(
         self,
-        tokenizer: "PreTrainedTokenizer",
         messages: list[dict[str, str]],
         system: str,
         tools: str,
-    ) -> list[list[int]]:
+    ) -> list["SLOTS"]:
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
@@ -412,9 +411,9 @@ class Llama2Template(Template):
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
 
     def _get_jinja_template(self, tokenizer: "PreTrainedTokenizer") -> str:
         prefix = self._convert_slots_to_jinja(self.format_prefix.apply(), tokenizer)
@@ -451,6 +450,10 @@ class Llama2Template(Template):
 class ReasoningTemplate(Template):
     r"""A template that add thought to assistant message."""
 
+    def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
+        r"""Process model-specific historical reasoning and return whether it was handled."""
+        pass
+
     @override
     def encode_oneturn(
         self,
@@ -460,7 +463,7 @@ class ReasoningTemplate(Template):
         tools: Optional[str] = None,
     ) -> tuple[list[int], list[int]]:
         messages = deepcopy(messages)
-        if not self.preserve_thinking:
+        if not self.preserve_thinking and not self._process_history_thoughts(messages, is_inference=True):
             for i in range(1, len(messages) - 2, 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
@@ -493,7 +496,7 @@ class ReasoningTemplate(Template):
             for i in range(1, len(messages), 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
-        if discarding_history_cot:
+        if discarding_history_cot and not self._process_history_thoughts(messages, is_inference=False):
             for i in range(1, len(messages) - 2, 2):  # preserve the last cot
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -447,6 +447,22 @@ class Llama2Template(Template):
 
 
 @dataclass
+class Granite30Template(Template):
+    r"""Place Granite 3.0 available tools before the optional system message."""
+
+    @override
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
+        if not tools:
+            return None
+
+        elements = self.format_tools.apply(content=tools)
+        if system:
+            elements += self.format_system.apply(content=system)
+
+        return elements
+
+
+@dataclass
 class ReasoningTemplate(Template):
     r"""A template that add thought to assistant message."""
 
@@ -1261,6 +1277,30 @@ register_template(
     ),
     format_assistant=StringFormatter(slots=["{{content}}<|end_of_text|>\n"]),
     format_system=StringFormatter(slots=["<|start_of_role|>system<|end_of_role|>{{content}}<|end_of_text|>\n"]),
+)
+
+
+register_template(
+    name="granite3_0",
+    format_user=StringFormatter(
+        slots=[
+            "<|start_of_role|>user<|end_of_role|>{{content}}<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>"
+        ]
+    ),
+    format_assistant=StringFormatter(slots=["{{content}}<|end_of_text|>\n"]),
+    format_system=StringFormatter(slots=["<|start_of_role|>system<|end_of_role|>{{content}}<|end_of_text|>\n"]),
+    format_function=FunctionFormatter(
+        slots=["<|tool_call|>{{content}}<|end_of_text|>\n"],
+        tool_format="granite3_0",
+    ),
+    format_observation=StringFormatter(
+        slots=[
+            "<|start_of_role|>tool_response<|end_of_role|>{{content}}<|end_of_text|>\n"
+            "<|start_of_role|>assistant<|end_of_role|>"
+        ]
+    ),
+    format_tools=ToolFormatter(tool_format="granite3_0"),
+    template_class=Granite30Template,
 )
 
 

--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -408,6 +408,46 @@ class GLM4ToolUtils(ToolUtils):
         return [FunctionCall(tool_name, json.dumps(arguments, ensure_ascii=False))]
 
 
+class Granite3ToolUtils(ToolUtils):
+    r"""Granite 3.0 tool format using its tokenizer-defined message roles."""
+
+    @override
+    @staticmethod
+    def tool_formatter(tools: list[dict[str, Any]]) -> str:
+        tool_text = "\n\n".join(json.dumps(tool, indent=4, ensure_ascii=False) for tool in tools)
+        return f"<|start_of_role|>available_tools<|end_of_role|>\n{tool_text}<|end_of_text|>\n"
+
+    @override
+    @staticmethod
+    def function_formatter(functions: list["FunctionCall"]) -> str:
+        if len(functions) != 1:
+            raise ValueError("Granite 3.0 only supports one function call per message.")
+
+        name, arguments = functions[0]
+        return json.dumps(
+            {"name": name, "arguments": json.loads(arguments)},
+            ensure_ascii=False,
+        )
+
+    @override
+    @staticmethod
+    def tool_extractor(content: str) -> Union[str, list["FunctionCall"]]:
+        marker = "<|tool_call|>"
+        if marker not in content:
+            return content
+
+        try:
+            tool_call = json.loads(content.split(marker, maxsplit=1)[1].strip())
+            return [
+                FunctionCall(
+                    tool_call["name"],
+                    json.dumps(tool_call["arguments"], ensure_ascii=False),
+                )
+            ]
+        except (json.JSONDecodeError, KeyError, TypeError):
+            return content
+
+
 class Llama3ToolUtils(ToolUtils):
     r"""Llama 3.x tool using template with `tools_in_user_message=False`.
 
@@ -885,6 +925,7 @@ TOOLS = {
     "default": DefaultToolUtils(),
     "gemma4": Gemma4ToolUtils(),
     "glm4": GLM4ToolUtils(),
+    "granite3_0": Granite3ToolUtils(),
     "llama3": Llama3ToolUtils(),
     "lfm2": LFM2ToolUtils(),
     "minimax1": MiniMaxM1ToolUtils(),

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -1130,22 +1130,6 @@ register_model_group(
             DownloadSource.DEFAULT: "ibm-granite/granite-3.0-8b-base",
             DownloadSource.MODELSCOPE: "AI-ModelScope/granite-3.0-8b-base",
         },
-        "Granite-3.0-1B-A400M-Instruct": {
-            DownloadSource.DEFAULT: "ibm-granite/granite-3.0-1b-a400m-instruct",
-            DownloadSource.MODELSCOPE: "AI-ModelScope/granite-3.0-1b-a400m-instruct",
-        },
-        "Granite-3.0-3B-A800M-Instruct": {
-            DownloadSource.DEFAULT: "ibm-granite/granite-3.0-3b-a800m-instruct",
-            DownloadSource.MODELSCOPE: "AI-ModelScope/granite-3.0-3b-a800m-instruct",
-        },
-        "Granite-3.0-2B-Instruct": {
-            DownloadSource.DEFAULT: "ibm-granite/granite-3.0-2b-instruct",
-            DownloadSource.MODELSCOPE: "AI-ModelScope/granite-3.0-2b-instruct",
-        },
-        "Granite-3.0-8B-Instruct": {
-            DownloadSource.DEFAULT: "ibm-granite/granite-3.0-8b-instruct",
-            DownloadSource.MODELSCOPE: "AI-ModelScope/granite-3.0-8b-instruct",
-        },
         "Granite-3.1-1B-A400M-Base": {
             DownloadSource.DEFAULT: "ibm-granite/granite-3.1-1b-a400m-base",
             DownloadSource.MODELSCOPE: "AI-ModelScope/granite-3.1-1b-a400m-base",
@@ -1204,6 +1188,29 @@ register_model_group(
         },
     },
     template="granite3",
+)
+
+
+register_model_group(
+    models={
+        "Granite-3.0-1B-A400M-Instruct": {
+            DownloadSource.DEFAULT: "ibm-granite/granite-3.0-1b-a400m-instruct",
+            DownloadSource.MODELSCOPE: "AI-ModelScope/granite-3.0-1b-a400m-instruct",
+        },
+        "Granite-3.0-3B-A800M-Instruct": {
+            DownloadSource.DEFAULT: "ibm-granite/granite-3.0-3b-a800m-instruct",
+            DownloadSource.MODELSCOPE: "AI-ModelScope/granite-3.0-3b-a800m-instruct",
+        },
+        "Granite-3.0-2B-Instruct": {
+            DownloadSource.DEFAULT: "ibm-granite/granite-3.0-2b-instruct",
+            DownloadSource.MODELSCOPE: "AI-ModelScope/granite-3.0-2b-instruct",
+        },
+        "Granite-3.0-8B-Instruct": {
+            DownloadSource.DEFAULT: "ibm-granite/granite-3.0-8b-instruct",
+            DownloadSource.MODELSCOPE: "AI-ModelScope/granite-3.0-8b-instruct",
+        },
+    },
+    template="granite3_0",
 )
 
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import pytest
@@ -95,6 +97,58 @@ def _check_template(
     assert content_str == prompt_str + answer_str
     assert content_ids == prompt_ids + answer_ids
     _check_tokenization(tokenizer, (prompt_ids, answer_ids), (prompt_str, answer_str))
+
+
+def test_rendering_refactor_preserves_existing_template_boundaries():
+    class ByteTokenizer:
+        bos_token_id = 1000
+        eos_token_id = 1001
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            return list(text.encode())
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    tokenizer = ByteTokenizer()
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+
+    standard = deepcopy(TEMPLATES["falcon_h1"])
+    prompt_ids, response_ids = standard.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<|im_start|>system\nsystem<|im_end|>\n"
+        "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    tools = json.dumps(
+        [
+            {
+                "name": "search",
+                "description": "Search documents.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            }
+        ]
+    )
+    moss_vl = deepcopy(TEMPLATES["moss_vl"])
+    prompt_ids, response_ids = moss_vl.encode_oneturn(tokenizer, messages, tools=tools)
+    tool_text = moss_vl.format_tools.apply(content=tools)[0].lstrip("\n")
+    assert prompt_ids == tokenizer.encode(
+        moss_vl.format_system.apply(content=tool_text)[0]
+        + "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    llama2 = deepcopy(TEMPLATES["gemma"])
+    prompt_ids, response_ids = llama2.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<start_of_turn>user\nsystem\n\nquestion<end_of_turn>\n<start_of_turn>model\n"
+    )
+    assert response_ids == tokenizer.encode("answer<end_of_turn>\n")
 
 
 def test_moss_vl_registration():

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -393,6 +393,122 @@ def test_phi4_template():
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_granite3_0_template_consistency():
+    granite3_0_instruct_models = [
+        "Granite-3.0-1B-A400M-Instruct",
+        "Granite-3.0-3B-A800M-Instruct",
+        "Granite-3.0-2B-Instruct",
+        "Granite-3.0-8B-Instruct",
+    ]
+    later_granite_instruct_models = [
+        "Granite-3.1-1B-A400M-Instruct",
+        "Granite-3.1-3B-A800M-Instruct",
+        "Granite-3.1-2B-Instruct",
+        "Granite-3.1-8B-Instruct",
+        "Granite-3.2-2B-Instruct",
+        "Granite-3.2-8B-Instruct",
+        "Granite-3.3-2B-Instruct",
+        "Granite-3.3-8B-Instruct",
+    ]
+    granite3_0_base_models = [
+        "Granite-3.0-1B-A400M-Base",
+        "Granite-3.0-3B-A800M-Base",
+        "Granite-3.0-2B-Base",
+        "Granite-3.0-8B-Base",
+    ]
+    for model_name in granite3_0_instruct_models:
+        assert DEFAULT_TEMPLATE[model_name] == "granite3_0"
+    for model_name in later_granite_instruct_models:
+        assert DEFAULT_TEMPLATE[model_name] == "granite3"
+    for model_name in granite3_0_base_models:
+        assert model_name not in DEFAULT_TEMPLATE
+
+    assert TEMPLATES["granite3"].__class__.__name__ == "Template"
+    assert TEMPLATES["granite3_0"].__class__.__name__ == "Granite30Template"
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_current_temperature",
+                "description": "Get the current temperature for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    system = "You are a helpful weather assistant. Use the available tools when needed."
+    observation = '{"temperature_celsius":21}'
+    function_call = '<tool_call>{"name":"get_current_temperature","arguments":{"city":"Paris"}}</tool_call>'
+    no_tool_messages = [
+        {"role": "user", "content": "What is 17 multiplied by 24?"},
+        {"role": "assistant", "content": "408"},
+    ]
+    tool_messages = [
+        {"role": "user", "content": "What is the current temperature in Paris?"},
+        {"role": "function", "content": function_call},
+        {"role": "observation", "content": observation},
+        {"role": "assistant", "content": "It is 21 degrees Celsius."},
+    ]
+    tool_call_content = json.dumps(
+        {"name": "get_current_temperature", "arguments": {"city": "Paris"}},
+        ensure_ascii=False,
+    )
+    cases = [
+        (
+            no_tool_messages,
+            [
+                {"role": "system", "content": system},
+                {"role": "user", "content": "What is 17 multiplied by 24?"},
+            ],
+            None,
+        ),
+        (
+            tool_messages,
+            [
+                {"role": "system", "content": system},
+                {"role": "user", "content": "What is the current temperature in Paris?"},
+                {"role": "assistant_tool_call", "content": tool_call_content},
+                {"role": "tool_response", "content": observation},
+            ],
+            tools,
+        ),
+    ]
+    model_ids = [
+        "ibm-granite/granite-3.0-1b-a400m-instruct",
+        "ibm-granite/granite-3.0-2b-instruct",
+    ]
+    for model_id in model_ids:
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        reference_tokenizer = AutoTokenizer.from_pretrained(model_id)
+        template = get_template_and_fix_tokenizer(tokenizer, DataArguments(template="granite3_0"))
+        extracted_calls = template.extract_tool("<|tool_call|>" + tool_call_content)
+        assert len(extracted_calls) == 1
+        assert extracted_calls[0].name == "get_current_temperature"
+        assert json.loads(extracted_calls[0].arguments) == {"city": "Paris"}
+        for messages, reference_messages, case_tools in cases:
+            prompt_ids, _ = template.encode_oneturn(
+                tokenizer,
+                messages,
+                system=system,
+                tools=json.dumps(case_tools, ensure_ascii=False) if case_tools else None,
+            )
+            reference_ids = reference_tokenizer.apply_chat_template(
+                reference_messages,
+                tools=case_tools,
+                tokenize=True,
+                add_generation_prompt=True,
+            )
+            if is_transformers_version_greater_than("5.0.0"):
+                reference_ids = reference_ids["input_ids"]
+
+            assert prompt_ids == reference_ids, (model_id, bool(case_tools))
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 @pytest.mark.xfail(not HF_TOKEN, reason="Authorization.")
 def test_qwen2_5_template():
     prompt_str = (


### PR DESCRIPTION
# What does this PR do?

Adds an isolated Granite 3.0 Instruct template that matches the official Transformers roles and tool protocol while leaving Granite 3.1, 3.2, and 3.3 on the existing `granite3` template.

### Affected Model Series and Templates

| Model series | Template |
| --- | --- |
| `Granite-3.0-{1B-A400M,3B-A800M,2B,8B}-Instruct` | `granite3_0` |

Granite 3.0 Base models remain without a default template, and later Granite Instruct families remain on `granite3`.

This PR depends on #10784 for the shared system-and-tools rendering hook. It adds only the Granite 3.0-specific override, tool formatter, template registration, model mappings, and tests on top of that base.

The regression test compares no-tool and tool-enabled prompt IDs with the official Granite 3.0 tokenizers and verifies native tool-call extraction.

## Introduction

While reviewing issues recently, I found a large number of problems caused by inconsistencies between templates.

This made us realize that these inconsistencies are not isolated incidents, especially for less common models. When users use the official templates provided by these models, such inconsistencies can cause severe mismatches between training and inference, significantly affecting training speed and the inference accuracy of the trained models.

This work consists of two parts:

1. I will use a script to perform large-scale testing on all models using the examples described below. The test will compare the generated text/token sequences across LlamaFactory training, LlamaFactory inference, and vLLM inference using the standard Transformers `chat_template` interface. I will then fix the issues one by one. Since there are many models, the fixes will be submitted in multiple PRs organized by model family to make them easier to review.

2. I will add a consistency-checking mechanism that runs automatically before training. If inconsistencies are detected, it will issue a warning and save the corresponding test examples, but it will not block training. This mechanism will be submitted as a separate PR.

The most common problems can be roughly divided into the following categories:

1. The native LlamaFactory templates do not have sufficiently fine-grained coverage. For example, Qwen3 includes several model variants, such as the Qwen3-8B-Thinking series and the Qwen3-30B-A3B-Thinking-2507 series. Qwen2.5 also includes variants such as Coder and Math. These models have subtle differences: the Qwen3-8B-Thinking series supports both thinking and non-thinking modes, while Qwen3-30B-A3B-Thinking-2507 only supports thinking mode. The official templates for the Coder and Math series also use different system prompts. However, the native system does not distinguish between these variants and applies the same template to all of them.

2. The handling of thinking traces is inconsistent. LlamaFactory provides `mask_history` and `preserve_thinking` to control whether historical thinking traces are removed during training and inference, but it currently uses the generic `remove_thought()` function for all models. In practice, different models require different handling, for example:

   - DeepSeek-R1: remove historical thinking content while preserving the two newlines after the closing tag.
   - GLM-4.5: remove the thinking content while preserving an empty thinking block.
   - Qwen/QwQ: follow the tokenizer-specific rules for historical assistant/tool messages.
   - Hunyuan: preserve or generate the corresponding boundaries according to its tokenizer; a generic removal function cannot be used.

3. The handling of whether the `<think>` tag is generated by the model is inconsistent. In the DeepSeek-R1-*B-Distill series, the `<think>` tag is part of the model output during training and is included in loss computation. During inference, however, the template automatically adds the `<think>` tag as part of the prompt, so the model does not need to generate it.

4. There are also various minor bugs of this kind. I will analyze and fix these issues individually.

### Verified Correct Models

The following models completed template validation and already match their tokenizer chat templates. They do not require a template change in this series of PRs.

- GLM-4-0414-*B-Chat
- Kimi-Dev-*B-Instruct
- Llama-3.1-*B-Chinese-Chat
- Phi-4-*B-Instruct
- Qwen2.5-*B-Instruct (standard, AWQ, GPTQ-Int4, and GPTQ-Int8)
- Qwen2.5-Coder-*B-Instruct
- Qwen3-*-Instruct-2507
- Qwen3-*-Thinking* (excluding the 2507-only thinking series)
- Qwen3-Next-80B-A3B-Instruct
- Seed-Coder-*B-Instruct
- SmolLM-*-Instruct
- Yi-Coder-*B-Chat

### Submit PR List

| PR | Model family or scope | Status |
| --- | --- | --- |
| 1 | `DeepSeek-Coder-*B-Instruct`; `DeepSeek-R1*`; `DeepSeek-LLM-*B-Chat`; `DeepSeek-Math-*B-Instruct` | √ |
| 2 | `GLM-4-0414-*B-Chat`; `GLM-4.5-*Thinking`; `GLM-Z1-0414-*B-Chat` | √ |
| 3 | `Hunyuan-*B-Instruct`; `Hunyuan-MT-*B-Instruct`; `HY-MT1.5-*B-Instruct`; `Hy-MT2-*B-Instruct` | √ |
| 4 | `Qwen2-*`; `Qwen2.5-*-Instruct-1M`; `Qwen2.5-Math-*-Instruct` | √ |
| 5 | `Qwen3-*-Instruct-2507`; `Qwen3-*-Thinking*`; `Qwen3-Next-*-Instruct`; `Qwen3-Next-*-Thinking` | √ |
| 6 | `QwQ-32B-Instruct`; `QwQ-32B-Preview-Instruct` | √ |
| 7 | `Falcon-H1-*B-*Instruct` | √ |
| 8 (current PR) | `Granite-3.0-{1B-A400M,3B-A800M,2B,8B}-Instruct` | √ |
| 9 | `Llama-3-*B-Chinese-Chat` | × |
| 10 | `Yi-6B-Chat`; `Yi-34B-Chat` | × |
| 11 | Automatic pre-training consistency warning | × |

### Planned PR
The validation and correction work described above has already covered 80% of the models. Some model families, such as Qwen 3.5, Gemini, MiniCPM, and MiniMax, could not be completed immediately due to the workload and the need to merge other contributors’ PRs. They will be gradually addressed in follow-up work.

## Models Fixed Diff

### ibm-granite/granite-3.0-1b-a400m-instruct

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `tool_call_multi_turn_with_system` | <code><span style="background-color: #e6ffec;">&lt;&#124;start_of_role&#124;&gt;available_tools&lt;&#124;end_of_role&#124;&gt;<br>{<br>&nbsp;&nbsp;&nbsp;&nbsp;&quot;type&quot;:&nbsp;&quot;function&quot;,<br>&nbsp;&nbsp;&nbsp;&nbsp;&quot;function&quot;:&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;parameters&quot;:&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;type&quot;:&nbsp;&quot;object&quot;,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;properties&quot;:&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;city&quot;:&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;type&quot;:&nbsp;&quot;string&quot;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;required&quot;:&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;city&quot;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}&lt;&#124;end_of_text&#124;&gt;<br></span>&lt;&#124;start_of_role&#124;&gt;system&lt;&#124;end_of_role&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;user&lt;&#124;end_of_role&#124;&gt;What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;assistant&lt;&#124;end_of_role&#124;&gt;<span style="background-color: #e6ffec;">&lt;&#124;tool_</span>c<span style="background-color: #e6ffec;">all&#124;&gt;{&quot;</span>n<span style="background-color: #e6ffec;">ame&quot;</span>:&nbsp;<span style="background-color: #e6ffec;">&quot;</span>get_current_temperature<span style="background-color: #e6ffec;">&quot;,&nbsp;&quot;argumen</span>t<span style="background-color: #e6ffec;">s&quot;</span>:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;<span style="background-color: #e6ffec;">}</span>}&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;<span style="background-color: #e6ffec;">tool_respon</span>se&lt;&#124;end_of_role&#124;&gt;{&quot;temperature_celsius&quot;:21}&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;assistant&lt;&#124;end_of_role&#124;&gt;</code> | <code>&lt;&#124;start_of_role&#124;&gt;system&lt;&#124;end_of_role&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.<span style="background-color: #ffebe9;">You&nbsp;have&nbsp;access&nbsp;to&nbsp;the&nbsp;following&nbsp;tools:<br>&gt;&nbsp;Tool&nbsp;Name:&nbsp;get_current_temperature<br>Tool&nbsp;Description:&nbsp;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.<br>Tool&nbsp;Args:<br>&nbsp;&nbsp;-&nbsp;city&nbsp;(string,&nbsp;required):&nbsp;<br><br>Use&nbsp;the&nbsp;following&nbsp;format&nbsp;if&nbsp;using&nbsp;a&nbsp;tool:<br>```<br>Action:&nbsp;tool&nbsp;name&nbsp;(one&nbsp;of&nbsp;[get_current_temperature])<br>Action&nbsp;Input:&nbsp;the&nbsp;input&nbsp;to&nbsp;the&nbsp;tool,&nbsp;in&nbsp;a&nbsp;JSON&nbsp;format&nbsp;representing&nbsp;the&nbsp;kwargs&nbsp;(e.g.&nbsp;```{&quot;input&quot;:&nbsp;&quot;hello&nbsp;world&quot;,&nbsp;&quot;num_beams&quot;:&nbsp;5}```)<br>```<br></span>&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;user&lt;&#124;end_of_role&#124;&gt;What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;assistant&lt;&#124;end_of_role&#124;&gt;<span style="background-color: #ffebe9;">A</span>c<span style="background-color: #ffebe9;">tio</span>n:&nbsp;get_current_temperature<span style="background-color: #ffebe9;"><br>Ac</span>t<span style="background-color: #ffebe9;">ion&nbsp;Input</span>:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;<span style="background-color: #ffebe9;">u</span>se<span style="background-color: #ffebe9;">r</span>&lt;&#124;end_of_role&#124;&gt;{&quot;temperature_celsius&quot;:21}&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;assistant&lt;&#124;end_of_role&#124;&gt;</code> | <code>&lt;&#124;start_of_role&#124;&gt;available_tools&lt;&#124;end_of_role&#124;&gt;<br>{<br>&nbsp;&nbsp;&nbsp;&nbsp;&quot;type&quot;:&nbsp;&quot;function&quot;,<br>&nbsp;&nbsp;&nbsp;&nbsp;&quot;function&quot;:&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;description&quot;:&nbsp;&quot;Get&nbsp;the&nbsp;current&nbsp;temperature&nbsp;for&nbsp;a&nbsp;city.&quot;,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;parameters&quot;:&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;type&quot;:&nbsp;&quot;object&quot;,<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;properties&quot;:&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;city&quot;:&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;type&quot;:&nbsp;&quot;string&quot;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;required&quot;:&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&quot;city&quot;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;system&lt;&#124;end_of_role&#124;&gt;You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;weather&nbsp;assistant.&nbsp;Use&nbsp;the&nbsp;available&nbsp;tools&nbsp;when&nbsp;needed.&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;user&lt;&#124;end_of_role&#124;&gt;What&nbsp;is&nbsp;the&nbsp;current&nbsp;temperature&nbsp;in&nbsp;Paris?&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;assistant&lt;&#124;end_of_role&#124;&gt;&lt;&#124;tool_call&#124;&gt;{&quot;name&quot;:&nbsp;&quot;get_current_temperature&quot;,&nbsp;&quot;arguments&quot;:&nbsp;{&quot;city&quot;:&nbsp;&quot;Paris&quot;}}&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;tool_response&lt;&#124;end_of_role&#124;&gt;{&quot;temperature_celsius&quot;:21}&lt;&#124;end_of_text&#124;&gt;<br>&lt;&#124;start_of_role&#124;&gt;assistant&lt;&#124;end_of_role&#124;&gt;</code> |

## Models Fixed in This PR

**Granite 3.0 Instruct Series**

**Background**

Granite 3.0 uses a protocol that differs from later Granite templates. Available tools are rendered as a dedicated turn before the optional system message, assistant calls use the `<|tool_call|>` marker, and observations use the `tool_response` role.

**Root Cause**

Granite 3.0 Instruct models shared the later `granite3` template and generic tool utilities, so their tool roles, ordering, and serialized function calls did not match their official tokenizer templates.

**Solution**

1. Add `Granite3ToolUtils` for the official available-tools turn, single function-call JSON, and `<|tool_call|>` extraction.
2. Add `granite3_0` with Granite 3.0's user, assistant, system, function, observation, and tool slots.
3. Override only `Granite30Template._format_system_and_tools()` from #10784 to place available tools before the optional system message. The shared role dispatch remains unchanged and continues to pass `thought_words` and `tool_call_words` to the function formatter.
4. Move only Granite 3.0 Instruct mappings to `granite3_0`; keep Granite 3.1-3.3 on `granite3` and Base models unassigned.

## Unit Tests

`test_granite3_0_template_consistency()` checks Granite 3.0, later Granite, and Base mappings; verifies native tool-call extraction; and compares no-tool and tool-enabled prompts for the Granite 3.0 1B-A400M and 2B tokenizers.

```bash
pytest -q tests/data/test_template.py::test_granite3_0_template_consistency
```

## About Test Samples

Models are classified as reasoning-only, non-reasoning-only, or dual-mode. Reasoning-only models use the reasoning sample, non-reasoning-only models use the non-reasoning sample, and dual-mode models use both. Each sample covers a single turn without a system prompt, a single turn with a system prompt, multi-turn dialogue with a system prompt, and multi-turn tool use with a system prompt.

Specific test examples will be elaborated in the consistency-checking mechanism PR.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
