### PR TITLE
fix(model): coerce composite VLM LoRA targets to leaf names for Unsloth

### DIFF
--- a/src/llamafactory/model/model_utils/unsloth.py
+++ b/src/llamafactory/model/model_utils/unsloth.py
@@ -27,23 +27,41 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-def _coerce_unsloth_target_modules(model: "PreTrainedModel", target_modules: list[str]) -> list[str]:
+def _coerce_unsloth_target_modules(
+    model: "PreTrainedModel", target_modules: list[str] | set[str] | str
+) -> list[str]:
     r"""Coerce full VLM module paths into leaf names for Unsloth.
 
     Unsloth builds LoRA regexes from leaf module names, but LlamaFactory's
     ``patch_target_modules()`` returns full dotted paths for composite VLMs.
     Convert those full paths back to leaf names while preserving the set of
     targeted layers (forbidden modules were already filtered out upstream).
+    Only language-model paths are kept; vision-tower paths are dropped.
     """
     from .visual import COMPOSITE_MODELS
 
+    if isinstance(target_modules, str):
+        target_modules = [target_modules]
+    elif isinstance(target_modules, set):
+        target_modules = list(target_modules)
+
     model_type = getattr(model.config, "model_type", None)
-    if model_type not in COMPOSITE_MODELS:
+    if model_type not in COMPOSITE_MODELS or not target_modules:
         return target_modules
 
-    if not target_modules or all("." not in name for name in target_modules):
+    if all("." not in name for name in target_modules):
         return target_modules
 
