### PR TITLE
[docker] add NPU image tag history

### DIFF
--- a/docker/docker-npu/OVERVIEW.md
+++ b/docker/docker-npu/OVERVIEW.md
@@ -21,6 +21,8 @@ The following `latest` NPU image tags are available:
 | A2 | openEuler 24.03 | `latest-910b-openeuler` |
 | A3 | openEuler 24.03 | `latest-a3-openeuler` |
 
+For historical NPU image tags and links to their corresponding archived Dockerfiles, see [Supported Tags](./supported_tags.md).
+
 ## Image Overview
 
 The image includes the following core components:
@@ -54,7 +56,7 @@ latest-<chip>-<os>
 | `chip` | `910b` or `a3` | Ascend chip model supported by the image |
 | `os` | `ubuntu` or `openeuler` | Container operating system family |
 
-Release builds use full tags:
+Future NPU release images will use the full tag format below. Historical release images used earlier naming formats and do not follow this rule.
 
 ```text
 <LlamaFactory-version>-cann<CANN-version>-torch_npu<TorchNPU-version>-<chip>-<os>-<Python-version>

--- a/docker/docker-npu/OVERVIEW.zh.md
+++ b/docker/docker-npu/OVERVIEW.zh.md
@@ -21,6 +21,8 @@ LlamaFactory 昇腾 NPU 镜像面向华为昇腾 Atlas NPU，提供可直接使�
 | A2 | openEuler 24.03 | `latest-910b-openeuler` |
 | A3 | openEuler 24.03 | `latest-a3-openeuler` |
 
+历史版本的 NPU 镜像 Tag 及其对应的 Dockerfile 归档链接，请参阅 [Supported Tags](./supported_tags.md)。
+
 ## 镜像介绍
 
 镜像内预装以下主要组件：
@@ -54,7 +56,7 @@ latest-<芯片信息>-<操作系统>
 | `芯片信息` | `910b` 或 `a3` | 镜像所适配的昇腾芯片型号 |
 | `操作系统` | `ubuntu` 或 `openeuler` | 容器操作系统类型 |
 
-Release 构建使用完整 tag：
+后续发布的 NPU release 镜像将使用以下完整 tag 格式。历史 release 镜像使用旧的命名格式，不适用以下规则。
 
 ```text
 <LlamaFactory版本>-cann<CANN版本>-torch_npu<TorchNPU版本>-<芯片信息>-<操作系统>-<Python版本>

--- a/docker/docker-npu/supported_tags.md
+++ b/docker/docker-npu/supported_tags.md
@@ -1,0 +1,19 @@
+# Supported Ascend Tags
+
+This document records historical LlamaFactory Ascend NPU image tags and their corresponding archived Dockerfiles. For currently available images, tag naming rules, and usage instructions, see [OVERVIEW.md](./OVERVIEW.md) or [OVERVIEW.zh.md](./OVERVIEW.zh.md).
+
+## Historical Release Tags
+
+### `LlamaFactory v0.9.5`
+
+| Image tag | Dockerfile | content |
+| --- | --- | --- |
+| `0.9.5-npu-a2` | [`Dockerfile`](https://github.com/hiyouga/LlamaFactory/blob/v0.9.5/docker/docker-npu/Dockerfile) | toolkit/ops/nnal/torch_npu/LlamaFactory |
+| `0.9.5-npu-a3` | [`Dockerfile`](https://github.com/hiyouga/LlamaFactory/blob/v0.9.5/docker/docker-npu/Dockerfile) | toolkit/ops/nnal/torch_npu/LlamaFactory |
+
+### `LlamaFactory v0.9.4`
+
+| Image tag | Dockerfile | content |
+| --- | --- | --- |
+| `0.9.4-npu-a3` | [`Dockerfile`](https://github.com/hiyouga/LlamaFactory/blob/v0.9.4/docker/docker-npu/Dockerfile) | toolkit/ops/nnal/torch_npu/LlamaFactory |
+| `0.9.4-npu-a2` | [`Dockerfile`](https://github.com/hiyouga/LlamaFactory/blob/v0.9.4/docker/docker-npu/Dockerfile) | toolkit/ops/nnal/torch_npu/LlamaFactory |


### PR DESCRIPTION
# What does this PR do?

- add supported tags for LlamaFactory v0.9.4 and v0.9.5
- link historical tags from the English and Chinese overviews
- clarify that the new release tag format applies to future images

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
