### PR TITLE
[v1, npu] fix: resolve GDN kernels where transformers 5.15 keeps them

### DIFF
--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from types import MethodType
 from typing import TYPE_CHECKING, Any
 
@@ -85,6 +86,44 @@ def _check_fla_dependencies() -> None:
         ) from exc
 
 
+def _install_npu_gdn_kernel(gdn_module, npu_kernel) -> str:
+    """Put the NPU kernel where the layer's forward will read it, and say where that was.
+
+    Up to transformers 5.14 the forward calls `self.chunk_gated_delta_rule`, so setting the
+    attribute is the override point. 5.15 moved the call to the module-level
+    `torch_chunk_gated_delta_rule` and dropped the attribute, so the same assignment lands on
+    something nothing reads and the run silently keeps the default kernel.
+    """
+    if hasattr(gdn_module, "chunk_gated_delta_rule"):
+        gdn_module.chunk_gated_delta_rule = npu_kernel
+        return "layer attribute"
+
+    modeling = sys.modules[type(gdn_module).__module__]
+    if hasattr(modeling, "torch_chunk_gated_delta_rule"):
+        modeling.torch_chunk_gated_delta_rule = npu_kernel
+        return f"{modeling.__name__}.torch_chunk_gated_delta_rule"
+
+    return ""
+
+
+def _replace_gdn_kernel_for_npu(layers, npu_kernel, model_name: str) -> None:
+    installed_at = ""
+    for layer in layers:
+        if hasattr(layer, "linear_attn"):
+            installed_at = _install_npu_gdn_kernel(layer.linear_attn, npu_kernel) or installed_at
+
+    if installed_at:
+        logger.info_rank0(
+            f"Replaced chunk_gated_delta_rule with NPU-compatible implementation for {model_name} "
+            f"model (via {installed_at})."
+        )
+    else:
+        logger.warning_rank0(
+            f"Could not install the NPU chunk_gated_delta_rule for {model_name}: this transformers "
+            "release exposes the kernel somewhere else. The run will use the default kernel."
+        )
+
+
 def patch_qwen3_5_forward_npu(model: "PreTrainedModel") -> None:
     """Patch for Qwen3.5 models on NPU by importing torch_npu to enable torch.cuda compatibility.
 
@@ -117,23 +156,15 @@ def patch_qwen3_5_forward_npu(model: "PreTrainedModel") -> None:
     if model.config.architectures[0] == "Qwen3_5MoeForConditionalGeneration":
         try:
             # Qwen3.5-MoE structure: model.model.language_model.layers
-            for layer in model.model.language_model.layers:
-                if hasattr(layer, "linear_attn"):
-                    layer.linear_attn.chunk_gated_delta_rule = npu_chunk_gated_delta_rule
-
-            logger.info_rank0(
-                "Replaced chunk_gated_delta_rule with NPU-compatible implementation for Qwen3.5-MoE model."
+            _replace_gdn_kernel_for_npu(
+                model.model.language_model.layers, npu_chunk_gated_delta_rule, "Qwen3.5-MoE"
             )
         except Exception as e:
             logger.warning_rank0(f"Failed to replace chunk_gated_delta_rule for NPU: {e}")
     elif model.config.architectures[0] == "Qwen3_5ForConditionalGeneration":
         try:
             # Qwen3.5 structure: model.model.layers
-            for layer in model.model.layers:
-                if hasattr(layer, "linear_attn"):
-                    layer.linear_attn.chunk_gated_delta_rule = npu_chunk_gated_delta_rule
-
-            logger.info_rank0("Replaced chunk_gated_delta_rule with NPU-compatible implementation for Qwen3.5 model.")
+            _replace_gdn_kernel_for_npu(model.model.layers, npu_chunk_gated_delta_rule, "Qwen3.5")
         except Exception as e:
             logger.warning_rank0(f"Failed to replace chunk_gated_delta_rule for NPU: {e}")
 

--- a/src/llamafactory/model/patcher.py
+++ b/src/llamafactory/model/patcher.py
@@ -86,36 +86,60 @@ def _check_fla_dependencies() -> None:
         ) from exc
 
 
-def _install_npu_gdn_kernel(gdn_module, npu_kernel) -> str:
-    """Put the NPU kernel where the layer's forward will read it, and say where that was.
+def _install_npu_gdn_kernel_on_layer(gdn_module, npu_kernel) -> bool:
+    """Set the per-layer override, where this transformers still reads one.
 
     Up to transformers 5.14 the forward calls `self.chunk_gated_delta_rule`, so setting the
-    attribute is the override point. 5.15 moved the call to the module-level
-    `torch_chunk_gated_delta_rule` and dropped the attribute, so the same assignment lands on
-    something nothing reads and the run silently keeps the default kernel.
+    attribute is the override point, and it reaches only the model being patched.
     """
