### PR TITLE
fix: align Yi chat templates with Transformers

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -410,7 +410,7 @@ class YiLegacyTemplate(Template):
         messages: list[dict[str, str]],
         system: Optional[str],
         tools: Optional[str],
-    ) -> list[list[int]]:
+    ) -> tuple[list[list[int]], set[int]]:
         processed_messages = self._process_messages(messages)
         if processed_messages is not None:
             messages = processed_messages
@@ -430,7 +430,7 @@ class YiLegacyTemplate(Template):
             split_index = self._get_common_prefix_length(source_ids, full_ids)
             encoded_messages.extend([full_ids[:split_index], full_ids[split_index:]])
 
-        return encoded_messages
+        return encoded_messages, set()
 
 
 @dataclass

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -373,6 +373,67 @@ class Template:
 
 
 @dataclass
+class YiLegacyTemplate(Template):
+    r"""Tokenize legacy Yi prompt-response pairs in their rendered context."""
+
+    @staticmethod
+    def _convert_elements_to_text(tokenizer: "PreTrainedTokenizer", elements: "SLOTS") -> str:
+        text = []
+        for element in elements:
+            if isinstance(element, str):
+                text.append(element)
+            elif isinstance(element, dict):
+                text.append(element["token"])
+            elif isinstance(element, set):
+                if "bos_token" in element and tokenizer.bos_token is not None:
+                    text.append(tokenizer.bos_token)
+                elif "eos_token" in element and tokenizer.eos_token is not None:
+                    text.append(tokenizer.eos_token)
+
+        return "".join(text)
+
+    @staticmethod
+    def _get_common_prefix_length(first_ids: list[int], second_ids: list[int]) -> int:
+        common_length = 0
+        for first_id, second_id in zip(first_ids, second_ids):
+            if first_id != second_id:
+                break
+
+            common_length += 1
+
+        return common_length
+
+    @override
+    def _encode(
+        self,
+        tokenizer: "PreTrainedTokenizer",
+        messages: list[dict[str, str]],
+        system: Optional[str],
+        tools: Optional[str],
+    ) -> list[list[int]]:
+        processed_messages = self._process_messages(messages)
+        if processed_messages is not None:
+            messages = processed_messages
+
+        rendered_messages = self._render(messages, system, tools)
+        self._process_rendered_messages(rendered_messages, messages)
+        encoded_messages = []
+        for index in range(0, len(rendered_messages), 2):
+            source_text = self._convert_elements_to_text(tokenizer, rendered_messages[index])
+            source_ids = tokenizer.encode(source_text, add_special_tokens=False)
+            if index + 1 == len(rendered_messages):
+                encoded_messages.append(source_ids)
+                break
+
+            target_text = self._convert_elements_to_text(tokenizer, rendered_messages[index + 1])
+            full_ids = tokenizer.encode(source_text + target_text, add_special_tokens=False)
+            split_index = self._get_common_prefix_length(source_ids, full_ids)
+            encoded_messages.extend([full_ids[:split_index], full_ids[split_index:]])
+
+        return encoded_messages
+
+
+@dataclass
 class MossVLTemplate(Template):
     @override
     def _format_system_and_tools(self, system: str, tools: Optional[str]) -> "SLOTS":
@@ -2410,6 +2471,17 @@ register_template(
     format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),
     format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
     stop_words=["<|im_end|>"],
+)
+
+
+# copied from yi template
+register_template(
+    name="yi_legacy",
+    format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),
+    format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
+    stop_words=["<|im_end|>"],
+    template_class=YiLegacyTemplate,
 )
 
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -65,7 +65,7 @@ class Template:
         tools: Optional[str] = None,
     ) -> tuple[list[int], list[int]]:
         r"""Return a single pair of token ids representing prompt and response respectively."""
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, _ = self._encode(tokenizer, messages, system, tools)
         prompt_ids = []
         for encoded_ids in encoded_messages[:-1]:
             prompt_ids += encoded_ids
@@ -82,7 +82,7 @@ class Template:
         discarding_history_cot: bool = False,  # only effect reasoning template
     ) -> list[tuple[list[int], list[int]]]:
         r"""Return multiple pairs of token ids representing prompts and responses respectively."""
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, _ = self._encode(tokenizer, messages, system, tools)
         return [(encoded_messages[i], encoded_messages[i + 1]) for i in range(0, len(encoded_messages), 2)]
 
     def extract_tool(self, content: str) -> Union[str, list["FunctionCall"]]:
@@ -135,7 +135,7 @@ class Template:
         messages: list[dict[str, str]],
         system: Optional[str],
         tools: Optional[str],
-    ) -> list[list[int]]:
+    ) -> tuple[list[list[int]], set[int]]:
         r"""Encode formatted inputs to pairs of token ids.
 
         Turn 0: prefix + system + query        resp
@@ -147,15 +147,17 @@ class Template:
 
         rendered_messages = self._render(messages, system, tools)
         self._process_rendered_messages(rendered_messages, messages)
-        return [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+        processed_response_indices = self._process_thought_boundaries(rendered_messages, messages)
+        encoded_messages = [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+        return encoded_messages, processed_response_indices
 
     def _process_messages(self, messages: list[dict[str, str]]) -> Optional[list[dict[str, str]]]:
         r"""Return model-specific messages before rendering, or use the original messages."""
-        pass
+        return None
 
     def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
         r"""Return model-specific system and tool elements, or use the default formatter."""
-        pass
+        return None
 
     def _render(
         self,
@@ -200,7 +202,13 @@ class Template:
         self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
     ) -> None:
         r"""Apply model-specific changes to formatter output before tokenization."""
-        pass
+        return None
+
+    def _process_thought_boundaries(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> set[int]:
+        r"""Process model-specific thought boundaries and return the handled response indices."""
+        return set()
 
     @staticmethod
     def _add_or_replace_eos_token(tokenizer: "PreTrainedTokenizer", eos_token: str) -> None:
@@ -452,7 +460,7 @@ class ReasoningTemplate(Template):
 
     def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
         r"""Process model-specific historical reasoning and return whether it was handled."""
-        pass
+        return False
 
     @override
     def encode_oneturn(
@@ -470,8 +478,14 @@ class ReasoningTemplate(Template):
         if self.enable_thinking is False:  # remove all cot
             messages[-1]["content"] = self.remove_thought(messages[-1]["content"])
 
-        prompt_ids, response_ids = super().encode_oneturn(tokenizer, messages, system, tools)
-        if (
+        encoded_messages, processed_response_indices = self._encode(tokenizer, messages, system, tools)
+        prompt_ids = []
+        for encoded_ids in encoded_messages[:-1]:
+            prompt_ids += encoded_ids
+
+        response_index = len(encoded_messages) - 1
+        response_ids = encoded_messages[response_index]
+        if response_index not in processed_response_indices and (
             self.thought_words[0].strip() not in messages[-1]["content"]
             and self.thought_words[1].strip() not in messages[-1]["content"]
         ):  # add empty cot
@@ -500,14 +514,14 @@ class ReasoningTemplate(Template):
             for i in range(1, len(messages) - 2, 2):  # preserve the last cot
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
-        encoded_messages = self._encode(tokenizer, messages, system, tools)
+        encoded_messages, processed_response_indices = self._encode(tokenizer, messages, system, tools)
         if discarding_history_cot:
             turn_indices = [len(messages) - 2]
         else:
             turn_indices = range(0, len(messages), 2)
 
         for i in turn_indices:
-            if (
+            if i + 1 not in processed_response_indices and (
                 self.thought_words[0].strip() not in messages[i + 1]["content"]
                 and self.thought_words[1].strip() not in messages[i + 1]["content"]
             ):  # add empty cot

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -141,16 +141,43 @@ class Template:
         Turn 0: prefix + system + query        resp
         Turn t: query                          resp.
         """
+        processed_messages = self._process_messages(messages)
+        if processed_messages is not None:
+            messages = processed_messages
+
+        rendered_messages = self._render(messages, system, tools)
+        self._process_rendered_messages(rendered_messages, messages)
+        return [self._convert_elements_to_ids(tokenizer, elements) for elements in rendered_messages]
+
+    def _process_messages(self, messages: list[dict[str, str]]) -> Optional[list[dict[str, str]]]:
+        r"""Return model-specific messages before rendering, or use the original messages."""
+        pass
+
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> Optional["SLOTS"]:
+        r"""Return model-specific system and tool elements, or use the default formatter."""
+        pass
+
+    def _render(
+        self,
+        messages: list[dict[str, str]],
+        system: Optional[str],
+        tools: Optional[str],
+    ) -> list["SLOTS"]:
+        r"""Render messages into formatter elements before tokenization."""
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
             if i == 0:
                 elements += self.format_prefix.apply()
                 if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    elements += self.format_system.apply(content=(system + tool_text))
