### PR TITLE
[v1] Disable dropout during DPO training

### DIFF
--- a/src/llamafactory/v1/config/training_args.py
+++ b/src/llamafactory/v1/config/training_args.py
@@ -144,6 +144,10 @@ class TrainingArguments:
         default=1,
         metadata={"help": "Log metrics every N optimizer steps."},
     )
+    disable_dropout: bool = field(
+        default=True,
+        metadata={"help": "Disable model dropout during DPO and reward model training."},
+    )
     pref_loss: Literal["sigmoid", "orpo", "simpo"] = field(
         default="sigmoid",
         metadata={"help": "The type of DPO loss to use."},

--- a/src/llamafactory/v1/trainers/dpo_trainer.py
+++ b/src/llamafactory/v1/trainers/dpo_trainer.py
@@ -27,16 +27,10 @@ from ..core.model_engine import ModelEngine
 from ..utils import logging
 from ..utils.constants import IGNORE_INDEX
 from ..utils.types import BatchInput, HFModel, Tensor
+from .dropout import disable_dropout_in_model
 
 
 logger = logging.get_logger(__name__)
-
-
-def _disable_dropout_in_model(model: HFModel) -> None:
-    r"""Disable module dropout so preference log-probabilities stay deterministic."""
-    for module in model.modules():
-        if isinstance(module, torch.nn.Dropout):
-            module.p = 0.0
 
 
 def compute_sigmoid_dpo_loss(
@@ -100,14 +94,16 @@ class DPOTrainer(BaseTrainer):
         renderer,
         train_dataset,
         callbacks=None,
+        disable_dropout: bool = True,
     ) -> None:
         if args.cp_size > 1:
             raise NotImplementedError("DPO trainer currently only supports cp_size == 1.")
 
-        # DPO compares policy and reference log-probabilities for the same sequence. Keeping
-        # dropout active makes both estimates stochastic (including the LoRA reference path,
-        # which reuses this model with adapters disabled) and injects noise into the objective.
-        _disable_dropout_in_model(model)
+        if disable_dropout:
+            # DPO compares policy and reference log-probabilities for the same sequence. Keeping
+            # dropout active makes both estimates stochastic (including the LoRA reference path,
+            # which reuses this model with adapters disabled) and injects noise into the objective.
+            disable_dropout_in_model(model)
 
         self.pref_loss = args.pref_loss
         self.pref_beta = args.pref_beta

--- a/src/llamafactory/v1/trainers/dpo_trainer.py
+++ b/src/llamafactory/v1/trainers/dpo_trainer.py
@@ -32,6 +32,13 @@ from ..utils.types import BatchInput, HFModel, Tensor
 logger = logging.get_logger(__name__)
 
 
+def _disable_dropout_in_model(model: HFModel) -> None:
+    r"""Disable module dropout so preference log-probabilities stay deterministic."""
+    for module in model.modules():
+        if isinstance(module, torch.nn.Dropout):
+            module.p = 0.0
+
+
 def compute_sigmoid_dpo_loss(
     policy_chosen_logps: Tensor,
     policy_rejected_logps: Tensor,
@@ -96,6 +103,11 @@ class DPOTrainer(BaseTrainer):
     ) -> None:
         if args.cp_size > 1:
             raise NotImplementedError("DPO trainer currently only supports cp_size == 1.")
+
+        # DPO compares policy and reference log-probabilities for the same sequence. Keeping
+        # dropout active makes both estimates stochastic (including the LoRA reference path,
+        # which reuses this model with adapters disabled) and injects noise into the objective.
+        _disable_dropout_in_model(model)
 
         self.pref_loss = args.pref_loss
         self.pref_beta = args.pref_beta

--- a/src/llamafactory/v1/trainers/dpo_trainer.py
+++ b/src/llamafactory/v1/trainers/dpo_trainer.py
@@ -94,12 +94,11 @@ class DPOTrainer(BaseTrainer):
         renderer,
         train_dataset,
         callbacks=None,
-        disable_dropout: bool = True,
     ) -> None:
         if args.cp_size > 1:
             raise NotImplementedError("DPO trainer currently only supports cp_size == 1.")
 
-        if disable_dropout:
+        if args.disable_dropout:
             # DPO compares policy and reference log-probabilities for the same sequence. Keeping
             # dropout active makes both estimates stochastic (including the LoRA reference path,
             # which reuses this model with adapters disabled) and injects noise into the objective.