-    if hasattr(gdn_module, "chunk_gated_delta_rule"):
-        gdn_module.chunk_gated_delta_rule = npu_kernel
-        return "layer attribute"
+    if not hasattr(gdn_module, "chunk_gated_delta_rule"):
+        return False
 
+    gdn_module.chunk_gated_delta_rule = npu_kernel
+    return True
+
+
+def _install_npu_gdn_kernel_on_modeling(gdn_module, npu_kernel) -> str:
+    """Set the kernel on the modeling module, which is process-wide and not undone.
+
+    5.15 moved the call to the module-level `torch_chunk_gated_delta_rule` and dropped the
+    attribute, so no per-instance override point is left. Writing here reaches every model of
+    this architecture in the process: the intent for a training script, but worth being loud
+    about under the WebUI or the API server, where several models share one process.
+    """
     modeling = sys.modules[type(gdn_module).__module__]
-    if hasattr(modeling, "torch_chunk_gated_delta_rule"):
-        modeling.torch_chunk_gated_delta_rule = npu_kernel
-        return f"{modeling.__name__}.torch_chunk_gated_delta_rule"
+    if not hasattr(modeling, "torch_chunk_gated_delta_rule"):
+        return ""
 
-    return ""
+    modeling.torch_chunk_gated_delta_rule = npu_kernel
+    return f"{modeling.__name__}.torch_chunk_gated_delta_rule"
 
 
 def _replace_gdn_kernel_for_npu(layers, npu_kernel, model_name: str) -> None:
-    installed_at = ""
-    for layer in layers:
-        if hasattr(layer, "linear_attn"):
-            installed_at = _install_npu_gdn_kernel(layer.linear_attn, npu_kernel) or installed_at
+    gdn_modules = [layer.linear_attn for layer in layers if hasattr(layer, "linear_attn")]
+    patched = [module for module in gdn_modules if _install_npu_gdn_kernel_on_layer(module, npu_kernel)]
 