+                    system_and_tools = self._format_system_and_tools(system, tools)
+                    if system_and_tools is None:
+                        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+                        system_and_tools = self.format_system.apply(content=(system + tool_text))
+
+                    elements += system_and_tools
 
             if message["role"] == Role.USER:
                 elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
@@ -165,9 +192,15 @@ class Template:
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
+
+    def _process_rendered_messages(
+        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
+    ) -> None:
+        r"""Apply model-specific changes to formatter output before tokenization."""
+        pass
 
     @staticmethod
     def _add_or_replace_eos_token(tokenizer: "PreTrainedTokenizer", eos_token: str) -> None:
@@ -336,45 +369,12 @@ class Template:
 @dataclass
 class MossVLTemplate(Template):
     @override
-    def _encode(
-        self,
-        tokenizer: "PreTrainedTokenizer",
-        messages: list[dict[str, str]],
-        system: Optional[str],
-        tools: Optional[str],
-    ) -> list[list[int]]:
-        system = system or self.default_system
-        encoded_messages = []
-        for i, message in enumerate(messages):
-            elements = []
+    def _format_system_and_tools(self, system: str, tools: Optional[str]) -> "SLOTS":
+        tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+        if tools and not system:
+            tool_text = tool_text.lstrip("\n")
 
-            if i == 0:
-                elements += self.format_prefix.apply()
-                if system or tools:
-                    tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
-                    if tools and not system:
-                        tool_text = tool_text.lstrip("\n")
-
-                    elements += self.format_system.apply(content=(system + tool_text))
-
-            if message["role"] == Role.USER:
-                elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
-            elif message["role"] == Role.ASSISTANT:
-                elements += self.format_assistant.apply(content=message["content"])
-            elif message["role"] == Role.OBSERVATION:
-                elements += self.format_observation.apply(content=message["content"])
-            elif message["role"] == Role.FUNCTION:
-                elements += self.format_function.apply(
-                    content=message["content"],
-                    thought_words=self.thought_words,
-                    tool_call_words=self.tool_call_words,
-                )
-            else:
-                raise NotImplementedError("Unexpected role: {}".format(message["role"]))
-
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
-
-        return encoded_messages
+        return self.format_system.apply(content=(system + tool_text))
 
 
 @dataclass
@@ -382,15 +382,14 @@ class Llama2Template(Template):
     r"""A template that fuse the system message to first user message."""
 
     @override
-    def _encode(
+    def _render(
         self,
-        tokenizer: "PreTrainedTokenizer",
         messages: list[dict[str, str]],
         system: str,
         tools: str,
-    ) -> list[list[int]]:
+    ) -> list["SLOTS"]:
         system = system or self.default_system
-        encoded_messages = []
+        rendered_messages = []
         for i, message in enumerate(messages):
             elements = []
 
@@ -412,9 +411,9 @@ class Llama2Template(Template):
             else:
                 raise NotImplementedError("Unexpected role: {}".format(message["role"]))
 
-            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+            rendered_messages.append(elements)
 
-        return encoded_messages
+        return rendered_messages
 
     def _get_jinja_template(self, tokenizer: "PreTrainedTokenizer") -> str:
         prefix = self._convert_slots_to_jinja(self.format_prefix.apply(), tokenizer)
@@ -451,6 +450,10 @@ class Llama2Template(Template):
 class ReasoningTemplate(Template):
     r"""A template that add thought to assistant message."""
 
+    def _process_history_thoughts(self, messages: list[dict[str, str]], is_inference: bool) -> bool:
+        r"""Process model-specific historical reasoning and return whether it was handled."""
+        pass
+
     @override
     def encode_oneturn(
         self,
@@ -460,7 +463,7 @@ class ReasoningTemplate(Template):
         tools: Optional[str] = None,
     ) -> tuple[list[int], list[int]]:
         messages = deepcopy(messages)