--- a/src/llamafactory/v1/trainers/dropout.py
+++ b/src/llamafactory/v1/trainers/dropout.py
@@ -1,0 +1,75 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import torch
+from transformers import PretrainedConfig
+
+from ..utils.types import HFModel
+
+
+_DROPOUT_ATTRIBUTES = (
+    "activation_dropout",
+    "attention_dropout",
+    "attention_probs_dropout_prob",
+    "attn_pdrop",
+    "classifier_dropout",
+    "dropout",
+    "dropout_rate",
+    "embd_pdrop",
+    "hidden_dropout",
+    "hidden_dropout_prob",
+    "resid_pdrop",
+    "summary_first_dropout",
+)
+_DROPOUT_MODULES = (
+    torch.nn.Dropout,
+    torch.nn.Dropout1d,
+    torch.nn.Dropout2d,
+    torch.nn.Dropout3d,
+    torch.nn.AlphaDropout,
+    torch.nn.FeatureAlphaDropout,
+)
+
+
+def _zero_dropout_attributes(obj) -> None:
+    for name in _DROPOUT_ATTRIBUTES:
+        value = getattr(obj, name, None)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            setattr(obj, name, 0.0)
+
+
+def disable_dropout_in_model(model: HFModel) -> None:
+    r"""Disable module and functional dropout paths used by Transformers models."""
+    configs = []
+    for module in model.modules():
+        if isinstance(module, _DROPOUT_MODULES):
+            module.p = 0.0
+
+        # Llama/Qwen-style attention applies dropout with a float stored on the
+        # attention module rather than an ``nn.Dropout`` child.
+        _zero_dropout_attributes(module)
+        config = getattr(module, "config", None)
+        if isinstance(config, PretrainedConfig):
+            configs.append(config)
+
+    seen = set()
+    while configs:
+        config = configs.pop()
+        if id(config) in seen:
+            continue
+
+        seen.add(id(config))
+        _zero_dropout_attributes(config)
+        configs.extend(value for value in vars(config).values() if isinstance(value, PretrainedConfig))

--- a/src/llamafactory/v1/trainers/dropout.py
+++ b/src/llamafactory/v1/trainers/dropout.py
@@ -14,7 +14,6 @@
 
 
 import torch
-from transformers import PretrainedConfig
 
 from ..utils.types import HFModel
 
@@ -52,24 +51,8 @@ def _zero_dropout_attributes(obj) -> None:
 
 def disable_dropout_in_model(model: HFModel) -> None:
     r"""Disable module and functional dropout paths used by Transformers models."""
-    configs = []
     for module in model.modules():
         if isinstance(module, _DROPOUT_MODULES):
             module.p = 0.0
 
-        # Llama/Qwen-style attention applies dropout with a float stored on the
-        # attention module rather than an ``nn.Dropout`` child.
         _zero_dropout_attributes(module)
-        config = getattr(module, "config", None)
-        if isinstance(config, PretrainedConfig):
-            configs.append(config)
-
-    seen = set()
-    while configs:
-        config = configs.pop()
-        if id(config) in seen:
-            continue
-
-        seen.add(id(config))
-        _zero_dropout_attributes(config)
-        configs.extend(value for value in vars(config).values() if isinstance(value, PretrainedConfig))

--- a/src/llamafactory/v1/trainers/rm_trainer.py
+++ b/src/llamafactory/v1/trainers/rm_trainer.py
@@ -24,6 +24,7 @@ from ..core.data_engine import DataEngine
 from ..core.model_engine import ModelEngine
 from ..utils import logging
 from ..utils.types import BatchInput, HFModel, Tensor
+from .dropout import disable_dropout_in_model
 
 
 logger = logging.get_logger(__name__)
@@ -75,9 +76,13 @@ class RMTrainer(BaseTrainer):
         renderer,
         train_dataset,
         callbacks=None,
+        disable_dropout: bool = True,
     ) -> None:
         if args.cp_size > 1:
             raise NotImplementedError("RM trainer currently only supports cp_size == 1.")
+
+        if disable_dropout:
+            disable_dropout_in_model(model)
 
         super().__init__(args, model, renderer, train_dataset, callbacks)
 

--- a/src/llamafactory/v1/trainers/rm_trainer.py
+++ b/src/llamafactory/v1/trainers/rm_trainer.py
@@ -76,12 +76,11 @@ class RMTrainer(BaseTrainer):
         renderer,
         train_dataset,
         callbacks=None,
-        disable_dropout: bool = True,
     ) -> None:
         if args.cp_size > 1:
             raise NotImplementedError("RM trainer currently only supports cp_size == 1.")
 
-        if disable_dropout:
+        if args.disable_dropout:
             disable_dropout_in_model(model)
 
         super().__init__(args, model, renderer, train_dataset, callbacks)

