### PR TITLE
fix: align Llama 3 Chinese chat templates with Transformers

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -1512,6 +1512,36 @@ register_template(
 )
 
 
+# copied from llama3 template
+register_template(
+    name="llama3_zh",
+    format_user=StringFormatter(
+        slots=[
+            (
+                "<|start_header_id|>user<|end_header_id|>\n\n{{content}}<|eot_id|>"
+                "<|start_header_id|>assistant<|end_header_id|>\n\n"
+            )
+        ]
+    ),
+    format_assistant=StringFormatter(slots=["{{content}}<|eot_id|>"]),
+    format_system=StringFormatter(slots=["<|start_header_id|>system<|end_header_id|>\n\n{{content}}<|eot_id|>"]),
+    format_function=FunctionFormatter(slots=["{{content}}<|eot_id|>"], tool_format="llama3"),
+    format_observation=StringFormatter(
+        slots=[
+            (
+                "<|start_header_id|>ipython<|end_header_id|>\n\n{{content}}<|eot_id|>"
+                "<|start_header_id|>assistant<|end_header_id|>\n\n"
+            )
+        ]
+    ),
+    format_tools=ToolFormatter(tool_format="llama3"),
+    format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
+    default_system="You are a helpful assistant.",
+    stop_words=["<|eot_id|>", "<|eom_id|>"],
+    replace_eos=True,
+)
+
+
 register_template(
     name="llama4",
     format_user=StringFormatter(

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -1625,14 +1625,6 @@ register_model_group(
             DownloadSource.DEFAULT: "meta-llama/Meta-Llama-3-70B-Instruct",
             DownloadSource.MODELSCOPE: "LLM-Research/Meta-Llama-3-70B-Instruct",
         },
-        "Llama-3-8B-Chinese-Chat": {
-            DownloadSource.DEFAULT: "shenzhi-wang/Llama3-8B-Chinese-Chat",
-            DownloadSource.MODELSCOPE: "LLM-Research/Llama3-8B-Chinese-Chat",
-            DownloadSource.OPENMIND: "LlamaFactory/Llama3-Chinese-8B-Instruct",
-        },
-        "Llama-3-70B-Chinese-Chat": {
-            DownloadSource.DEFAULT: "shenzhi-wang/Llama3-70B-Chinese-Chat",
-        },
         "Llama-3.1-8B": {
             DownloadSource.DEFAULT: "meta-llama/Meta-Llama-3.1-8B",
             DownloadSource.MODELSCOPE: "LLM-Research/Meta-Llama-3.1-8B",
@@ -1687,6 +1679,21 @@ register_model_group(
         },
     },
     template="llama3",
+)
+
+
+register_model_group(
+    models={
+        "Llama-3-8B-Chinese-Chat": {
+            DownloadSource.DEFAULT: "shenzhi-wang/Llama3-8B-Chinese-Chat",
+            DownloadSource.MODELSCOPE: "LLM-Research/Llama3-8B-Chinese-Chat",
+            DownloadSource.OPENMIND: "LlamaFactory/Llama3-Chinese-8B-Instruct",
+        },
+        "Llama-3-70B-Chinese-Chat": {
+            DownloadSource.DEFAULT: "shenzhi-wang/Llama3-70B-Chinese-Chat",
+        },
+    },
+    template="llama3_zh",
 )
 
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -73,6 +73,7 @@ def _check_template(
     prompt_str: str,
     answer_str: str,
     messages: list[dict[str, str]] = MESSAGES,
+    system: str | None = None,
 ) -> None:
     r"""Check template.
 
@@ -82,16 +83,18 @@ def _check_template(
         prompt_str: the string corresponding to the prompt part.
         answer_str: the string corresponding to the answer part.
         messages: the list of messages.
+        system: the optional system message.
 
     """
     tokenizer = AutoTokenizer.from_pretrained(model_id)
-    content_str = tokenizer.apply_chat_template(messages, tokenize=False)
-    content_ids = tokenizer.apply_chat_template(messages, tokenize=True)
+    reference_messages = ([{"role": "system", "content": system}] if system else []) + messages
+    content_str = tokenizer.apply_chat_template(reference_messages, tokenize=False)
+    content_ids = tokenizer.apply_chat_template(reference_messages, tokenize=True)
     if is_transformers_version_greater_than("5.0.0"):
         content_ids = content_ids["input_ids"]
 
     template = get_template_and_fix_tokenizer(tokenizer, DataArguments(template=template_name))
-    prompt_ids, answer_ids = template.encode_oneturn(tokenizer, messages)
+    prompt_ids, answer_ids = template.encode_oneturn(tokenizer, messages, system=system)
     assert content_str == prompt_str + answer_str
     assert content_ids == prompt_ids + answer_ids
     _check_tokenization(tokenizer, (prompt_ids, answer_ids), (prompt_str, answer_str))
@@ -353,33 +356,24 @@ def test_llama3_chinese_template_consistency():
     assert TEMPLATES["llama3_zh"].default_system == "You are a helpful assistant."
     assert TEMPLATES["llama3"].default_system == ""
 
-    conversations = [
+    messages = [
         {"role": "user", "content": "A box contains 12 red markers and 8 blue markers."},
         {"role": "assistant", "content": "There are 20 markers."},
         {"role": "user", "content": "If 5 are removed, how many remain?"},
         {"role": "assistant", "content": "15 markers remain."},
     ]
-    custom_system = "You are a concise math assistant."
-    checks = [
-        (target_models["Llama-3-8B-Chinese-Chat"], "llama3_zh", None, True),
-        (target_models["Llama-3-8B-Chinese-Chat"], "llama3_zh", custom_system, True),
-        ("shenzhi-wang/Llama3.1-8B-Chinese-Chat", "llama3", None, False),
-    ]
-    for model_id, template_name, system, check_full_conversation in checks:
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
-        template = get_template_and_fix_tokenizer(tokenizer, DataArguments(template=template_name))
-        message_sets = (conversations[:-1], conversations) if check_full_conversation else (conversations[:-1],)
-        for messages in message_sets:
-            actual_ids = sum(template._encode(tokenizer, messages, system, tools=None), [])
-            reference_messages = ([{"role": "system", "content": system}] if system else []) + messages
-            reference_ids = tokenizer.apply_chat_template(
-                reference_messages,
-                tokenize=True,
-                add_generation_prompt=messages[-1]["role"] == "user",
-            )
-            if hasattr(reference_ids, "input_ids"):
-                reference_ids = reference_ids.input_ids
-            assert actual_ids == reference_ids
+    model_id = target_models["Llama-3-8B-Chinese-Chat"]
+    for system in (None, "You are a concise math assistant."):
+        system_text = system or "You are a helpful assistant."
+        prompt_str = (
+            f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n{system_text}<|eot_id|>"
+            f"<|start_header_id|>user<|end_header_id|>\n\n{messages[0]['content']}<|eot_id|>"
+            f"<|start_header_id|>assistant<|end_header_id|>\n\n{messages[1]['content']}<|eot_id|>"
+            f"<|start_header_id|>user<|end_header_id|>\n\n{messages[2]['content']}<|eot_id|>"
+            "<|start_header_id|>assistant<|end_header_id|>\n\n"
+        )
+        answer_str = f"{messages[3]['content']}<|eot_id|>"
+        _check_template(model_id, "llama3_zh", prompt_str, answer_str, messages=messages, system=system)
 
 
 @pytest.mark.runs_on(["cpu", "mps"])

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -339,6 +339,50 @@ def test_phi4_template():
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_llama3_chinese_template_consistency():
+    target_models = {
+        "Llama-3-8B-Chinese-Chat": "shenzhi-wang/Llama3-8B-Chinese-Chat",
+        "Llama-3-70B-Chinese-Chat": "shenzhi-wang/Llama3-70B-Chinese-Chat",
+    }
+    unaffected_models = ["Llama-3.1-8B-Chinese-Chat", "Llama-3.1-70B-Chinese-Chat"]
+    for model_name in target_models:
+        assert DEFAULT_TEMPLATE[model_name] == "llama3_zh"
+    for model_name in unaffected_models:
+        assert DEFAULT_TEMPLATE[model_name] == "llama3"
+
+    assert TEMPLATES["llama3_zh"].default_system == "You are a helpful assistant."
+    assert TEMPLATES["llama3"].default_system == ""
+
+    conversations = [
+        {"role": "user", "content": "A box contains 12 red markers and 8 blue markers."},
+        {"role": "assistant", "content": "There are 20 markers."},
+        {"role": "user", "content": "If 5 are removed, how many remain?"},
+        {"role": "assistant", "content": "15 markers remain."},
+    ]
+    custom_system = "You are a concise math assistant."
+    checks = [
+        (target_models["Llama-3-8B-Chinese-Chat"], "llama3_zh", None, True),
+        (target_models["Llama-3-8B-Chinese-Chat"], "llama3_zh", custom_system, True),
+        ("shenzhi-wang/Llama3.1-8B-Chinese-Chat", "llama3", None, False),
+    ]
+    for model_id, template_name, system, check_full_conversation in checks:
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        template = get_template_and_fix_tokenizer(tokenizer, DataArguments(template=template_name))
+        message_sets = (conversations[:-1], conversations) if check_full_conversation else (conversations[:-1],)
+        for messages in message_sets:
+            actual_ids = sum(template._encode(tokenizer, messages, system, tools=None), [])
+            reference_messages = ([{"role": "system", "content": system}] if system else []) + messages
+            reference_ids = tokenizer.apply_chat_template(
+                reference_messages,
+                tokenize=True,
+                add_generation_prompt=messages[-1]["role"] == "user",
+            )
+            if hasattr(reference_ids, "input_ids"):
+                reference_ids = reference_ids.input_ids
+            assert actual_ids == reference_ids
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 @pytest.mark.xfail(not HF_TOKEN, reason="Authorization.")
 def test_qwen2_5_template():
     prompt_str = (


### PR DESCRIPTION
# What does this PR do?

Adds an isolated template for the original Llama-3 Chinese Chat models so their tokenizer-defined default system message is applied without changing Llama-3.1 Chinese Chat or other Llama-3 variants.

### Affected Model Series and Templates

| Model series | Template |
| --- | --- |
| `Llama-3-8B-Chinese-Chat`; `Llama-3-70B-Chinese-Chat` | `llama3_zh` |

`Llama-3.1-8B-Chinese-Chat` and `Llama-3.1-70B-Chinese-Chat` remain on the unchanged `llama3` template. This PR does not depend on #10784 because it only adds an isolated template registration and updates the corresponding model mappings.

I have added unit tests to this PR. All the models have been verified and modified through the unit tests and our consistency-checking mechanism script. There are no errors after the modification.



## Introduction

While reviewing issues recently, I found a large number of problems caused by inconsistencies between templates.

This made us realize that these inconsistencies are not isolated incidents, especially for less common models. When users use the official templates provided by these models, such inconsistencies can cause severe mismatches between training and inference, significantly affecting training speed and the inference accuracy of the trained models.

This work consists of two parts:

1. I will use a script to perform large-scale testing on all models using the examples described below. The test will compare the generated text/token sequences across LlamaFactory training, LlamaFactory inference, and vLLM inference using the standard Transformers `chat_template` interface. I will then fix the issues one by one. Since there are many models, the fixes will be submitted in multiple PRs organized by model family to make them easier to review.

2. I will add a consistency-checking mechanism that runs automatically before training. If inconsistencies are detected, it will issue a warning and save the corresponding test examples, but it will not block training. This mechanism will be submitted as a separate PR.

The most common problems can be roughly divided into the following categories:

1. The native LlamaFactory templates do not have sufficiently fine-grained coverage. For example, Qwen3 includes several model variants, such as the Qwen3-8B-Thinking series and the Qwen3-30B-A3B-Thinking-2507 series. Qwen2.5 also includes variants such as Coder and Math. These models have subtle differences: the Qwen3-8B-Thinking series supports both thinking and non-thinking modes, while Qwen3-30B-A3B-Thinking-2507 only supports thinking mode. The official templates for the Coder and Math series also use different system prompts. However, the native system does not distinguish between these variants and applies the same template to all of them.

2. The handling of thinking traces is inconsistent. LlamaFactory provides `mask_history` and `preserve_thinking` to control whether historical thinking traces are removed during training and inference, but it currently uses the generic `remove_thought()` function for all models. In practice, different models require different handling, for example:

   - DeepSeek-R1: remove historical thinking content while preserving the two newlines after the closing tag.
   - GLM-4.5: remove the thinking content while preserving an empty thinking block.
   - Qwen/QwQ: follow the tokenizer-specific rules for historical assistant/tool messages.
   - Hunyuan: preserve or generate the corresponding boundaries according to its tokenizer; a generic removal function cannot be used.

3. The handling of whether the `<think>` tag is generated by the model is inconsistent. In the DeepSeek-R1-*B-Distill series, the `<think>` tag is part of the model output during training and is included in loss computation. During inference, however, the template automatically adds the `<think>` tag as part of the prompt, so the model does not need to generate it.

4. There are also various minor bugs of this kind. I will analyze and fix these issues individually.

### Verified Correct Models

The following models completed template validation and already match their tokenizer chat templates. They do not require a template change in this series of PRs.

- Kimi-Dev-*B-Instruct
- Llama-3.1-*B-Chinese-Chat
- Phi-4-*B-Instruct
- Qwen2.5-*B-Instruct (standard, AWQ, GPTQ-Int4, and GPTQ-Int8)
- Qwen2.5-Coder-*B-Instruct
- Qwen3-*-Instruct-2507
- Qwen3-*-Thinking* (excluding the 2507-only thinking series)
- Qwen3-Next-80B-A3B-Instruct
- Seed-Coder-*B-Instruct
- SmolLM-*-Instruct
- Yi-Coder-*B-Chat

### Submit PR List

| PR | Model family or scope | Status |
| --- | --- | --- |
| 1 | `DeepSeek-Coder-*B-Instruct`; `DeepSeek-R1*`; `DeepSeek-LLM-*B-Chat`; `DeepSeek-Math-*B-Instruct` | √ |
| 2 | `GLM-4-0414-*B-Chat`; `GLM-4.5-*Thinking`; `GLM-Z1-0414-*B-Chat` | √ |
| 3 | `Hunyuan-*B-Instruct`; `Hunyuan-MT-*B-Instruct`; `HY-MT1.5-*B-Instruct`; `Hy-MT2-*B-Instruct` | √ |
| 4 | `Qwen2-*`; `Qwen2.5-*-Instruct-1M`; `Qwen2.5-Math-*-Instruct` | √ |
| 5 | `Qwen3-*-Instruct-2507`; `Qwen3-*-Thinking*`; `Qwen3-Next-*-Instruct`; `Qwen3-Next-*-Thinking` | √ |
| 6 | `QwQ-32B-Instruct`; `QwQ-32B-Preview-Instruct` | √ |
| 7 | `Falcon-H1-*B-*Instruct` | √ |
| 8 | `Granite-3.0-*B-A400M-Instruct` | √ |
| 9 (current PR) | `Llama-3-*B-Chinese-Chat` | √ |
| 10 | `Yi-6B-Chat`; `Yi-34B-Chat` | × |
| 11 | Automatic pre-training consistency warning | × |

### Planned PR

The validation and correction work described above has already covered 80% of the models. Some model families, such as Qwen 3.5, Gemini, MiniCPM, and MiniMax, could not be completed immediately due to the workload and the need to merge other contributors' PRs. They will be gradually addressed in follow-up work.


## Models Fixed Diff

### shenzhi-wang/Llama3.1-8B-Chinese-Chat

The original template was already consistent.

### shenzhi-wang/Llama3-8B-Chinese-Chat

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `single_turn_without_system` | <code>&lt;&#124;begin_of_text<mark>&#124;&gt;&lt;&#124;start_header_id&#124;&gt;system&lt;&#124;end_header_id&#124;&gt;<br><br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;assistant.&lt;&#124;eot_id</mark>&#124;&gt;&lt;&#124;start_header_id&#124;&gt;user&lt;&#124;end_header_id&#124;&gt;<br><br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;eot_id&#124;&gt;&lt;&#124;start_header_id&#124;&gt;assistant&lt;&#124;end_header_id&#124;&gt;<br><br></code> | <code>&lt;&#124;begin_of_text&#124;&gt;&lt;&#124;start_header_id&#124;&gt;user&lt;&#124;end_header_id&#124;&gt;<br><br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;eot_id&#124;&gt;&lt;&#124;start_header_id&#124;&gt;assistant&lt;&#124;end_header_id&#124;&gt;<br><br></code> | <code>&lt;&#124;begin_of_text&#124;&gt;&lt;&#124;start_header_id&#124;&gt;system&lt;&#124;end_header_id&#124;&gt;<br><br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;assistant.&lt;&#124;eot_id&#124;&gt;&lt;&#124;start_header_id&#124;&gt;user&lt;&#124;end_header_id&#124;&gt;<br><br>What&nbsp;is&nbsp;17&nbsp;multiplied&nbsp;by&nbsp;24?&lt;&#124;eot_id&#124;&gt;&lt;&#124;start_header_id&#124;&gt;assistant&lt;&#124;end_header_id&#124;&gt;<br><br></code> |


## Models Fixed in This PR

**Llama-3-\*B-Chinese-Chat Series**

**Affected Model Names**

- Llama-3-8B-Chinese-Chat
- Llama-3-70B-Chinese-Chat

**Background**

Both tokenizers use the standard Llama-3 role and end-of-turn protocol, but insert `You are a helpful assistant.` as an implicit system message when the input conversation does not begin with a system role. Llama-3.1 Chinese Chat does not insert this default system message and already matches the existing `llama3` template.

**Root Cause**

`src/llamafactory/extras/constants.py` placed both original Llama-3 Chinese Chat models in the shared `llama3` model group. The `llama3` registration in `src/llamafactory/data/template.py` intentionally has an empty `default_system`, so prompts without an explicit system message omitted the tokenizer-defined system turn.

**Solution**

1. In `src/llamafactory/data/template.py`, add `llama3_zh` with the existing Llama-3 user, assistant, system, function, observation, tool, BOS/EOS, and stop-token formatting.
2. Set `llama3_zh.default_system` to `You are a helpful assistant.`.
3. In `src/llamafactory/extras/constants.py`, move only `Llama-3-8B-Chinese-Chat` and `Llama-3-70B-Chinese-Chat` to `llama3_zh`.
4. Keep both Llama-3.1 Chinese Chat mappings and all other Llama-3 models on the unchanged `llama3` template.

The official tokenizer applies Jinja `trim` filters to system and message content, while the shared LlamaFactory `StringFormatter` preserves caller-provided leading and trailing whitespace. This pre-existing behavior is shared with `llama3` and is outside the scope of this isolated default-system correction.

## Unit Tests

`tests/data/test_template.py` adds `test_llama3_chinese_template_consistency()`. It verifies the target and unaffected Llama-3.1 mappings, checks the isolated default-system value, and compares the target tokenizer and LlamaFactory token IDs with both the implicit default system and an explicit system override. The shared `_check_template()` helper now accepts the optional system message used by this coverage.

```bash
pytest -q tests/data/test_template.py::test_llama3_chinese_template_consistency
```


## About Test Samples

Models are classified as reasoning-only, non-reasoning-only, or dual-mode. Reasoning-only models use the reasoning sample, non-reasoning-only models use the non-reasoning sample, and dual-mode models use both. Each sample covers a single turn without a system prompt, a single turn with a system prompt, multi-turn dialogue with a system prompt, and multi-turn tool use with a system prompt.

Specific test examples will be elaborated in the consistency-checking mechanism PR.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
