### PR TITLE
修复(data):在 packed-mrope 路径补齐合并后的 position_ids(延续 #10737)

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -317,6 +317,16 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                 [features["attention_mask"], dummy_image_right_padding_attention_mask], dim=-1
             )
 
+        # Mirror the non-FA2 packing fix (#10737) for the packed-mrope path. The merged position_ids
+        # is built from per-subseq sequence_boundaries, which end at cutoff_len, while
+        # `DataCollatorForSeq2Seq(pad_to_multiple_of=...)` right-pads input_ids/attention_mask past
+        # cutoff_len. Right-pad the trailing (masked) positions with 0 so the merged position_ids
+        # matches seq_len before validating. Works for both 2D and 3D (mrope) position_ids since the
+        # sequence axis is last, and is idempotent with the has_dummy_image cat above.
+        pad_len = seq_len - features["position_ids"].shape[-1]
+        if pad_len > 0:
+            features["position_ids"] = F.pad(features["position_ids"], (0, pad_len), value=0)
+
         if features["position_ids"].shape != expected_position_ids_shape:
             raise ValueError(
                 "Merged position_ids shape mismatch: "


### PR DESCRIPTION
## 这个 PR 做了什么 / What does this PR do

延续 #10737,把「pad_to_multiple_of 补齐了 input_ids 却没补齐 position_ids」这一修复扩展到 **mrope 模型的打包路径**。

Closes #10782(修复 issue #10782)

## 根因 / Root cause

mrope 模型(`MROPE_MODELS`:Qwen2-VL / Qwen2.5-VL / Qwen3-VL / Qwen3.5 等)的 `position_ids` 是在 `_compute_rope_position_ids_with_packing` 里按子序列预先计算、再依据 `sequence_boundaries` 拼接的,长度停在 `cutoff_len`。而 `DataCollatorForSeq2Seq(pad_to_multiple_of=8)` 会把 `input_ids` / `attention_mask` 右补齐到 8 的倍数;`position_ids` 不在 `model_input_names` 里,不会被补齐。

当 `cutoff_len % 8 != 0` 时,合并后的 `position_ids`(= `cutoff_len`)短于 `seq_len`(下一个 8 的倍数),末尾的形状校验抛出:

```
ValueError: Merged position_ids shape mismatch: got torch.Size([3, 1, 1234]), expected (3, 1, 1240).
```

#10737 只修了非 mrope 的通用 SDPA/eager 分支(`SFTDataCollatorWith4DAttentionMask.__call__` 的 `else`),没有覆盖 packed-mrope 的合并校验。

## 改动 / Solution

在 `_compute_rope_position_ids_with_packing` 的形状校验之前,把合并后的 `position_ids` 右补齐(补 0,补在末尾被 mask 的位置)到 `seq_len`,做法与 #10737 一致:

```python
pad_len = seq_len - features["position_ids"].shape[-1]
if pad_len > 0:
    features["position_ids"] = F.pad(features["position_ids"], (0, pad_len), value=0)
```

- 对 2D 和 3D(mrope)`position_ids` 都成立(序列维在最后一维)。
- 与上方 `has_dummy_image` 的 cat 幂等(补 0 长度为 0 时不动)。
- 不影响非打包 / FA2 路径。

## 验证 / Verification

`Qwen/Qwen3.5-0.8B` + `mllm_demo` + `neat_packing` + `sdpa` + `cutoff_len=1234`:

- **修复前**:第 0 步崩溃 `Merged position_ids shape mismatch: got (3,1,1234), expected (3,1,1240)`
- **修复后**:正常训练,`loss 2.227`,顺利跑完

## Before submitting

- [x] Does your PR follow the [contributor guidelines](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Have you verified the change locally?