+    language_model_keys = COMPOSITE_MODELS[model_type].language_model_keys
+    target_modules = [
+        name
+        for name in target_modules
+        if "." not in name
+        or any(
+            name == key or name.startswith(f"{key}.") or f".{key}." in name or name.endswith(f".{key}")
+            for key in language_model_keys
+        )
+    ]
     leaf_names = sorted({name.rsplit(".", 1)[-1] for name in target_modules})
     logger.info_rank0(
         f"Unsloth expects leaf LoRA targets; converting {model_type} composite target_modules "

--- a/src/llamafactory/model/model_utils/unsloth.py
+++ b/src/llamafactory/model/model_utils/unsloth.py
@@ -27,6 +27,31 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
+def _coerce_unsloth_target_modules(model: "PreTrainedModel", target_modules: list[str]) -> list[str]:
+    r"""Coerce full VLM module paths into leaf names for Unsloth.
+
+    Unsloth builds LoRA regexes from leaf module names, but LlamaFactory's
+    ``patch_target_modules()`` returns full dotted paths for composite VLMs.
+    Convert those full paths back to leaf names while preserving the set of
+    targeted layers (forbidden modules were already filtered out upstream).
+    """
+    from .visual import COMPOSITE_MODELS
+
+    model_type = getattr(model.config, "model_type", None)
+    if model_type not in COMPOSITE_MODELS:
+        return target_modules
+
+    if not target_modules or all("." not in name for name in target_modules):
+        return target_modules
+
+    leaf_names = sorted({name.rsplit(".", 1)[-1] for name in target_modules})
+    logger.info_rank0(
+        f"Unsloth expects leaf LoRA targets; converting {model_type} composite target_modules "
+        f"to leaf names: {leaf_names}"
+    )
+    return leaf_names
+
+
 def _get_unsloth_kwargs(
     config: "PretrainedConfig",
     model_name_or_path: str,
@@ -70,6 +95,9 @@ def get_unsloth_peft_model(
 ) -> "PreTrainedModel":
     r"""Get the peft model for the pretrained model with unsloth. Used in training."""
     from unsloth import FastLanguageModel  # type: ignore
+
+    if "target_modules" in peft_kwargs:
+        peft_kwargs["target_modules"] = _coerce_unsloth_target_modules(model, peft_kwargs["target_modules"])
 
     unsloth_peft_kwargs = {
         "model": model,

--- a/tests/model/model_utils/test_unsloth.py
+++ b/tests/model/model_utils/test_unsloth.py
@@ -1,0 +1,61 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+from llamafactory.model.model_utils.unsloth import _coerce_unsloth_target_modules
+
+
+def _make_model(model_type: str):
+    return SimpleNamespace(config=SimpleNamespace(model_type=model_type))
+
+
+def test_coerce_composite_full_paths_to_leaf_names():
+    model = _make_model("moss_vl")
+    target_modules = [
+        "model.language_model.layers.0.self_attn.q_proj",
+        "model.language_model.layers.0.self_attn.v_proj",
+        "model.language_model.layers.1.mlp.gate_proj",
+    ]
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["gate_proj", "q_proj", "v_proj"]
+
+
+def test_coerce_composite_already_leaf_names_is_noop():
+    model = _make_model("moss_vl")
+    target_modules = ["q_proj", "v_proj", "gate_proj"]
+    assert _coerce_unsloth_target_modules(model, target_modules) == target_modules
+
+
+def test_coerce_non_composite_is_noop():
+    model = _make_model("llama")
+    target_modules = [
+        "model.layers.0.self_attn.q_proj",
+        "model.layers.0.self_attn.v_proj",
+    ]
+    assert _coerce_unsloth_target_modules(model, target_modules) == target_modules
+
+
+def test_coerce_empty_target_modules_is_noop():
+    model = _make_model("moss_vl")
+    assert _coerce_unsloth_target_modules(model, []) == []
+
+
+def test_coerce_dedupes_duplicate_leaf_names():
+    model = _make_model("moss_vl")
+    target_modules = [
+        "model.language_model.layers.0.self_attn.q_proj",
+        "model.language_model.layers.1.self_attn.q_proj",
+        "model.visual.blocks.0.attn.qkv",
+    ]
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["q_proj", "qkv"]

--- a/tests/model/model_utils/test_unsloth.py
+++ b/tests/model/model_utils/test_unsloth.py
@@ -12,29 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from llamafactory.model.model_utils.unsloth import _coerce_unsloth_target_modules
 
 
 def _make_model(model_type: str):
-    return SimpleNamespace(config=SimpleNamespace(model_type=model_type))
+    model = MagicMock()
+    model.config.model_type = model_type
+    return model
 
 
 def test_coerce_composite_full_paths_to_leaf_names():
-    model = _make_model("moss_vl")
+    model = _make_model("qwen2_vl")
     target_modules = [
         "model.language_model.layers.0.self_attn.q_proj",
-        "model.language_model.layers.0.self_attn.v_proj",
-        "model.language_model.layers.1.mlp.gate_proj",
+        "model.language_model.layers.0.self_attn.k_proj",
+        "model.language_model.layers.1.self_attn.q_proj",
     ]
-    assert _coerce_unsloth_target_modules(model, target_modules) == ["gate_proj", "q_proj", "v_proj"]
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["k_proj", "q_proj"]
 
 
-def test_coerce_composite_already_leaf_names_is_noop():
-    model = _make_model("moss_vl")
-    target_modules = ["q_proj", "v_proj", "gate_proj"]
-    assert _coerce_unsloth_target_modules(model, target_modules) == target_modules
+def test_coerce_excludes_vision_tower_paths():
+    model = _make_model("qwen2_vl")
+    target_modules = [
+        "model.language_model.layers.0.self_attn.q_proj",
+        "lm_head",
+        "model.visual.blocks.0.attn.vision_only_proj",
+    ]
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["lm_head", "q_proj"]
+
+
+def test_coerce_uses_model_specific_language_root():
+    model = _make_model("dots_ocr")
+    target_modules = [
+        "model.layers.0.self_attn.q_proj",
+        "vision_tower.blocks.0.attn.vision_only_proj",
+    ]
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["q_proj"]
+
+
+def test_coerce_string_target_modules():
+    model = _make_model("qwen2_vl")
+    target_modules = "model.language_model.layers.0.self_attn.q_proj"
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["q_proj"]
+
+
+def test_coerce_set_target_modules():
+    model = _make_model("qwen2_vl")
+    target_modules = {
+        "model.language_model.layers.0.self_attn.q_proj",
+        "model.language_model.layers.0.self_attn.k_proj",
+    }
+    assert _coerce_unsloth_target_modules(model, target_modules) == ["k_proj", "q_proj"]
 
 
 def test_coerce_non_composite_is_noop():
@@ -47,15 +77,11 @@ def test_coerce_non_composite_is_noop():
 
 
 def test_coerce_empty_target_modules_is_noop():
-    model = _make_model("moss_vl")
+    model = _make_model("qwen2_vl")
     assert _coerce_unsloth_target_modules(model, []) == []
 
 
-def test_coerce_dedupes_duplicate_leaf_names():
-    model = _make_model("moss_vl")
-    target_modules = [
-        "model.language_model.layers.0.self_attn.q_proj",
-        "model.language_model.layers.1.self_attn.q_proj",
-        "model.visual.blocks.0.attn.qkv",
-    ]
-    assert _coerce_unsloth_target_modules(model, target_modules) == ["q_proj", "qkv"]
+def test_coerce_already_leaf_names_is_noop():
+    model = _make_model("qwen2_vl")
+    target_modules = ["q_proj", "k_proj"]
+    assert _coerce_unsloth_target_modules(model, target_modules) == target_modules


### PR DESCRIPTION
**What this PR does**

Unsloth builds LoRA regexes from leaf module names (e.g. `q_proj`, `gate_proj`), but LlamaFactory's `patch_target_modules()` expands short targets into full dotted paths for composite VLMs such as `qwen2_vl`, `qwen3_5`, and `llava` (e.g. `model.language_model.layers.0.self_attn.q_proj`).

Passing those full paths to `FastLanguageModel.get_peft_model()` produces regexes that match nothing, so zero LoRA adapters are attached and training crashes with a "no trainable layers" error. This is the root cause of #10662.

**Changes**

- Add `_coerce_unsloth_target_modules()` in `src/llamafactory/model/model_utils/unsloth.py` to convert expanded composite-model paths back to unique leaf names before handing them to Unsloth.
- Only composite models (`model_type in COMPOSITE_MODELS`) with dotted target paths are coerced; non-composite models and already-leaf target lists are left untouched.
- Add unit tests in `tests/model/model_utils/test_unsloth.py` covering composite full paths, already-leaf names, non-composite models, empty lists, and duplicate leaf deduplication.

**Verification**

- `WANDB_DISABLED=true python -m pytest tests/model/model_utils/test_unsloth.py -v` passes (5/5).
- `make quality` lint passes for the changed files; the one unrelated formatting failure in `src/llamafactory/v1/plugins/model_plugins/parallelization/gdn_attention.py` is pre-existing on upstream `main`.
- GPU smoke test on a single H100 with `Qwen/Qwen2-VL-2B-Instruct` (4-bit, Unsloth booster, LoRA target_modules=all) now attaches 392 LoRA parameters to the language model, whereas before the fix it would attach none and crash.

Fixes #10662.