-        if not self.preserve_thinking:
+        if not self.preserve_thinking and not self._process_history_thoughts(messages, is_inference=True):
             for i in range(1, len(messages) - 2, 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
@@ -493,7 +496,7 @@ class ReasoningTemplate(Template):
             for i in range(1, len(messages), 2):
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 
-        if discarding_history_cot:
+        if discarding_history_cot and not self._process_history_thoughts(messages, is_inference=False):
             for i in range(1, len(messages) - 2, 2):  # preserve the last cot
                 messages[i]["content"] = self.remove_thought(messages[i]["content"])
 

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -198,9 +198,7 @@ class Template:
 
         return rendered_messages
 
-    def _process_rendered_messages(
-        self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]
-    ) -> None:
+    def _process_rendered_messages(self, rendered_messages: list["SLOTS"], messages: list[dict[str, str]]) -> None:
         r"""Apply model-specific changes to formatter output before tokenization."""
         return None
 

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -3508,14 +3508,6 @@ register_model_group(
             DownloadSource.DEFAULT: "01-ai/Yi-34B",
             DownloadSource.MODELSCOPE: "01ai/Yi-34B",
         },
-        "Yi-6B-Chat": {
-            DownloadSource.DEFAULT: "01-ai/Yi-6B-Chat",
-            DownloadSource.MODELSCOPE: "01ai/Yi-6B-Chat",
-        },
-        "Yi-34B-Chat": {
-            DownloadSource.DEFAULT: "01-ai/Yi-34B-Chat",
-            DownloadSource.MODELSCOPE: "01ai/Yi-34B-Chat",
-        },
         "Yi-6B-Chat-8bits": {
             DownloadSource.DEFAULT: "01-ai/Yi-6B-Chat-8bits",
             DownloadSource.MODELSCOPE: "01ai/Yi-6B-Chat-8bits",
@@ -3575,6 +3567,21 @@ register_model_group(
         },
     },
     template="yi",
+)
+
+
+register_model_group(
+    models={
+        "Yi-6B-Chat": {
+            DownloadSource.DEFAULT: "01-ai/Yi-6B-Chat",
+            DownloadSource.MODELSCOPE: "01ai/Yi-6B-Chat",
+        },
+        "Yi-34B-Chat": {
+            DownloadSource.DEFAULT: "01-ai/Yi-34B-Chat",
+            DownloadSource.MODELSCOPE: "01ai/Yi-34B-Chat",
+        },
+    },
+    template="yi_legacy",
 )
 
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import pytest
@@ -95,6 +97,58 @@ def _check_template(
     assert content_str == prompt_str + answer_str
     assert content_ids == prompt_ids + answer_ids
     _check_tokenization(tokenizer, (prompt_ids, answer_ids), (prompt_str, answer_str))
+
+
+def test_rendering_refactor_preserves_existing_template_boundaries():
+    class ByteTokenizer:
+        bos_token_id = 1000
+        eos_token_id = 1001
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            return list(text.encode())
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    tokenizer = ByteTokenizer()
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+
+    standard = deepcopy(TEMPLATES["falcon_h1"])
+    prompt_ids, response_ids = standard.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<|im_start|>system\nsystem<|im_end|>\n"
+        "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    tools = json.dumps(
+        [
+            {
+                "name": "search",
+                "description": "Search documents.",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            }
+        ]
+    )
+    moss_vl = deepcopy(TEMPLATES["moss_vl"])
+    prompt_ids, response_ids = moss_vl.encode_oneturn(tokenizer, messages, tools=tools)
+    tool_text = moss_vl.format_tools.apply(content=tools)[0].lstrip("\n")
+    assert prompt_ids == tokenizer.encode(
+        moss_vl.format_system.apply(content=tool_text)[0]
+        + "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert response_ids == tokenizer.encode("answer<|im_end|>\n")
+
+    llama2 = deepcopy(TEMPLATES["gemma"])
+    prompt_ids, response_ids = llama2.encode_oneturn(tokenizer, messages, system="system")
+    assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
+        "<start_of_turn>user\nsystem\n\nquestion<end_of_turn>\n<start_of_turn>model\n"
+    )
+    assert response_ids == tokenizer.encode("answer<end_of_turn>\n")
 
 
 def test_moss_vl_registration():

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -120,8 +120,7 @@ def test_rendering_refactor_preserves_existing_template_boundaries():
     standard = deepcopy(TEMPLATES["falcon_h1"])
     prompt_ids, response_ids = standard.encode_oneturn(tokenizer, messages, system="system")
     assert prompt_ids == [tokenizer.bos_token_id] + tokenizer.encode(
-        "<|im_start|>system\nsystem<|im_end|>\n"
-        "<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
+        "<|im_start|>system\nsystem<|im_end|>\n<|im_start|>user\nquestion<|im_end|>\n<|im_start|>assistant\n"
     )
     assert response_ids == tokenizer.encode("answer<|im_end|>\n")
 

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -21,7 +21,7 @@ import pytest
 from transformers import AutoTokenizer
 
 from llamafactory.data import get_template_and_fix_tokenizer