--- a/tests_v1/trainers/test_dpo_dropout.py
+++ b/tests_v1/trainers/test_dpo_dropout.py
@@ -19,6 +19,7 @@ import torch
 import torch.nn.functional as F
 from transformers import PretrainedConfig
 
+from llamafactory.v1.config import get_args
 from llamafactory.v1.trainers.dpo_trainer import DPOTrainer
 from llamafactory.v1.trainers.rm_trainer import RMTrainer
 
@@ -45,9 +46,10 @@ class _DropoutModel(torch.nn.Module):
         return self.functional_dropout(self.module_dropout(self.linear(inputs)))
 
 
-def _get_args():
+def _get_args(disable_dropout: bool = True):
     return SimpleNamespace(
         cp_size=1,
+        disable_dropout=disable_dropout,
         pref_loss="orpo",
         pref_beta=0.1,
         pref_ftx=0.0,
@@ -67,8 +69,8 @@ def test_dpo_trainer_disables_dropout():
     assert model.training
     assert model.module_dropout.p == 0.0
     assert model.functional_dropout.attention_dropout == 0.0
-    assert model.config.attention_dropout == 0.0
-    assert model.config.text_config.hidden_dropout == 0.0
+    assert model.config.attention_dropout == 0.5
+    assert model.config.text_config.hidden_dropout == 0.25
     inputs = torch.ones(2, 4)
     torch.manual_seed(1)
     first = model(inputs)
@@ -95,10 +97,15 @@ def test_preference_trainers_can_keep_dropout_enabled():
         patch("llamafactory.v1.trainers.dpo_trainer.BaseTrainer.__init__", return_value=None),
         patch("llamafactory.v1.trainers.rm_trainer.BaseTrainer.__init__", return_value=None),
     ):
-        DPOTrainer(_get_args(), dpo_model, renderer=None, train_dataset=None, disable_dropout=False)
-        RMTrainer(_get_args(), rm_model, renderer=None, train_dataset=None, disable_dropout=False)
+        DPOTrainer(_get_args(disable_dropout=False), dpo_model, renderer=None, train_dataset=None)
+        RMTrainer(_get_args(disable_dropout=False), rm_model, renderer=None, train_dataset=None)
 
     assert dpo_model.module_dropout.p == 0.75
     assert dpo_model.functional_dropout.attention_dropout == 0.5
     assert rm_model.module_dropout.p == 0.75
     assert rm_model.functional_dropout.attention_dropout == 0.5
+
+
+def test_training_arguments_parser_exposes_dropout_control():
+    assert get_args({})[2].disable_dropout
+    assert not get_args({"disable_dropout": False})[2].disable_dropout

--- a/tests_v1/trainers/test_dpo_dropout.py
+++ b/tests_v1/trainers/test_dpo_dropout.py
@@ -16,19 +16,37 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
+import torch.nn.functional as F
+from transformers import PretrainedConfig
 
 from llamafactory.v1.trainers.dpo_trainer import DPOTrainer
+from llamafactory.v1.trainers.rm_trainer import RMTrainer
 
 
-def test_dpo_trainer_disables_dropout():
-    model = torch.nn.Sequential(
-        torch.nn.Linear(4, 4),
-        torch.nn.Dropout(p=0.75),
-        torch.nn.Sequential(torch.nn.Dropout(p=0.25)),
-    )
-    model.train()
+class _FunctionalDropout(torch.nn.Module):
+    def __init__(self, p: float = 0.5) -> None:
+        super().__init__()
+        self.attention_dropout = p
 
