### PR TITLE
[template] add Qwen3.8 chat template support

### DIFF
--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -540,6 +540,7 @@ class Qwen38ReasoningTemplate(ReasoningTemplate):
                 "conclusion without unnecessary elaboration."
             )
         else:
+            # Defensive validation for callers that configure the template without DataArguments.
             raise ValueError(
                 f"Unexpected reasoning effort {self.reasoning_effort}. "
                 "Supported types are xhigh (default), medium, and low."

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -517,6 +517,79 @@ class ReasoningTemplate(Template):
 
 
 @dataclass
+class Qwen38ReasoningTemplate(ReasoningTemplate):
+    r"""Qwen3.8 template with reasoning-effort instructions and official system ordering."""
+
+    reasoning_effort: str = "xhigh"
+
+    def _get_reasoning_instruction(self) -> str:
+        if self.enable_thinking is False:
+            return ""
+
+        if self.reasoning_effort == "xhigh":
+            return (
+                "Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, "
+                "consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final "
+                "answer."
+            )
+        elif self.reasoning_effort == "medium":
+            return ""
+        elif self.reasoning_effort == "low":
+            return (
+                "Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the "
+                "conclusion without unnecessary elaboration."
+            )
+        else:
+            raise ValueError(
+                f"Unexpected reasoning effort {self.reasoning_effort}. "
+                "Supported types are xhigh (default), medium, and low."
+            )
+
+    @override
+    def _encode(
+        self,
+        tokenizer: "PreTrainedTokenizer",
+        messages: list[dict[str, str]],
+        system: Optional[str],
+        tools: Optional[str],
+    ) -> list[list[int]]:
+        system = (system or self.default_system).strip()
+        reasoning_instruction = self._get_reasoning_instruction()
+        encoded_messages = []
+        for i, message in enumerate(messages):
+            elements = []
+
+            if i == 0:
+                elements += self.format_prefix.apply()
+                system_parts = []
+                if reasoning_instruction:
+                    system_parts.append(reasoning_instruction)
+                if tools:
+                    system_parts.append(self.format_tools.apply(content=tools)[0].lstrip("\n"))
+                if system:
+                    system_parts.append(system)
+                if system_parts:
+                    elements += self.format_system.apply(content="\n\n".join(system_parts))
+
+            if message["role"] == Role.USER:
+                elements += self.format_user.apply(content=message["content"], idx=str(i // 2))
+            elif message["role"] == Role.ASSISTANT:
+                elements += self.format_assistant.apply(content=message["content"])
+            elif message["role"] == Role.OBSERVATION:
+                elements += self.format_observation.apply(content=message["content"])
+            elif message["role"] == Role.FUNCTION:
+                elements += self.format_function.apply(
+                    content=message["content"], thought_words=self.thought_words, tool_call_words=self.tool_call_words
+                )
+            else:
+                raise NotImplementedError("Unexpected role: {}".format(message["role"]))
+
+            encoded_messages.append(self._convert_elements_to_ids(tokenizer, elements))
+
+        return encoded_messages
+
+
+@dataclass
 class Glm47ReasoningTemplate(ReasoningTemplate):
     r"""GLM-4.7 uses only the closing </think> tag for empty thinking blocks."""
 
@@ -687,6 +760,9 @@ def get_template_and_fix_tokenizer(tokenizer: "PreTrainedTokenizer", data_args: 
     if data_args.train_on_prompt and template.efficient_eos:
         raise ValueError("Current template does not support `train_on_prompt`.")
 
+    if isinstance(template, Qwen38ReasoningTemplate) and data_args.tool_format not in {None, "qwen3_8"}:
+        raise ValueError("Template `qwen3_8` uses its built-in tool format; remove the incompatible `tool_format`.")
+
     if data_args.tool_format is not None:
         logger.info_rank0(f"Using tool format: {data_args.tool_format}.")
         default_slots = ["{{content}}"] if template.efficient_eos else ["{{content}}", {"eos_token"}]
@@ -706,7 +782,13 @@ def get_template_and_fix_tokenizer(tokenizer: "PreTrainedTokenizer", data_args: 
             "e.g., qwen3_vl_nothink"
         )
         template.enable_thinking = data_args.enable_thinking
-        template.preserve_thinking = data_args.preserve_thinking
+        if isinstance(template, Qwen38ReasoningTemplate):
+            template.reasoning_effort = data_args.reasoning_effort
+            template.preserve_thinking = (
+                True if data_args.preserve_thinking is None else data_args.preserve_thinking
+            )
+        elif data_args.preserve_thinking is not None:
+            template.preserve_thinking = data_args.preserve_thinking
 
     template.fix_special_tokens(tokenizer)
     template.fix_jinja_template(tokenizer)
@@ -2265,6 +2347,24 @@ register_template(
     replace_eos=True,
     mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
     template_class=ReasoningTemplate,
+)
+
+
+register_template(
+    name="qwen3_8",
+    format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),
+    format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
+    format_function=FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="qwen3_8"),
+    format_observation=StringFormatter(
+        slots=["<|im_start|>user\n<tool_response>\n{{content}}\n</tool_response><|im_end|>\n<|im_start|>assistant\n"]
+    ),
+    format_tools=ToolFormatter(tool_format="qwen3_8"),
+    stop_words=["<|im_end|>"],
+    replace_eos=True,
+    preserve_thinking=True,
+    mm_plugin=get_mm_plugin(name="qwen3_vl", image_token="<|image_pad|>", video_token="<|video_pad|>"),
+    template_class=Qwen38ReasoningTemplate,
 )
 
 

--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -681,6 +681,20 @@ class Qwen35ToolUtils(ToolUtils):
         return results if results else content
 
 
+class Qwen38ToolUtils(Qwen35ToolUtils):
+    r"""Qwen 3.8 tool template preserving the OpenAI function wrapper."""
+
+    @override
+    @staticmethod
+    def tool_formatter(tools: list[dict[str, Any]]) -> str:
+        tool_text = ""
+        for tool in tools:
+            wrapped_tool = tool if tool.get("type") == "function" else {"type": "function", "function": tool}
+            tool_text += "\n" + json.dumps(wrapped_tool, ensure_ascii=False)
+
+        return QWEN35_TOOL_PROMPT.format(tool_text=tool_text)
+
+
 class GLM4MOEToolUtils(QwenToolUtils):
     r"""GLM-4-MOE tool using template."""
 
@@ -892,6 +906,7 @@ TOOLS = {
     "mistral": MistralToolUtils(),
     "qwen": QwenToolUtils(),
     "qwen3_5": Qwen35ToolUtils(),
+    "qwen3_8": Qwen38ToolUtils(),
     "glm4_moe": GLM4MOEToolUtils(),
     "seed_oss": SeedToolUtils(),
     "ling": LingToolUtils(),

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -125,9 +125,18 @@ class DataArguments:
         default=True,
         metadata={"help": "Whether or not to enable thinking mode for reasoning models."},
     )
-    preserve_thinking: bool = field(
-        default=False,
-        metadata={"help": "Whether or not to preserve thinking content in historical turns for reasoning models."},
+    reasoning_effort: str = field(
+        default="xhigh",
+        metadata={"help": "Reasoning effort for supported reasoning models (xhigh, medium, or low)."},
+    )
+    preserve_thinking: bool | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Whether or not to preserve thinking content in historical turns for reasoning models. "
+                "Uses the template default when unspecified."
+            )
+        },
     )
     tokenized_path: str | None = field(
         default=None,
@@ -181,6 +190,9 @@ class DataArguments:
 
         if self.mask_history and self.train_on_prompt:
             raise ValueError("`mask_history` is incompatible with `train_on_prompt`.")
+
+        if self.reasoning_effort not in {"xhigh", "medium", "low"}:
+            raise ValueError("`reasoning_effort` must be one of xhigh, medium, or low.")
 
         if self.neat_packing:
             self.packing = True

--- a/tests/data/test_formatter.py
+++ b/tests/data/test_formatter.py
@@ -282,6 +282,14 @@ def test_qwen_tool_extractor():
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
+def test_qwen38_tool_formatter():
+    formatter = ToolFormatter(tool_format="qwen3_8")
+    wrapped_tool = {"type": "function", "function": TOOLS[0]}
+    output = formatter.apply(content=json.dumps(TOOLS))[0]
+    assert json.dumps(wrapped_tool, ensure_ascii=False) in output
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
 def test_qwen_multi_tool_extractor():
     formatter = ToolFormatter(tool_format="qwen")
     result = (

--- a/tests/data/test_template.py
+++ b/tests/data/test_template.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import pytest
@@ -52,6 +53,16 @@ MESSAGES_WITH_THOUGHT = [
     {"role": "user", "content": "你好"},
     {"role": "assistant", "content": "<think>\n模型思考内容\n</think>\n\n很高兴认识你！"},
 ]
+
+
+class CharTokenizer:
+    r"""Minimal reversible tokenizer for testing rendered template text."""
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return [ord(char) for char in text]
+
+    def decode(self, token_ids: list[int]) -> str:
+        return "".join(chr(token_id) for token_id in token_ids)
 
 
 def _check_tokenization(
@@ -237,6 +248,48 @@ def test_reasoning_encode_multiturn_discarding_history_cot(enable_thinking: bool
         tokenizer,
         (encoded_pairs[0][0], encoded_pairs[0][1], encoded_pairs[1][0], encoded_pairs[1][1]),
         (prompt_str_1, answer_str_1, prompt_str_2, answer_str_2),
+    )
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_qwen38_reasoning_instruction():
+    tokenizer = CharTokenizer()
+    template = deepcopy(TEMPLATES["qwen3_8"])
+    encoded_pairs = template.encode_multiturn(tokenizer, MESSAGES[:2], system="Medical assistant")
+
+    prompt_text = tokenizer.decode(encoded_pairs[0][0])
+    answer_text = tokenizer.decode(encoded_pairs[0][1])
+    assert prompt_text == (
+        "<|im_start|>system\n"
+        "Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, "
+        "consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer."
+        "\n\nMedical assistant<|im_end|>\n"
+        "<|im_start|>user\nHow are you<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert answer_text == "<think>\n\n</think>\n\nI am fine!<|im_end|>\n"
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_qwen38_tool_system_order():
+    tokenizer = CharTokenizer()
+    template = deepcopy(TEMPLATES["qwen3_8"])
+    tools = '[{"name":"get_weather","parameters":{"type":"object","properties":{}}}]'
+    messages = [
+        {"role": "user", "content": "How is the weather?"},
+        {"role": "function", "content": '{"name":"get_weather","arguments":{}}'},
+    ]
+    encoded_pairs = template.encode_multiturn(tokenizer, messages, system="Use tools safely", tools=tools)
+
+    prompt_text = tokenizer.decode(encoded_pairs[0][0])
+    answer_text = tokenizer.decode(encoded_pairs[0][1])
+    reasoning_text = template._get_reasoning_instruction()
+    tool_text = template.format_tools.apply(content=tools)[0].lstrip("\n")
+    assert prompt_text == (
+        f"<|im_start|>system\n{reasoning_text}\n\n{tool_text}\n\nUse tools safely<|im_end|>\n"
+        "<|im_start|>user\nHow is the weather?<|im_end|>\n<|im_start|>assistant\n"
+    )
+    assert answer_text == (
+        "<think>\n\n</think>\n\n<tool_call>\n<function=get_weather>\n</function>\n</tool_call><|im_end|>\n"
     )
 
 


### PR DESCRIPTION
# What does this PR do?

Adds a dedicated `qwen3_8` chat template aligned with the [official Qwen3.8 tokenizer template](https://huggingface.co/Qwen/Qwen3.8-27B/blob/main/chat_template.jinja).

- supports `reasoning_effort` values `xhigh`, `medium`, and `low`
- uses the official default `xhigh` reasoning instruction
- preserves historical thinking by default while allowing an explicit override
- aligns system message ordering as reasoning instruction -> tools -> original system prompt
- preserves the OpenAI function wrapper in tool definitions
- keeps Qwen3.8 XML tool-call formatting
- rejects incompatible tool-format overrides
- adds focused formatter and template regression tests

This complements #10749 and addresses the template difference noted in its review.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