-    if installed_at:
+    if patched:
         logger.info_rank0(
             f"Replaced chunk_gated_delta_rule with NPU-compatible implementation for {model_name} "
-            f"model (via {installed_at})."
+            f"model ({len(patched)} layers)."
+        )
+        return
+
+    # Nothing per-layer to write to, so this is the module-level release. One write covers every
+    # layer, so it happens once rather than once per layer.
+    installed_at = ""
+    for gdn_module in gdn_modules:
+        installed_at = _install_npu_gdn_kernel_on_modeling(gdn_module, npu_kernel)
+        if installed_at:
+            break
+
+    if installed_at:
+        logger.warning_rank0(
+            f"Replaced chunk_gated_delta_rule with NPU-compatible implementation for {model_name} "
+            f"model (via {installed_at}). This transformers offers no per-layer override point, so "
+            "the replacement is process-wide: every model of this architecture loaded afterwards "
+            "gets it too, and it is not restored."
         )
     else:
         logger.warning_rank0(
@@ -156,9 +180,7 @@ def patch_qwen3_5_forward_npu(model: "PreTrainedModel") -> None:
     if model.config.architectures[0] == "Qwen3_5MoeForConditionalGeneration":
         try:
             # Qwen3.5-MoE structure: model.model.language_model.layers
-            _replace_gdn_kernel_for_npu(
-                model.model.language_model.layers, npu_chunk_gated_delta_rule, "Qwen3.5-MoE"
-            )
+            _replace_gdn_kernel_for_npu(model.model.language_model.layers, npu_chunk_gated_delta_rule, "Qwen3.5-MoE")
         except Exception as e:
             logger.warning_rank0(f"Failed to replace chunk_gated_delta_rule for NPU: {e}")
     elif model.config.architectures[0] == "Qwen3_5ForConditionalGeneration":

--- a/src/llamafactory/v1/plugins/model_plugins/parallelization/gdn_attention.py
+++ b/src/llamafactory/v1/plugins/model_plugins/parallelization/gdn_attention.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 
+import sys
+
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+from transformers.activations import ACT2FN
 
 from .seq_comm import SeqAllToAll4D
 from .ulysses import (
@@ -69,6 +72,22 @@ def get_parameter_local_cp(param, dim, cp_group, split_sections=None):
     dim_size = param.size(dim=dim)
     slices[dim] = slice(cp_rank * dim_size // cp_size, (cp_rank + 1) * dim_size // cp_size)
     return param[slices]
+
+
+def resolve_gdn_kernel(module, attribute: str, module_level: str):
+    """Return a GDN kernel, looking in both places transformers has kept them.
+
+    Up to transformers 5.14 the linear-attention kernels hang off the module, so
+    `self.causal_conv1d_fn` resolves. 5.15 moved them to module-level functions behind a
+    kernel-hub fallback decorator and dropped the attributes, so the same lookup returns
+    nothing. Check the instance first, since that is also where the NPU patch installs its
+    replacement, then the module the layer class came from.
+    """
+    kernel = getattr(module, attribute, None)
+    if kernel is not None:
+        return kernel
+
+    return getattr(sys.modules[type(module).__module__], module_level, None)
 
 
 def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
@@ -164,9 +183,12 @@ def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
             split_sections=[self.key_dim, self.key_dim, self.value_dim],
         )
 
-    if self.causal_conv1d_fn is not None:
-        mixed_qkv = self.causal_conv1d_fn(
-            x=mixed_qkv,
+    causal_conv1d_fn = resolve_gdn_kernel(self, "causal_conv1d_fn", "causal_conv1d_fn")
+    if causal_conv1d_fn is not None:
+        # The tensor goes in positionally: FLA names it `x`, the transformers 5.15 fallback
+        # names it `hidden_states`. Every other argument is keyword in both.
+        mixed_qkv = causal_conv1d_fn(
+            mixed_qkv,
             weight=conv1d_weight.squeeze(1),
             bias=conv1d_bias,
             activation=self.activation,
@@ -188,7 +210,7 @@ def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
             dilation=self.conv1d.dilation,
             groups=self.conv_dim // cp_size,
         )
-        mixed_qkv = self.act(conv_out[..., :full_seq_len])
+        mixed_qkv = ACT2FN[self.activation](conv_out[..., :full_seq_len])
     mixed_qkv = mixed_qkv.transpose(1, 2).contiguous()  # [B, S, conv_dim/cp]
 
     query, key, value = torch.split(
@@ -222,7 +244,8 @@ def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
     beta_final = beta.sigmoid()
 
     # Gated delta rule in HP layout (needs full sequence)
-    core_attn_out, _ = self.chunk_gated_delta_rule(
+    chunk_gated_delta_rule = resolve_gdn_kernel(self, "chunk_gated_delta_rule", "torch_chunk_gated_delta_rule")
+    core_attn_out, _ = chunk_gated_delta_rule(
         query,
         key,
         value,

--- a/src/llamafactory/v1/plugins/model_plugins/parallelization/gdn_attention.py
+++ b/src/llamafactory/v1/plugins/model_plugins/parallelization/gdn_attention.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 
+import functools
 import sys
 
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 from transformers.activations import ACT2FN
+from transformers.utils.import_utils import is_causal_conv1d_available
 
 from .seq_comm import SeqAllToAll4D
 from .ulysses import (
@@ -88,6 +90,49 @@ def resolve_gdn_kernel(module, attribute: str, module_level: str):
         return kernel
 
     return getattr(sys.modules[type(module).__module__], module_level, None)
+
+
+def require_packed_conv1d_support(cu_seqlens) -> None:
+    """Refuse a packed run when nothing will honour the document boundaries.
+
+    Up to transformers 5.14 `self.causal_conv1d_fn` was None exactly when the kernel package
+    was missing, so the caller's `is not None` check doubled as this guard. 5.15 exposes a
+    module-level `causal_conv1d_fn` whether or not any kernel is installed, and with none its
+    decorator resolves to a plain F.conv1d body that filters `cu_seqlens` out of **kwargs. The
+    boundaries would then be dropped with no error at all, so ask the original question here.
+    """
+    if cu_seqlens is None or is_causal_conv1d_available():
+        return
+
+    raise RuntimeError(
+        "cu_seqlens requires causal_conv1d (FLA) but it is not available. "
+        "Please install flash-linear-attention for pack support."
+    )
+
+
+@functools.cache
+def _build_activation(name: str):
+    """One activation module per name, not one per call.
+
+    `ACT2FN` is a `ClassInstantier`: every lookup runs `cls(**kwargs)` and hands back a fresh
+    `nn.Module`. The call site below is in the per-layer forward, so looking up directly would
+    allocate once per layer per step. These modules are stateless, so one per name is enough.
+    """
+    return ACT2FN[name]
+
+
+def resolve_activation(module):
+    """The module's activation module.
+
+    transformers 5.8 builds `self.act` in `__init__`; 5.15 dropped the attribute and kept only
+    `self.activation`, the name. Prefer the instance so a module that defines its own is
+    honoured, exactly like the kernel lookups above.
+    """
+    act = getattr(module, "act", None)
+    if act is not None:
+        return act
+
+    return _build_activation(module.activation)
 
 
 def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
@@ -184,6 +229,8 @@ def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
         )
 
     causal_conv1d_fn = resolve_gdn_kernel(self, "causal_conv1d_fn", "causal_conv1d_fn")
+    require_packed_conv1d_support(cu_seqlens)
+
     if causal_conv1d_fn is not None:
         # The tensor goes in positionally: FLA names it `x`, the transformers 5.15 fallback
         # names it `hidden_states`. Every other argument is keyword in both.
@@ -195,11 +242,6 @@ def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
             seq_idx=None,
             **({"cu_seqlens": cu_seqlens} if cu_seqlens is not None else {}),
         )
-    elif cu_seqlens is not None:
-        raise RuntimeError(
-            "cu_seqlens requires causal_conv1d_fn (FLA) but it is not available. "
-            "Please install flash-linear-attention for pack support."
-        )
     else:
         conv_out = F.conv1d(
             input=mixed_qkv,
@@ -210,7 +252,7 @@ def gdn_forward_with_cp(self, hidden_states, attention_mask=None, **kwargs):
             dilation=self.conv1d.dilation,
             groups=self.conv_dim // cp_size,
         )
-        mixed_qkv = ACT2FN[self.activation](conv_out[..., :full_seq_len])
+        mixed_qkv = resolve_activation(self)(conv_out[..., :full_seq_len])
     mixed_qkv = mixed_qkv.transpose(1, 2).contiguous()  # [B, S, conv_dim/cp]
 
     query, key, value = torch.split(

--- a/tests_v1/plugins/model_plugins/test_gdn_kernel_resolution.py
+++ b/tests_v1/plugins/model_plugins/test_gdn_kernel_resolution.py
@@ -1,0 +1,105 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from llamafactory.model.patcher import _install_npu_gdn_kernel
+from llamafactory.v1.plugins.model_plugins.parallelization.gdn_attention import resolve_gdn_kernel
+
+
+def _fake_gdn(module_name: str, **attributes):
+    """A GDN stand-in whose class lives in a throwaway module, so the module-level lookup is ours."""
+    modeling = ModuleType(module_name)
+    sys.modules[module_name] = modeling
+
+    layer_cls = type("FakeGatedDeltaNet", (), {"__module__": module_name})
+    layer = layer_cls()
+    for name, value in attributes.items():
+        setattr(layer, name, value)
+
+    return layer, modeling
+
+
+@pytest.fixture
+def modeling_module(request):
+    """Register a throwaway modeling module and take it back out afterwards."""
+    created: list[str] = []
+
+    def factory(**attributes):
+        name = f"_fake_modeling_{request.node.name}_{len(created)}"
+        created.append(name)
+        return _fake_gdn(name, **attributes)
+
+    yield factory
+
+    for name in created:
+        sys.modules.pop(name, None)
+
+
+def test_kernel_comes_from_the_layer_when_it_has_one(modeling_module):
+    # transformers <= 5.14 hangs the kernels off the module, and it is also where the NPU
+    # patch installs its replacement, so the layer has to win.
+    layer, modeling = modeling_module(chunk_gated_delta_rule="on the layer")
+    modeling.torch_chunk_gated_delta_rule = "on the module"
+
+    assert resolve_gdn_kernel(layer, "chunk_gated_delta_rule", "torch_chunk_gated_delta_rule") == "on the layer"
+
+
+def test_kernel_falls_back_to_the_module(modeling_module):
+    # transformers 5.15 dropped the attributes and left module-level functions behind a
+    # kernel-hub fallback decorator.
+    layer, modeling = modeling_module()
+    modeling.torch_chunk_gated_delta_rule = "on the module"
+
+    assert resolve_gdn_kernel(layer, "chunk_gated_delta_rule", "torch_chunk_gated_delta_rule") == "on the module"
+
+
+def test_missing_kernel_resolves_to_none(modeling_module):
+    # A layer whose attribute is None because flash-linear-attention is not installed reads
+    # the same as one that never had the attribute; both take the F.conv1d path.
+    layer, _ = modeling_module(causal_conv1d_fn=None)
+
+    assert resolve_gdn_kernel(layer, "causal_conv1d_fn", "causal_conv1d_fn") is None
+
+
+def test_npu_kernel_installs_on_the_layer_when_the_forward_reads_it(modeling_module):
+    layer, modeling = modeling_module(chunk_gated_delta_rule=lambda *_: "default")
+    modeling.torch_chunk_gated_delta_rule = lambda *_: "default"
+
+    installed_at = _install_npu_gdn_kernel(layer, "npu kernel")
+
+    assert installed_at == "layer attribute"
+    assert layer.chunk_gated_delta_rule == "npu kernel"
+
+
+def test_npu_kernel_installs_on_the_module_when_the_layer_has_no_attribute(modeling_module):
+    # Assigning to the layer here would land on something the forward never reads, and the
+    # run would silently keep the default kernel.
+    layer, modeling = modeling_module()
+    modeling.torch_chunk_gated_delta_rule = lambda *_: "default"
+
+    installed_at = _install_npu_gdn_kernel(layer, "npu kernel")
+
+    assert installed_at.endswith(".torch_chunk_gated_delta_rule")
+    assert modeling.torch_chunk_gated_delta_rule == "npu kernel"
+    assert not hasattr(layer, "chunk_gated_delta_rule")
+
+
+def test_npu_kernel_reports_when_it_finds_nowhere_to_install(modeling_module):
+    layer, _ = modeling_module()
+
+    assert _install_npu_gdn_kernel(layer, "npu kernel") == ""

--- a/tests_v1/plugins/model_plugins/test_gdn_kernel_resolution.py
+++ b/tests_v1/plugins/model_plugins/test_gdn_kernel_resolution.py
@@ -13,12 +13,22 @@
 # limitations under the License.
 
 import sys
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
+import torch
 
-from llamafactory.model.patcher import _install_npu_gdn_kernel
-from llamafactory.v1.plugins.model_plugins.parallelization.gdn_attention import resolve_gdn_kernel
+from llamafactory.model.patcher import (
+    _install_npu_gdn_kernel_on_layer,
+    _install_npu_gdn_kernel_on_modeling,
+    _replace_gdn_kernel_for_npu,
+)
+from llamafactory.v1.plugins.model_plugins.parallelization import gdn_attention
+from llamafactory.v1.plugins.model_plugins.parallelization.gdn_attention import (
+    require_packed_conv1d_support,
+    resolve_activation,
+    resolve_gdn_kernel,
+)
 
 
 def _fake_gdn(module_name: str, **attributes):
@@ -80,10 +90,10 @@ def test_npu_kernel_installs_on_the_layer_when_the_forward_reads_it(modeling_mod
     layer, modeling = modeling_module(chunk_gated_delta_rule=lambda *_: "default")
     modeling.torch_chunk_gated_delta_rule = lambda *_: "default"
 
-    installed_at = _install_npu_gdn_kernel(layer, "npu kernel")
-
-    assert installed_at == "layer attribute"
+    assert _install_npu_gdn_kernel_on_layer(layer, "npu kernel") is True
     assert layer.chunk_gated_delta_rule == "npu kernel"
+    # The per-layer write is the narrow one, so the shared module is left alone.
+    assert modeling.torch_chunk_gated_delta_rule != "npu kernel"
 
 
 def test_npu_kernel_installs_on_the_module_when_the_layer_has_no_attribute(modeling_module):
@@ -92,7 +102,7 @@ def test_npu_kernel_installs_on_the_module_when_the_layer_has_no_attribute(model
     layer, modeling = modeling_module()
     modeling.torch_chunk_gated_delta_rule = lambda *_: "default"
 
-    installed_at = _install_npu_gdn_kernel(layer, "npu kernel")
+    installed_at = _install_npu_gdn_kernel_on_modeling(layer, "npu kernel")
 
     assert installed_at.endswith(".torch_chunk_gated_delta_rule")
     assert modeling.torch_chunk_gated_delta_rule == "npu kernel"
@@ -102,4 +112,75 @@ def test_npu_kernel_installs_on_the_module_when_the_layer_has_no_attribute(model
 def test_npu_kernel_reports_when_it_finds_nowhere_to_install(modeling_module):
     layer, _ = modeling_module()
 
-    assert _install_npu_gdn_kernel(layer, "npu kernel") == ""
+    assert _install_npu_gdn_kernel_on_layer(layer, "npu kernel") is False
+    assert _install_npu_gdn_kernel_on_modeling(layer, "npu kernel") == ""
+
+
+def test_npu_module_level_kernel_is_written_once_not_once_per_layer(modeling_module):
+    # One write covers every layer, and it mutates state shared by the whole process, so
+    # doing it per layer is repeated global mutation for no gain.
+    layer, modeling = modeling_module()
+    modeling.torch_chunk_gated_delta_rule = lambda *_: "default"
+
+    writes = []
+    original_setattr = type(modeling).__setattr__
+
+    def counting_setattr(self, name, value):
+        if name == "torch_chunk_gated_delta_rule":
+            writes.append(value)
+
+        original_setattr(self, name, value)
+
+    object.__setattr__(
+        modeling, "__class__", type("CountingModule", (type(modeling),), {"__setattr__": counting_setattr})
+    )
+
+    layers = [SimpleNamespace(linear_attn=layer) for _ in range(4)]
+    _replace_gdn_kernel_for_npu(layers, "npu kernel", "fake model")
+
+    assert writes == ["npu kernel"]
+
+
+def test_packed_run_without_causal_conv1d_is_refused(monkeypatch):
+    # transformers 5.15 always exposes a module-level causal_conv1d_fn, and with no kernel
+    # package installed its decorator resolves to an F.conv1d body that filters cu_seqlens
+    # out of **kwargs. Without this the boundaries would be dropped and nothing would say so.
+    monkeypatch.setattr(gdn_attention, "is_causal_conv1d_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="cu_seqlens requires causal_conv1d"):
+        require_packed_conv1d_support(cu_seqlens=torch.tensor([0, 4, 8]))
+
+
+def test_unpacked_run_without_causal_conv1d_is_allowed(monkeypatch):
+    # No boundaries to lose, so an unpacked run must not start demanding the kernels.
+    monkeypatch.setattr(gdn_attention, "is_causal_conv1d_available", lambda: False)
+
+    assert require_packed_conv1d_support(cu_seqlens=None) is None
+
+
+def test_packed_run_with_causal_conv1d_is_allowed(monkeypatch):
+    monkeypatch.setattr(gdn_attention, "is_causal_conv1d_available", lambda: True)
+
+    assert require_packed_conv1d_support(cu_seqlens=torch.tensor([0, 4, 8])) is None
+
+
+def test_activation_prefers_the_module_that_defines_its_own():
+    # transformers <= 5.8 builds self.act in __init__, and a module that overrides it should
+    # keep winning.
+    own = torch.nn.Tanh()
+
+    assert resolve_activation(SimpleNamespace(act=own, activation="silu")) is own
+
+
+def test_activation_falls_back_to_the_name_and_is_not_rebuilt(monkeypatch):
+    # 5.15 dropped self.act. ACT2FN is a ClassInstantier, so a direct lookup constructs a new
+    # nn.Module every time, and this sits in the per-layer forward.
+    module = SimpleNamespace(activation="silu")
+
+    first = resolve_activation(module)
+    second = resolve_activation(SimpleNamespace(activation="silu"))
+
+    # Not asserting the concrete class: transformers has moved silu between its own
+    # SiLUActivation and torch.nn.SiLU across the supported range. The point is the identity.
+    assert isinstance(first, torch.nn.Module)
+    assert first is second


### PR DESCRIPTION
# What does this PR do?

Fixes #10788.

`transformers` 5.15.0 moved the linear-attention kernels off the module in `🚨 [Kernels] Refactor all linear attn models & native kernels fallback` and left module-level functions behind a kernel-hub fallback decorator. `Qwen3_5GatedDeltaNet` and `Qwen3NextGatedDeltaNet` no longer carry `causal_conv1d_fn`, `chunk_gated_delta_rule` or `act`:

```
tag        self.causal_conv1d_fn   self.chunk_gated_delta_rule   self.act
v5.14.0            3                        2                       1
v5.15.0            0                        0                       0
```

Two places here read them.

## The NPU patch stops working without saying so

`patcher.py` assigns the attribute and logs that the replacement happened:

```python
layer.linear_attn.chunk_gated_delta_rule = npu_chunk_gated_delta_rule
logger.info_rank0("Replaced chunk_gated_delta_rule with NPU-compatible implementation ...")
```

On 5.15 the forward calls the module-level `torch_chunk_gated_delta_rule` instead. I put a spy on each candidate and ran a real forward on 5.15.1:

```
A) replacing module-level torch_chunk_gated_delta_rule  -> called 1 time   works
B) assigning self.chunk_gated_delta_rule                -> called 0 times  silent
```

B is what the code does today. `hasattr` still passes, there is no exception for the surrounding `try/except` to catch, and the log still claims success — so an NPU run reports the kernel installed and quietly uses the default one.

## GDN context parallel raises

`gdn_forward_with_cp` reads `self.causal_conv1d_fn` and `self.chunk_gated_delta_rule`, which is an `AttributeError` on 5.15. Resolving the name is not enough either — the call passes the tensor as `x=`, and the two signatures disagree:

```
FLA:            causal_conv1d_fn(x, weight, bias, ...)
5.15 fallback:  causal_conv1d_fn(hidden_states, weight, bias=None, activation=None, **kwargs)
```

```
conv(x=..., weight=..., bias=..., activation=..., seq_idx=None)
  -> TypeError: causal_conv1d_fn() missing 1 required positional argument: 'hidden_states'
conv(tensor, weight=..., bias=..., activation=..., seq_idx=None)
  -> OK
```

## The change

`resolve_gdn_kernel(module, attribute, module_level)` checks the layer first — that is also where the NPU patch installs its replacement, so it has to win — then the module the layer class came from. `chunk_gated_delta_rule` maps to `torch_chunk_gated_delta_rule`, which is module-level in both 5.8 and 5.15.

The conv tensor now goes in positionally; every other argument is keyword in both signatures. `self.act`, gone in 5.15, becomes `ACT2FN[self.activation]` — `self.activation` is present in both and is `config.hidden_act` either way.

`_install_npu_gdn_kernel_on_layer` sets the per-layer attribute where one still exists, which
reaches only the model being patched. Only when there is none does
`_install_npu_gdn_kernel_on_modeling` write to the modeling module, and that happens **once**
rather than once per layer, since a single write already covers every layer. That write is
process-wide and is not restored: intended in a training script, but the log says so outright,
because in the WebUI or the API server several models share one process.

`self.act` is gone in 5.15, so `resolve_activation` prefers a module that defines its own and
otherwise builds from `self.activation`, which is `config.hidden_act` in both releases. It is
built once per name: `ACT2FN` is a `ClassInstantier`, so each lookup runs `cls(**kwargs)` and
returns a fresh `nn.Module`, and this call site is in the per-layer forward.

### Keeping the pack guard alive

Worth calling out, because the first version of this PR broke it. On 5.8 the
`self.causal_conv1d_fn is None` test did double duty: it chose the `F.conv1d` path *and* it was
the guard that refuses a packed run, since the attribute is `None` exactly when the kernel
package is absent.

5.15 breaks that equivalence. `causal_conv1d_fn` is module-level and always exists —

```python
@use_kernel_func_from_hub_with_fallback("causal_conv1d_fn", "causal_conv1d")
def causal_conv1d_fn(hidden_states, weight, bias=None, activation=None, **kwargs):
```

— and with no kernel installed the decorator resolves to that plain `F.conv1d` body, whose
wrapper drops anything the live implementation does not name:

```python
kwargs = {k: v for k, v in kwargs.items() if k in applicable_params}
```

so `cu_seqlens` is filtered out and the documents in a packed batch convolve across each other,
with no error. `require_packed_conv1d_support` therefore asks the original question directly,
via `is_causal_conv1d_available()`, instead of inferring it from the symbol.

### It is a no-op inside the declared range

`pyproject.toml` pins `transformers>=4.55.0,<=5.8.0`, so nothing a user on a supported version
gets today changes. That is not just an argument — on 5.8.0 the new lookups return the very
objects the old code read:

```
transformers 5.8.0   causal_conv1d installed: False

  causal_conv1d_fn           old=None                     new is old -> True
  chunk_gated_delta_rule     old=<torch_chunk_gated...>    new is old -> True
  act                        old=SiLUActivation()          new is old -> True

  packed guard: old would raise=True  new raises=True  -> match=True
```

The module-level branches only ever run outside the pin. I have not raised the ceiling here:
that is a claim about the whole repo on 5.15, not about this file.

Note this touches `gdn_attention.py`, which #10787 also touches, but in different parts of the
file — either can land first.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

Twelve cases in `tests_v1/plugins/model_plugins/test_gdn_kernel_resolution.py`, using a
throwaway modeling module so both layouts can be built without pinning a transformers version:
layer wins over module, module fallback, `None` when neither has it, the three install
outcomes, that the module-level write happens once and not once per layer, the pack guard
raising without the kernels and staying quiet for an unpacked run or with them, and the two
activation paths.

```
$ pytest tests_v1/plugins/model_plugins/test_gdn_kernel_resolution.py
12 passed

$ pytest tests_v1/plugins tests_v1/core
77 passed, 5 skipped, 1 xfailed

$ make quality        # ruff 0.15.5, as pinned in the Makefile
All checks passed!
```