-    args = SimpleNamespace(
+    def forward(self, inputs):
+        return F.dropout(inputs, p=self.attention_dropout, training=self.training)
+
+
+class _DropoutModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.config = PretrainedConfig(attention_dropout=0.5)
+        self.config.text_config = PretrainedConfig(hidden_dropout=0.25)
+        self.linear = torch.nn.Linear(4, 4)
+        self.module_dropout = torch.nn.Dropout(p=0.75)
+        self.functional_dropout = _FunctionalDropout(p=0.5)
+
+    def forward(self, inputs):
+        return self.functional_dropout(self.module_dropout(self.linear(inputs)))
+
+
+def _get_args():
+    return SimpleNamespace(
         cp_size=1,
         pref_loss="orpo",
         pref_beta=0.1,
@@ -37,14 +55,50 @@ def test_dpo_trainer_disables_dropout():
         ld_alpha=None,
         dpo_label_smoothing=0.0,
     )
+
+
+def test_dpo_trainer_disables_dropout():
+    model = _DropoutModel()
+    model.train()
+
     with patch("llamafactory.v1.trainers.dpo_trainer.BaseTrainer.__init__", return_value=None):
-        DPOTrainer(args, model, renderer=None, train_dataset=None)
+        DPOTrainer(_get_args(), model, renderer=None, train_dataset=None)
 
     assert model.training
-    assert all(module.p == 0.0 for module in model.modules() if isinstance(module, torch.nn.Dropout))
+    assert model.module_dropout.p == 0.0
+    assert model.functional_dropout.attention_dropout == 0.0
+    assert model.config.attention_dropout == 0.0
+    assert model.config.text_config.hidden_dropout == 0.0
     inputs = torch.ones(2, 4)
     torch.manual_seed(1)
     first = model(inputs)
     torch.manual_seed(2)
     second = model(inputs)
     torch.testing.assert_close(first, second)
+
+
+def test_rm_trainer_disables_dropout():
+    model = _DropoutModel()
+
+    with patch("llamafactory.v1.trainers.rm_trainer.BaseTrainer.__init__", return_value=None):
+        RMTrainer(_get_args(), model, renderer=None, train_dataset=None)
+
+    assert model.module_dropout.p == 0.0
+    assert model.functional_dropout.attention_dropout == 0.0
+
+
+def test_preference_trainers_can_keep_dropout_enabled():
+    dpo_model = _DropoutModel()
+    rm_model = _DropoutModel()
+
+    with (
+        patch("llamafactory.v1.trainers.dpo_trainer.BaseTrainer.__init__", return_value=None),
+        patch("llamafactory.v1.trainers.rm_trainer.BaseTrainer.__init__", return_value=None),
+    ):
+        DPOTrainer(_get_args(), dpo_model, renderer=None, train_dataset=None, disable_dropout=False)
+        RMTrainer(_get_args(), rm_model, renderer=None, train_dataset=None, disable_dropout=False)
+
+    assert dpo_model.module_dropout.p == 0.75
+    assert dpo_model.functional_dropout.attention_dropout == 0.5
+    assert rm_model.module_dropout.p == 0.75
+    assert rm_model.functional_dropout.attention_dropout == 0.5

--- a/tests_v1/trainers/test_dpo_dropout.py
+++ b/tests_v1/trainers/test_dpo_dropout.py
@@ -1,0 +1,50 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from llamafactory.v1.trainers.dpo_trainer import DPOTrainer
+
+
+def test_dpo_trainer_disables_dropout():
+    model = torch.nn.Sequential(
+        torch.nn.Linear(4, 4),
+        torch.nn.Dropout(p=0.75),
+        torch.nn.Sequential(torch.nn.Dropout(p=0.25)),
+    )
+    model.train()
+
+    args = SimpleNamespace(
+        cp_size=1,
+        pref_loss="orpo",
+        pref_beta=0.1,
+        pref_ftx=0.0,
+        simpo_gamma=0.0,
+        ld_alpha=None,
+        dpo_label_smoothing=0.0,
+    )
+    with patch("llamafactory.v1.trainers.dpo_trainer.BaseTrainer.__init__", return_value=None):
+        DPOTrainer(args, model, renderer=None, train_dataset=None)
+
+    assert model.training
+    assert all(module.p == 0.0 for module in model.modules() if isinstance(module, torch.nn.Dropout))
+    inputs = torch.ones(2, 4)
+    torch.manual_seed(1)
+    first = model(inputs)
+    torch.manual_seed(2)
+    second = model(inputs)
+    torch.testing.assert_close(first, second)


### PR DESCRIPTION
# What does this PR do?

The v1 DPO and reward-model trainers run paired comparisons while the model remains in training mode. Active module or functional dropout makes those scores stochastic, including the adapter-disabled reference forward used by LoRA DPO.

This change:

- adds `disable_dropout: bool = True` to v1 `TrainingArguments`, so CLI and YAML configs can opt out;
- disables `torch.nn.Dropout` modules and numeric dropout attributes used by functional attention paths;
- applies the shared policy to both DPO and reward-model training;
- leaves the model's `PretrainedConfig` unchanged, so exported checkpoints retain the base model's dropout metadata; and
- preserves the existing v0-compatible default while supporting `disable_dropout: false`.

The regression tests cover module dropout, functional dropout, DPO and RM integration, config preservation, deterministic forwards, the opt-out path, and argument parsing.

## Tests

- `uv run --with pytest python -m pytest --import-mode=importlib tests_v1/trainers/test_dpo_dropout.py -q` (`4 passed` on Windows, Python 3.13)
- `uv run pre-commit run --files` on all five changed files (AST, conflict, whitespace, pyupgrade, Ruff lint, and Ruff format hooks passed)

## Before submitting

- [x] Did you read the contributor guideline?
- [x] Did you write any new necessary tests?