-from llamafactory.data.template import TEMPLATES, parse_template
+from llamafactory.data.template import TEMPLATES, ReasoningTemplate, parse_template
 from llamafactory.extras.constants import (
     DEFAULT_TEMPLATE,
     MULTIMODAL_SUPPORTED_MODELS,
@@ -149,6 +149,42 @@ def test_rendering_refactor_preserves_existing_template_boundaries():
         "<start_of_turn>user\nsystem\n\nquestion<end_of_turn>\n<start_of_turn>model\n"
     )
     assert response_ids == tokenizer.encode("answer<end_of_turn>\n")
+
+
+def test_thought_boundary_hook_reports_handled_responses():
+    class ByteTokenizer:
+        bos_token_id = 1000
+        eos_token_id = 1001
+
+        def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            return list(text.encode())
+
+        def convert_tokens_to_ids(self, token: str) -> int:
+            raise AssertionError(f"Unexpected direct token conversion: {token}")
+
+    class HookedReasoningTemplate(ReasoningTemplate):
+        def _process_thought_boundaries(self, rendered_messages, messages) -> set[int]:
+            response_index = len(rendered_messages) - 1
+            rendered_messages[response_index][0] = self.add_thought() + rendered_messages[response_index][0]
+            return {response_index}
+
+    template = HookedReasoningTemplate(**vars(deepcopy(TEMPLATES["qwen3"])))
+    template.enable_thinking = True
+    messages = [
+        {"role": "user", "content": "question 1"},
+        {"role": "assistant", "content": "answer 1"},
+        {"role": "user", "content": "question 2"},
+        {"role": "assistant", "content": "answer 2"},
+    ]
+
+    tokenizer = ByteTokenizer()
+    response_ids = template.encode_oneturn(tokenizer, messages)[1]
+    assert response_ids == list((template.add_thought() + "answer 2<|im_end|>\n").encode())
+
+    encoded_pairs = template.encode_multiturn(tokenizer, messages)
+    assert encoded_pairs[0][1] == list((template.add_thought() + "answer 1<|im_end|>\n").encode())
+    assert encoded_pairs[1][1] == list((template.add_thought() + "answer 2<|im_end|>\n").encode())
 
 
 def test_moss_vl_registration():

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -532,8 +532,10 @@ def test_yi_legacy_template_boundary_merge():
     rendered_messages = template._render(messages, system=None, tools=None)
     source_text = template._convert_elements_to_text(tokenizer, rendered_messages[0])
     target_text = template._convert_elements_to_text(tokenizer, rendered_messages[1])
-    source_ids, target_ids = template._encode(tokenizer, messages, system=None, tools=None)
+    encoded_messages, processed_response_indices = template._encode(tokenizer, messages, system=None, tools=None)
+    source_ids, target_ids = encoded_messages
 
