### PR TITLE
[hparams] fix: route report_to swanlab through the native callback

### DIFF
--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -172,15 +172,11 @@ def _route_swanlab_reporting(finetuning_args: "FinetuningArguments", training_ar
     ``RuntimeError: No active Run`` instead of returning None, which ends training in
     ``on_train_begin``. Ours also skips the setup off rank zero, which the transformers
     callback does not.
+
+    ``TrainingArguments.__post_init__`` has already normalized ``report_to`` to a list
+    by the time ``get_train_args`` runs, so a bare string never reaches this.
     """
-    report_to = training_args.report_to
-    if not report_to:
-        return
-
-    if isinstance(report_to, str):
-        report_to = [report_to]
-
-    if "swanlab" in report_to:
+    if "swanlab" in (training_args.report_to or []):
         finetuning_args.use_swanlab = True
 
 

--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -163,6 +163,27 @@ def _parse_args(
     return tuple(parsed_args)
 
 
+def _route_swanlab_reporting(finetuning_args: "FinetuningArguments", training_args: "TrainingArguments") -> None:
+    """Send ``report_to: swanlab`` through this project's SwanLab callback.
+
+    The example configs list ``swanlab`` as a ``report_to`` choice, but only ``use_swanlab``
+    reached our callback, so ``report_to: swanlab`` alone fell through to the one in
+    transformers. That one probes ``swanlab.get_run() is None``, and SwanLab raises
+    ``RuntimeError: No active Run`` instead of returning None, which ends training in
+    ``on_train_begin``. Ours also skips the setup off rank zero, which the transformers
+    callback does not.
+    """
+    report_to = training_args.report_to
+    if not report_to:
+        return
+
+    if isinstance(report_to, str):
+        report_to = [report_to]
+
+    if "swanlab" in report_to:
+        finetuning_args.use_swanlab = True
+
+
 def _verify_trackio_args(training_args: "TrainingArguments") -> None:
     """Validates Trackio-specific arguments.
 
@@ -537,6 +558,7 @@ def get_train_args(args: dict[str, Any] | list[str] | None = None) -> _TRAIN_CLS
 
     _set_env_vars()
     _verify_model_args(model_args, data_args, finetuning_args)
+    _route_swanlab_reporting(finetuning_args, training_args)
     _check_extra_dependencies(model_args, finetuning_args, training_args)
     _verify_trackio_args(training_args)
 

--- a/tests/train/test_swanlab_reporting.py
+++ b/tests/train/test_swanlab_reporting.py
@@ -33,14 +33,6 @@ def test_report_to_swanlab_selects_the_native_callback():
     assert finetuning_args.use_swanlab is True
 
 
-def test_report_to_swanlab_as_a_bare_string_is_recognised():
-    finetuning_args, training_args = _args("swanlab")
-
-    _route_swanlab_reporting(finetuning_args, training_args)
-
-    assert finetuning_args.use_swanlab is True
-
-
 def test_swanlab_alongside_another_logger_still_selects_it():
     finetuning_args, training_args = _args(["tensorboard", "swanlab"])
 

--- a/tests/train/test_swanlab_reporting.py
+++ b/tests/train/test_swanlab_reporting.py
@@ -1,0 +1,68 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from llamafactory.hparams.parser import _route_swanlab_reporting
+
+
+def _args(report_to, use_swanlab=False):
+    return SimpleNamespace(use_swanlab=use_swanlab), SimpleNamespace(report_to=report_to)
+
+
+def test_report_to_swanlab_selects_the_native_callback():
+    # The example configs offer `swanlab` as a report_to choice and none of them set
+    # use_swanlab, so this is the path a user following them takes.
+    finetuning_args, training_args = _args(["swanlab"])
+
+    _route_swanlab_reporting(finetuning_args, training_args)
+
+    assert finetuning_args.use_swanlab is True
+
+
+def test_report_to_swanlab_as_a_bare_string_is_recognised():
+    finetuning_args, training_args = _args("swanlab")
+
+    _route_swanlab_reporting(finetuning_args, training_args)
+
+    assert finetuning_args.use_swanlab is True
+
+
+def test_swanlab_alongside_another_logger_still_selects_it():
+    finetuning_args, training_args = _args(["tensorboard", "swanlab"])
+
+    _route_swanlab_reporting(finetuning_args, training_args)
+
+    assert finetuning_args.use_swanlab is True
+    # The other logger is untouched here; report_to is trimmed later in get_train_args.
+    assert training_args.report_to == ["tensorboard", "swanlab"]
+
+
+@pytest.mark.parametrize("report_to", [["none"], ["tensorboard"], [], None])
+def test_other_loggers_do_not_turn_swanlab_on(report_to):
+    finetuning_args, training_args = _args(report_to)
+
+    _route_swanlab_reporting(finetuning_args, training_args)
+
+    assert finetuning_args.use_swanlab is False
+
+
+def test_explicit_use_swanlab_is_left_alone():
+    finetuning_args, training_args = _args(["tensorboard"], use_swanlab=True)
+
+    _route_swanlab_reporting(finetuning_args, training_args)
+
+    assert finetuning_args.use_swanlab is True


### PR DESCRIPTION
# What does this PR do?

Fixes #10704.

Every example config carries this line:

```yaml
report_to: none  # choices: [none, wandb, tensorboard, swanlab, mlflow]
```

and none of them mentions `use_swanlab`, so `report_to: swanlab` on its own is what a user following the examples writes — which is exactly the config in #10704. Only `use_swanlab` reached our callback, though, so that config fell through to the SwanLab integration in transformers.

That one probes `swanlab.get_run() is None`:

```python
# transformers/integrations/integration_utils.py, SwanLabCallback.setup
if self._swanlab.get_run() is None:
```

and SwanLab raises rather than returning None:

```
>>> import swanlab; swanlab.__version__
'0.9.8'
>>> swanlab.get_run()
RuntimeError: No active Run. Call swanlab.init() first.
```

which is the error in the issue, raised from `on_train_begin`. Our `SwanLabCallbackExtension` also returns early when `not state.is_world_process_zero`, which the transformers one does not, so the same config takes out every rank of a multi-GPU run rather than just rank 0.

## The change

`report_to: swanlab` now selects `use_swanlab`, and the two existing lines below already turn that into "drop swanlab from `report_to`, attach our callback". Driving `get_train_args` directly:

```
                      before                               after
report_to='swanlab'   use_swanlab=False                    use_swanlab=True
                      report_to=['swanlab']                report_to=[]
report_to='none'      use_swanlab=False, report_to=[]      unchanged
```

With `report_to` emptied, transformers no longer auto-enables its integration, and the callback that runs is the one that already handles the rank guard and writes `swanlab_public_config`.

`use_swanlab: true` on its own keeps working exactly as before; this only adds the second documented spelling.

A previous attempt at this, #10711, was closed by its author with no discussion. It took a different route (selecting the callback at report-time); this one reuses the `use_swanlab` path that is already wired end to end, so it is three lines of behaviour plus a docstring.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

`tests/train/test_swanlab_reporting.py`, seven cases: the list form, alongside another logger,
the four `report_to` values that must not turn it on, and an already-explicit `use_swanlab`.

```
$ pytest tests/train/test_swanlab_reporting.py
7 passed

$ make quality        # ruff 0.15.5, as pinned in the Makefile
All checks passed!
```

The before/after table above is from running `get_train_args` on a clean checkout and on this
branch, not inferred.

### Dropped after review

The first version also handled `report_to` arriving as a bare string. That branch was
unreachable: `TrainingArguments.__post_init__` normalizes it before `get_train_args` runs, on
both ends of the declared range (`elif not isinstance(self.report_to, list): self.report_to =
[self.report_to]`). On the pinned 5.8.0:

```
report_to='swanlab'      -> after __post_init__: ['swanlab']
report_to=['swanlab']    -> after __post_init__: ['swanlab']
```

So the branch and the test pinning it are gone, and the helper is now one condition.
