### PR TITLE
[v1] fix: keep packed document boundaries in GDN context parallel

### DIFF
--- a/src/llamafactory/v1/plugins/model_plugins/parallelization/gdn_attention.py
+++ b/src/llamafactory/v1/plugins/model_plugins/parallelization/gdn_attention.py
@@ -19,6 +19,7 @@ import torch.nn.functional as F
 
 from .seq_comm import SeqAllToAll4D
 from .ulysses import (
+    _get_text_position_ids,
     get_ulysses_sequence_parallel_group,
     get_ulysses_sequence_parallel_world_size,
 )
@@ -68,7 +69,52 @@ def get_parameter_local_cp(param, dim, cp_group, split_sections=None):
     slices = [slice(None)] * param.dim()
     dim_size = param.size(dim=dim)
     slices[dim] = slice(cp_rank * dim_size // cp_size, (cp_rank + 1) * dim_size // cp_size)
-    return param[slices]
+    return param[tuple(slices)]
+
+
+def packed_cu_seqlens(position_ids, cp_group, cp_size):
+    """Document boundaries of the whole packed sequence, or None when there is nothing to split.
+
+    Every rank holds one shard of position_ids, so the boundaries are only visible after
+    gathering them back into one sequence.
+    """
+    position_ids = _get_text_position_ids(position_ids)
+    if position_ids is None:
+        return None
+
+    global_position_ids = [torch.empty_like(position_ids) for _ in range(cp_size)]
+    dist.all_gather(global_position_ids, position_ids, group=cp_group)
+    global_position_ids = torch.cat(global_position_ids, dim=-1).contiguous()
+
+    try:
+        from transformers.modeling_flash_attention_utils import prepare_fa_kwargs_from_position_ids
+    except ImportError:
+        return None
+
+    cu_seqlens = prepare_fa_kwargs_from_position_ids(global_position_ids)[0][0]
+    if cu_seqlens.numel() <= 2:
+        # One unbroken sequence. Nothing for the kernels to separate, and claiming otherwise
+        # would demand FLA from runs that are not packed at all.
+        return None
+
+    return cu_seqlens
+
+
+def bind_position_ids(decoder_layer, gdn_module):
+    """Hand the decoder layer's position_ids down to the GDN module it owns.
+
+    Transformers calls `linear_attn(hidden_states=..., cache_params=..., attention_mask=...)`
+    and stops there, so the packed document boundaries the collator encodes in position_ids
+    never reach the delta-rule kernels. Full attention receives them through the attention
+    interface, which is why only the linear layers of a hybrid model lose them.
+    """
+    original_forward = decoder_layer.forward
+
+    def forward_with_position_ids(*args, **kwargs):
+        gdn_module.cp_position_ids = kwargs.get("position_ids")
+        return original_forward(*args, **kwargs)
+
+    decoder_layer.forward = forward_with_position_ids
 
 
 def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
@@ -98,18 +144,14 @@ def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
     batch_size, seq_len, _ = hidden_states.shape
     full_seq_len = seq_len * cp_size
 
-    # Extract position_ids and derive cu_seqlens for pack support
+    # The decoder layer does not forward position_ids, so bind_position_ids parks them on the
+    # module before this runs.
     position_ids = kwargs.get("position_ids", None)
+    if position_ids is None:
+        position_ids = getattr(self, "cp_position_ids", None)
     cu_seqlens = None
-    if position_ids is not None and batch_size == 1:
-        global_position_ids = [torch.empty_like(position_ids) for _ in range(cp_size)]
-        dist.all_gather(global_position_ids, position_ids, group=cp_group)
-        global_position_ids = torch.cat(global_position_ids, dim=-1).contiguous()
-        try:
-            from transformers.modeling_flash_attention_utils import prepare_fa_kwargs_from_position_ids
-            cu_seqlens = prepare_fa_kwargs_from_position_ids(global_position_ids)[0][0]
-        except ImportError:
-            cu_seqlens = None
+    if batch_size == 1:
+        cu_seqlens = packed_cu_seqlens(position_ids, cp_group, cp_size)
 
     # Input projections in CP layout: [B, seq/cp, hidden]
     qkv = self.in_proj_qkv(hidden_states)  # [B, seq/cp, key_dim*2 + value_dim]

--- a/src/llamafactory/v1/plugins/model_plugins/parallelization/gdn_attention.py
+++ b/src/llamafactory/v1/plugins/model_plugins/parallelization/gdn_attention.py
@@ -17,12 +17,35 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 
+from ....utils.logging import get_logger
 from .seq_comm import SeqAllToAll4D
 from .ulysses import (
     _get_text_position_ids,
     get_ulysses_sequence_parallel_group,
     get_ulysses_sequence_parallel_world_size,
 )
+
+
+logger = get_logger(__name__)
+
+_warned_missing_boundaries = False
+
+
+def _warn_missing_boundaries(reason: str) -> None:
+    """Say once that the packed boundaries were lost, instead of training on the wrong mask.
+
+    Both ways of losing them are silent otherwise: the delta-rule kernels simply run without
+    cu_seqlens and the documents in a packed batch attend across each other.
+    """
+    global _warned_missing_boundaries
+    if _warned_missing_boundaries:
+        return
+
+    _warned_missing_boundaries = True
+    logger.warning_rank0(
+        f"Sequence parallelism could not derive packed document boundaries for the GDN layers: {reason}. "
+        "If this run packs multiple documents per sequence, they will attend across each other."
+    )
 
 
 def is_gdn_layer(layer) -> bool:
@@ -89,6 +112,7 @@ def packed_cu_seqlens(position_ids, cp_group, cp_size):
     try:
         from transformers.modeling_flash_attention_utils import prepare_fa_kwargs_from_position_ids
     except ImportError:
+        _warn_missing_boundaries("this transformers has no prepare_fa_kwargs_from_position_ids")
         return None
 
     cu_seqlens = prepare_fa_kwargs_from_position_ids(global_position_ids)[0][0]
@@ -115,6 +139,20 @@ def bind_position_ids(decoder_layer, gdn_module):
         return original_forward(*args, **kwargs)
 
     decoder_layer.forward = forward_with_position_ids
+
+
+def resolve_position_ids(gdn_module, kwargs):
+    """position_ids as the caller passed them, else as bind_position_ids parked them.
+
+    The keyword is normally absent, because transformers calls the GDN module without it;
+    the value on the module is then the one carrying the boundaries. A caller that passes
+    position_ids positionally lands here with neither, which is why the None case warns.
+    """
+    position_ids = kwargs.get("position_ids")
+    if position_ids is None:
+        position_ids = getattr(gdn_module, "cp_position_ids", None)
+
+    return position_ids
 
 
 def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
@@ -146,12 +184,13 @@ def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
 
     # The decoder layer does not forward position_ids, so bind_position_ids parks them on the
     # module before this runs.
-    position_ids = kwargs.get("position_ids", None)
-    if position_ids is None:
-        position_ids = getattr(self, "cp_position_ids", None)
+    position_ids = resolve_position_ids(self, kwargs)
     cu_seqlens = None
     if batch_size == 1:
-        cu_seqlens = packed_cu_seqlens(position_ids, cp_group, cp_size)
+        if position_ids is None:
+            _warn_missing_boundaries("position_ids did not reach the module")
+        else:
+            cu_seqlens = packed_cu_seqlens(position_ids, cp_group, cp_size)
 
     # Input projections in CP layout: [B, seq/cp, hidden]
     qkv = self.in_proj_qkv(hidden_states)  # [B, seq/cp, key_dim*2 + value_dim]

--- a/src/llamafactory/v1/plugins/model_plugins/parallelization/sequence_parallel.py
+++ b/src/llamafactory/v1/plugins/model_plugins/parallelization/sequence_parallel.py
@@ -24,7 +24,7 @@ from ....accelerator.interface import Dim, DistributedInterface
 from ....utils import logging
 from ....utils.plugin import BasePlugin
 from ....utils.types import ModelOutput
-from .gdn_attention import _get_gdn_module, gdn_forward_with_cp, is_gdn_layer
+from .gdn_attention import _get_gdn_module, bind_position_ids, gdn_forward_with_cp, is_gdn_layer
 from .ulysses import (
     UlyssesAttention,
     get_ulysses_sequence_parallel_group,
@@ -139,6 +139,8 @@ def apply_sequence_parallel(model, cp_size: int):
                 replaced_modules.add(id(gdn_module))
                 gdn_module.original_forward = gdn_module.forward
                 gdn_module.forward = gdn_forward_with_cp.__get__(gdn_module, type(gdn_module))
+                if gdn_module is not module:
+                    bind_position_ids(module, gdn_module)
                 gdn_name = name if gdn_module is module else f"{name}.linear_attn"
                 logger.info_rank0(f"Replaced GDN forward in {gdn_name} with gdn_forward_with_cp for context parallel.")
 

--- a/tests_v1/plugins/model_plugins/test_ulysses_cp.py
+++ b/tests_v1/plugins/model_plugins/test_ulysses_cp.py
@@ -76,6 +76,53 @@ def test_gdn_receives_position_ids_from_the_decoder_layer():
     assert layer.linear_attn.cp_position_ids is position_ids
 
 
+def test_gdn_position_ids_prefer_the_keyword():
+    # A caller that does pass the keyword is authoritative; the bound value is a stale
+    # leftover from whichever forward ran last.
+    module = torch.nn.Identity()
+    module.cp_position_ids = torch.tensor([[9, 9, 9]])
+    passed = torch.tensor([[0, 1, 2]])
+
+    assert gdn_attention.resolve_position_ids(module, {"position_ids": passed}) is passed
+
+
+def test_gdn_position_ids_fall_back_to_the_bound_value():
+    # This is the live path: transformers calls the GDN module without position_ids.
+    module = torch.nn.Identity()
+    bound = torch.tensor([[0, 1, 0, 1]])
+    module.cp_position_ids = bound
+
+    assert gdn_attention.resolve_position_ids(module, {}) is bound
+
+
+def test_gdn_position_ids_fall_back_when_the_keyword_is_none():
+    # A decoder-layer signature that defaults position_ids to None and forwards it anyway
+    # would otherwise mask the bound value.
+    module = torch.nn.Identity()
+    bound = torch.tensor([[0, 1, 0, 1]])
+    module.cp_position_ids = bound
+
+    assert gdn_attention.resolve_position_ids(module, {"position_ids": None}) is bound
+
+
+def test_gdn_position_ids_are_none_when_nothing_bound():
+    assert gdn_attention.resolve_position_ids(torch.nn.Identity(), {}) is None
+
+
+def test_gdn_missing_boundaries_warns_once(monkeypatch: pytest.MonkeyPatch):
+    # Losing the boundaries is silent otherwise, but this sits in a per-layer forward, so
+    # warning every call would bury the log it is supposed to surface.
+    messages = []
+    monkeypatch.setattr(gdn_attention, "_warned_missing_boundaries", False)
+    monkeypatch.setattr(gdn_attention.logger, "warning_rank0", messages.append)
+
+    gdn_attention._warn_missing_boundaries("position_ids did not reach the module")
+    gdn_attention._warn_missing_boundaries("this transformers has no prepare_fa_kwargs_from_position_ids")
+
+    assert len(messages) == 1
+    assert "position_ids did not reach the module" in messages[0]
+
+
 def test_gdn_cu_seqlens_marks_packed_document_boundaries(monkeypatch: pytest.MonkeyPatch):
     local_position_ids = torch.tensor([[0, 1, 2, 3]])
     remote_position_ids = torch.tensor([[0, 1, 2, 3]])

--- a/tests_v1/plugins/model_plugins/test_ulysses_cp.py
+++ b/tests_v1/plugins/model_plugins/test_ulysses_cp.py
@@ -20,7 +20,7 @@ from llamafactory.v1.accelerator.interface import DistributedInterface
 from llamafactory.v1.config.model_args import ModelArguments
 from llamafactory.v1.config.training_args import TrainingArguments
 from llamafactory.v1.core.model_engine import ModelEngine
-from llamafactory.v1.plugins.model_plugins.parallelization import ulysses
+from llamafactory.v1.plugins.model_plugins.parallelization import gdn_attention, ulysses
 from llamafactory.v1.plugins.model_plugins.parallelization.sequence_parallel import (
     SequenceParallelModelPlugin,
     sequence_parallel_loss,
@@ -54,6 +54,61 @@ def test_qwen3_5_broadcast_position_ids_keep_packed_boundaries(monkeypatch: pyte
 
     assert captured["position_ids"].tolist() == [[0, 1, 0, 1, 2, 3]]
     assert captured["position_ids"].is_contiguous()
+
+
+def test_gdn_receives_position_ids_from_the_decoder_layer():
+    # Transformers calls linear_attn with hidden_states / cache_params / attention_mask only,
+    # so without this binding the packed boundaries never reach the delta-rule kernels.
+    class DecoderLayer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear_attn = torch.nn.Identity()
+
+        def forward(self, hidden_states, position_ids=None, **kwargs):
+            return self.linear_attn(hidden_states)
+
+    layer = DecoderLayer()
+    gdn_attention.bind_position_ids(layer, layer.linear_attn)
+    position_ids = torch.tensor([[0, 1, 2, 0, 1]])
+
+    layer(torch.zeros(1, 5, 2), position_ids=position_ids)
+
+    assert layer.linear_attn.cp_position_ids is position_ids
+
+
+def test_gdn_cu_seqlens_marks_packed_document_boundaries(monkeypatch: pytest.MonkeyPatch):
+    local_position_ids = torch.tensor([[0, 1, 2, 3]])
+    remote_position_ids = torch.tensor([[0, 1, 2, 3]])
+
+    def fake_all_gather(outputs, tensor, **_):
+        outputs[0].copy_(tensor)
+        outputs[1].copy_(remote_position_ids)
+
+    monkeypatch.setattr(gdn_attention.dist, "all_gather", fake_all_gather)
+    cu_seqlens = gdn_attention.packed_cu_seqlens(local_position_ids, object(), 2)
+
+    assert cu_seqlens.tolist() == [0, 4, 8]
+
+
+def test_gdn_cu_seqlens_is_none_for_one_unbroken_sequence(monkeypatch: pytest.MonkeyPatch):
+    # An unpacked run has nothing for the kernels to separate, and claiming otherwise would
+    # demand flash-linear-attention from every sequence-parallel job.
+    local_position_ids = torch.tensor([[0, 1, 2, 3]])
+
+    def fake_all_gather(outputs, tensor, **_):
+        outputs[0].copy_(tensor)
+        outputs[1].copy_(torch.tensor([[4, 5, 6, 7]]))
+
+    monkeypatch.setattr(gdn_attention.dist, "all_gather", fake_all_gather)
+
+    assert gdn_attention.packed_cu_seqlens(local_position_ids, object(), 2) is None
+
+
+def test_gdn_cu_seqlens_ignores_true_mrope_position_ids(monkeypatch: pytest.MonkeyPatch):
+    mrope_position_ids = torch.tensor([[[0, 1, 2]], [[0, 1, 1]], [[0, 1, 0]]])
+    monkeypatch.setattr(gdn_attention.dist, "all_gather", lambda *_, **__: pytest.fail("gathered mRoPE ids"))
+
+    assert gdn_attention.packed_cu_seqlens(mrope_position_ids, object(), 2) is None
 
 
 def test_true_mrope_position_ids_are_not_used_as_packed_boundaries():


### PR DESCRIPTION
# What does this PR do?

Packed document boundaries are dropped by the GDN layers under context parallel, so the linear-attention half of a hybrid model trains with state carried across documents. Follow-up to #10727.

`gdn_forward_with_cp` reads the boundaries from `kwargs["position_ids"]`:

```python
position_ids = kwargs.get("position_ids", None)
cu_seqlens = None
if position_ids is not None and batch_size == 1:
    ...
```

but the decoder layer calls it with three keywords and nothing else:

```python
hidden_states = self.linear_attn(
    hidden_states=hidden_states,
    cache_params=past_key_values,
    attention_mask=attention_mask,
)
```

That is the same on `qwen3_5` and `qwen3_next` across v5.2 through v5.8, so `position_ids` never arrives, `cu_seqlens` is always `None`, and the whole block — including the `RuntimeError` that asks for flash-linear-attention — is unreachable.

Full attention does not lose this. `UlyssesAttention` receives `position_ids` through the attention interface and gathers them itself, which is what `test_qwen3_5_broadcast_position_ids_keep_packed_boundaries` covers. Qwen3.5 alternates three `linear_attention` layers per `full_attention` layer, so three quarters of the layers ignore the boundaries the other quarter respects.

## What it looks like

Two documents packed into one sequence over cp=2, tiny `Qwen3_5GatedDeltaNet`, the second document's content and position held fixed while the first document's content changes. Both runs go through a decoder-layer stand-in that calls `linear_attn` exactly the way transformers does.

Before:

```
global position_ids = [0, 1, 2, 3, 0, 1, 2, 3]   boundary at token 4
cu_seqlens handed to the kernels = None
changing doc A -> doc A output moves by 0.693277
changing doc A -> doc B output moves by 0.558471   <- should be 0
```

After:

```
cu_seqlens handed to the kernels = [0, 4, 8]
changing doc A -> doc A output moves by 0.693277
changing doc A -> doc B output moves by 0.000000
```

## The change

`bind_position_ids` wraps the decoder layer that owns a GDN module and parks `position_ids` on the module, which `gdn_forward_with_cp` then picks up. The gather and the `prepare_fa_kwargs_from_position_ids` call move into `packed_cu_seqlens` so they can be tested directly.

Two things it deliberately keeps quiet about:

- a single unbroken sequence resolves to `None`, so unpacked runs behave exactly as before and do not start requiring FLA
- mRoPE position ids go through `_get_text_position_ids`, the same filter `UlyssesAttention` uses, rather than being gathered as 3-D and fed to a helper that wants 2-D

Both ways of losing the boundaries now say so once, rather than training on the wrong mask
in silence: `position_ids` arriving positionally (so the keyword lookup misses it and the
binding was never applied), and a transformers without `prepare_fa_kwargs_from_position_ids`.
It is one line per process, not per layer per step. A single unbroken sequence is not one of
these cases and stays quiet.

The `position_ids` resolution moved out into `resolve_position_ids` so the keyword-then-bound
fallback is covered directly; that is the part most likely to regress if the decoder-layer
signature changes.

Genuinely packed runs without FLA now hit the pre-existing `RuntimeError` instead of silently training across boundaries. `torch_chunk_gated_delta_rule` has no `cu_seqlens` argument, so that guard is the honest outcome there.

## Also in here: a second, unrelated bug

Calling it out on its own because it looks like a formatting change in the diff.
`get_parameter_local_cp` indexed with a `list` of slices. torch warns on it today:

```
UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated ...
In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will
result either in an error or a different result.
  return param[slices]
```

which would silently reshard the conv, `A_log` and `dt_bias` weights — a list index is
advanced indexing in recent torch and does not select what this code wants. Now a tuple.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

Nine cases now in `tests_v1/plugins/model_plugins/test_ulysses_cp.py`, all CPU-only so they run in the normal `tests` workflow rather than only on the accelerator ones: the decoder-layer binding, the four `resolve_position_ids` paths (keyword wins, keyword absent, keyword present but `None`, nothing bound), the warning firing exactly once, `[0, 4, 8]` for a real pack, `None` for one unbroken sequence, and `None` for true mRoPE ids.

```
$ pytest tests_v1/plugins/model_plugins/test_ulysses_cp.py
11 passed, 2 skipped

$ pytest tests_v1/plugins tests_v1/core
73 passed, 1 failed, 5 skipped, 1 xfailed

$ ruff check / ruff format --check
All checks passed! / 2 files already formatted
```

The one failure is `test_fsdp2_meta_loading_buffers_and_tied_weights`, which fails the same
way on a clean `origin/main` worktree in this environment (macOS/MPS) and does not touch
anything in this PR.