+    assert processed_response_indices == set()
     assert source_ids == tokenizer.encode(source_text)[:-1]
     assert target_ids[0] == 0x110000
     assert source_ids + target_ids == tokenizer.encode(source_text + target_text)

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -428,6 +428,118 @@ def test_phi4_template():
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_yi_legacy_template_consistency():
+    target_models = {
+        "Yi-6B-Chat": "01-ai/Yi-6B-Chat",
+        "Yi-34B-Chat": "01-ai/Yi-34B-Chat",
+    }
+    for model_name in target_models:
+        assert DEFAULT_TEMPLATE[model_name] == "yi_legacy"
+
+    unaffected_models = [
+        "Yi-6B-Chat-4bits",
+        "Yi-34B-Chat-8bits",
+        "Yi-1.5-6B-Chat",
+        "Yi-1.5-34B-Chat",
+        "Yi-Coder-1.5B-Chat",
+        "Yi-Coder-9B-Chat",
+    ]
+    for model_name in unaffected_models:
+        assert DEFAULT_TEMPLATE[model_name] == "yi"
+
+    assert TEMPLATES["yi_legacy"].__class__.__name__ == "YiLegacyTemplate"
+    assert TEMPLATES["yi"].__class__.__name__ == "Template"
+
+    test_cases = [
+        (
+            [
+                {"role": "user", "content": "A box contains 12 red markers and 8 blue markers."},
+                {"role": "assistant", "content": "There are 20 markers."},
+            ],
+            None,
+        ),
+        (
+            [
+                {"role": "user", "content": "盒子里有 12 支红笔和 8 支蓝笔，共有多少支？"},
+                {"role": "assistant", "content": "一共有 20 支。"},
+            ],
+            "你是一名简洁的数学助手。",
+        ),
+        (
+            [
+                {"role": "user", "content": "A box contains 20 markers."},
+                {"role": "assistant", "content": "Understood."},
+                {"role": "user", "content": "移除 5 支后还剩多少支？"},
+                {"role": "assistant", "content": "还剩 15 支。"},
+            ],
+            None,
+        ),
+    ]
+    for model_id in target_models.values():
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        template = get_template_and_fix_tokenizer(tokenizer, DataArguments(template="yi_legacy"))
+        for messages, system in test_cases:
+            prompt_ids, response_ids = template.encode_oneturn(tokenizer, messages, system, tools=None)
+            reference_prefix = ([{"role": "system", "content": system}] if system else []) + messages[:-1]
+            reference_prompt_ids = tokenizer.apply_chat_template(
+                reference_prefix,
+                tokenize=True,
+                add_generation_prompt=True,
+            )
+            reference_messages = ([{"role": "system", "content": system}] if system else []) + messages
+            reference_full_ids = tokenizer.apply_chat_template(
+                reference_messages,
+                tokenize=True,
+                add_generation_prompt=False,
+            )
+            if hasattr(reference_prompt_ids, "input_ids"):
+                reference_prompt_ids = reference_prompt_ids.input_ids
+            if hasattr(reference_full_ids, "input_ids"):
+                reference_full_ids = reference_full_ids.input_ids
+
+            inference_messages = messages[:-1] + [{"role": "assistant", "content": ""}]
+            inference_prompt_ids, _ = template.encode_oneturn(tokenizer, inference_messages, system, tools=None)
+            assert prompt_ids == inference_prompt_ids == reference_prompt_ids
+            assert prompt_ids + response_ids == reference_full_ids
+
+
+def test_yi_legacy_template_boundary_merge():
+    class BoundaryMergingTokenizer:
+        bos_token = None
+        eos_token = None
+
+        @staticmethod
+        def encode(text: str, add_special_tokens: bool = False) -> list[int]:
+            assert not add_special_tokens
+            token_ids = []
+            index = 0
+            while index < len(text):
+                if text.startswith("\nT", index):
+                    token_ids.append(0x110000)
+                    index += 2
+                else:
+                    token_ids.append(ord(text[index]))
+                    index += 1
+
+            return token_ids
+
+    tokenizer = BoundaryMergingTokenizer()
+    template = TEMPLATES["yi_legacy"]
+    messages = [
+        {"role": "user", "content": "Count the markers."},
+        {"role": "assistant", "content": "There are 20 markers."},
+    ]
+    rendered_messages = template._render(messages, system=None, tools=None)
+    source_text = template._convert_elements_to_text(tokenizer, rendered_messages[0])
+    target_text = template._convert_elements_to_text(tokenizer, rendered_messages[1])
+    source_ids, target_ids = template._encode(tokenizer, messages, system=None, tools=None)
+
+    assert source_ids == tokenizer.encode(source_text)[:-1]
+    assert target_ids[0] == 0x110000
+    assert source_ids + target_ids == tokenizer.encode(source_text + target_text)
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 @pytest.mark.xfail(not HF_TOKEN, reason="Authorization.")
 def test_qwen2_5_template():
     prompt_str = (


### PR DESCRIPTION
# What does this PR do?

Adds an isolated legacy Yi encoding template that preserves continuous tokenizer behavior across prompt/response boundaries for `Yi-6B-Chat` and `Yi-34B-Chat`, without changing Yi-1.5, Yi-Coder, or quantized model mappings.

### Affected Model Series and Templates

| Model series | Template |
| --- | --- |
| `Yi-6B-Chat`; `Yi-34B-Chat` | `yi_legacy` |

Yi-1.5, Yi-Coder, base Yi, and quantized Yi models remain on their existing mappings.

This PR depends on #10784 for the shared rendered-message stage. It adds only the Yi-specific continuous-encoding override, template registration, model mappings, and tests on top of that base.

The regression tests compare both generation-prompt IDs and complete prompt-plus-response IDs with the official Yi tokenizers and cover token merges at the prompt/response boundary.

## Introduction

While reviewing issues recently, I found a large number of problems caused by inconsistencies between templates.

This made us realize that these inconsistencies are not isolated incidents, especially for less common models. When users use the official templates provided by these models, such inconsistencies can cause severe mismatches between training and inference, significantly affecting training speed and the inference accuracy of the trained models.

This work consists of two parts:

1. I will use a script to perform large-scale testing on all models using the examples described below. The test will compare the generated text/token sequences across LlamaFactory training, LlamaFactory inference, and vLLM inference using the standard Transformers `chat_template` interface. I will then fix the issues one by one. Since there are many models, the fixes will be submitted in multiple PRs organized by model family to make them easier to review.

2. I will add a consistency-checking mechanism that runs automatically before training. If inconsistencies are detected, it will issue a warning and save the corresponding test examples, but it will not block training. This mechanism will be submitted as a separate PR.

The most common problems can be roughly divided into the following categories:

1. The native LlamaFactory templates do not have sufficiently fine-grained coverage. For example, Qwen3 includes several model variants, such as the Qwen3-8B-Thinking series and the Qwen3-30B-A3B-Thinking-2507 series. Qwen2.5 also includes variants such as Coder and Math. These models have subtle differences: the Qwen3-8B-Thinking series supports both thinking and non-thinking modes, while Qwen3-30B-A3B-Thinking-2507 only supports thinking mode. The official templates for the Coder and Math series also use different system prompts. However, the native system does not distinguish between these variants and applies the same template to all of them.

2. The handling of thinking traces is inconsistent. LlamaFactory provides `mask_history` and `preserve_thinking` to control whether historical thinking traces are removed during training and inference, but it currently uses the generic `remove_thought()` function for all models. In practice, different models require different handling, for example:

   - DeepSeek-R1: remove historical thinking content while preserving the two newlines after the closing tag.
   - GLM-4.5: remove the thinking content while preserving an empty thinking block.
   - Qwen/QwQ: follow the tokenizer-specific rules for historical assistant/tool messages.
   - Hunyuan: preserve or generate the corresponding boundaries according to its tokenizer; a generic removal function cannot be used.

3. The handling of whether the `<think>` tag is generated by the model is inconsistent. In the DeepSeek-R1-*B-Distill series, the `<think>` tag is part of the model output during training and is included in loss computation. During inference, however, the template automatically adds the `<think>` tag as part of the prompt, so the model does not need to generate it.

4. There are also various minor bugs of this kind. I will analyze and fix these issues individually.

### Verified Correct Models

The following models completed template validation and already match their tokenizer chat templates. They do not require a template change in this series of PRs.

- GLM-4-0414-*B-Chat
- Kimi-Dev-*B-Instruct
- Llama-3.1-*B-Chinese-Chat
- Phi-4-*B-Instruct
- Qwen2.5-*B-Instruct (standard, AWQ, GPTQ-Int4, and GPTQ-Int8)
- Qwen2.5-Coder-*B-Instruct
- Qwen3-*-Instruct-2507
- Qwen3-*-Thinking* (excluding the 2507-only thinking series)
- Qwen3-Next-80B-A3B-Instruct
- Seed-Coder-*B-Instruct
- SmolLM-*-Instruct
- Yi-Coder-*B-Chat

### Submit PR List

| PR | Model family or scope | Status |
| --- | --- | --- |
| 1 | `DeepSeek-Coder-*B-Instruct`; `DeepSeek-R1*`; `DeepSeek-LLM-*B-Chat`; `DeepSeek-Math-*B-Instruct` | √ |
| 2 | `GLM-4-0414-*B-Chat`; `GLM-4.5-*Thinking`; `GLM-Z1-0414-*B-Chat` | √ |
| 3 | `Hunyuan-*B-Instruct`; `Hunyuan-MT-*B-Instruct`; `HY-MT1.5-*B-Instruct`; `Hy-MT2-*B-Instruct` | √ |
| 4 | `Qwen2-*`; `Qwen2.5-*-Instruct-1M`; `Qwen2.5-Math-*-Instruct` | √ |
| 5 | `Qwen3-*-Instruct-2507`; `Qwen3-*-Thinking*`; `Qwen3-Next-*-Instruct`; `Qwen3-Next-*-Thinking` | √ |
| 6 | `QwQ-32B-Instruct`; `QwQ-32B-Preview-Instruct` | √ |
| 7 | `Falcon-H1-*B-*Instruct` | √ |
| 8 | `Granite-3.0-{1B-A400M,3B-A800M,2B,8B}-Instruct` | √ |
| 9 | `Llama-3-*B-Chinese-Chat` | √ |
| 10 (current PR) | `Yi-6B-Chat`; `Yi-34B-Chat` | √ |
| 11 | Automatic pre-training consistency warning | × |

### Planned PR
The validation and correction work described above has already covered 80% of the models. Some model families, such as Qwen 3.5, Gemini, MiniCPM, and MiniMax, could not be completed immediately due to the workload and the need to merge other contributors’ PRs. They will be gradually addressed in follow-up work.

## Models Fixed Diff

### 01-ai/Yi-6B-Chat

| Sample Type | Transformers | Original | Modified |
| --- | --- | --- | --- |
| `multi_turn_with_system` | <code>&lt;&#124;im_start&#124;&gt;&nbsp;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;user<br>A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;assistant<br>There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;user<br>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;&nbsp;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;user<br>A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;assistant<br><span style="background-color: #ffebe9;">&nbsp;</span>There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;user<br>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;assistant<br></code> | <code>&lt;&#124;im_start&#124;&gt;&nbsp;system<br>You&nbsp;are&nbsp;a&nbsp;helpful&nbsp;math&nbsp;assistant.&nbsp;Give&nbsp;a&nbsp;concise&nbsp;final&nbsp;answer.&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;user<br>A&nbsp;box&nbsp;contains&nbsp;12&nbsp;red&nbsp;markers&nbsp;and&nbsp;8&nbsp;blue&nbsp;markers.&nbsp;How&nbsp;many&nbsp;markers&nbsp;are&nbsp;there?&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;assistant<br>There&nbsp;are&nbsp;20&nbsp;markers.&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;user<br>If&nbsp;5&nbsp;markers&nbsp;are&nbsp;removed,&nbsp;how&nbsp;many&nbsp;remain?&lt;&#124;im_end&#124;&gt;&nbsp;<br>&lt;&#124;im_start&#124;&gt;&nbsp;assistant<br></code> |

### 01-ai/Yi-Coder-1.5B-Chat

The original template was already consistent.

## Models Fixed in This PR

**Yi-6B-Chat and Yi-34B-Chat**

**Background**

The visible ChatML text was already correct. However, Yi's legacy metaspace tokenizer must encode an assistant response as a continuation of the rendered assistant prefix. Encoding the response independently inserts an extra word-boundary token in some multi-turn examples.

**Root Cause**

The generic template tokenized each rendered message slot independently. This differed from the tokenizer's continuous `apply_chat_template()` encoding even when the decoded text looked identical.

**Solution**

1. Add `YiLegacyTemplate`, which derives the prompt and response text from the registered formatter output instead of hard-coding the assistant prefix.
2. Encode each prompt/response pair continuously and split the IDs at their longest common token prefix. Boundary merges are assigned to the response rather than causing a hard failure.
3. Keep the shared `_encode()` contract by returning the encoded message list together with an empty handled-response set, since Yi changes continuous tokenization but does not apply reasoning-boundary handling.
3. Register `yi_legacy` with the same visible ChatML slots as `yi`.
4. Move only `Yi-6B-Chat` and `Yi-34B-Chat` to `yi_legacy`; keep Yi-1.5, Yi-Coder, base Yi, and quantized Yi mappings unchanged.

## Unit Tests

`test_yi_legacy_template_consistency()` compares generation-prompt and full-conversation IDs for both legacy Yi tokenizers across single-turn, multi-turn, explicit-system, and Chinese-content cases.

`test_yi_legacy_template_boundary_merge()` uses a tokenizer with a deliberate cross-boundary merge to verify that the combined IDs remain identical to continuous tokenization and that the merged token is assigned to the response.

```bash
pytest -q tests/data/test_template.py::test_yi_legacy_template_consistency tests/data/test_template.py::test_yi_legacy_template_boundary_merge
```

## About Test Samples

Models are classified as reasoning-only, non-reasoning-only, or dual-mode. Reasoning-only models use the reasoning sample, non-reasoning-only models use the non-reasoning sample, and dual-mode models use both. Each sample covers a single turn without a system prompt, a single turn with a system prompt, multi-turn dialogue with a system prompt, and multi-turn tool use with a system prompt.

Specific test examples will be elaborated in the consistency-checking mechanism PR.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
