### PR TITLE
[v1] fix: give every CP rank a KV head when the model has fewer than cp_size

### DIFF
--- a/src/llamafactory/v1/plugins/model_plugins/parallelization/sequence_parallel.py
+++ b/src/llamafactory/v1/plugins/model_plugins/parallelization/sequence_parallel.py
@@ -102,7 +102,7 @@ def apply_sequence_parallel(model, cp_size: int):
 
     assert num_attention_heads % cp_size == 0, "num_attention_heads must be divisible by cp_size"
     assert num_key_value_heads % cp_size == 0 or cp_size % num_key_value_heads == 0, (
-        "num_key_value_heads must be divisible by cp_size"
+        "one of num_key_value_heads and cp_size must be divisible by the other"
     )
 
     origin_attn = transformers.modeling_flash_attention_utils._flash_attention_forward

--- a/src/llamafactory/v1/plugins/model_plugins/parallelization/ulysses.py
+++ b/src/llamafactory/v1/plugins/model_plugins/parallelization/ulysses.py
@@ -123,6 +123,17 @@ class UlyssesAttention(torch.nn.Module):
         # in shape : e.g.,  [s/p:h:]
         # (bs, seq_len/N, head_cnt, head_size) -> (bs, seq_len, head_cnt/N, head_size)
         # scatter 2, gather 1
+        sp_world_size = get_ulysses_sequence_parallel_world_size(self.spg)
+        # apply_sequence_parallel() admits models whose KV head count divides the CP
+        # size, but the all2all splits the head dim with tensor_split, which hands the
+        # trailing ranks empty shards once there are fewer KV heads than ranks. Give
+        # each rank the KV head its query group needs by repeating heads in place.
+        num_kv_heads = key.shape[self.scatter_idx]
+        if num_kv_heads < sp_world_size:
+            repeats = sp_world_size // num_kv_heads
+            key = key.repeat_interleave(repeats, dim=self.scatter_idx)
+            value = value.repeat_interleave(repeats, dim=self.scatter_idx)
+
         q = SeqAllToAll4D.apply(self.spg, query, self.scatter_idx, self.gather_idx)
         k = SeqAllToAll4D.apply(self.spg, key, self.scatter_idx, self.gather_idx)
         v = SeqAllToAll4D.apply(self.spg, value, self.scatter_idx, self.gather_idx)
@@ -130,7 +141,6 @@ class UlyssesAttention(torch.nn.Module):
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** -0.5
 
-        sp_world_size = get_ulysses_sequence_parallel_world_size(self.spg)
         # HF FlashAttention only uses 2-D position IDs to detect packed sequences.
         position_ids = _get_text_position_ids(position_ids)
         if position_ids is not None:

--- a/tests_v1/plugins/model_plugins/test_ulysses_cp.py
+++ b/tests_v1/plugins/model_plugins/test_ulysses_cp.py
@@ -62,6 +62,49 @@ def test_true_mrope_position_ids_are_not_used_as_packed_boundaries():
     assert ulysses._get_text_position_ids(mrope_position_ids) is None
 
 
+def test_kv_heads_fewer_than_cp_size_are_repeated_before_the_all2all(monkeypatch: pytest.MonkeyPatch):
+    # apply_sequence_parallel() accepts models whose KV head count divides cp_size, so a
+    # 2-KV-head model may run on 4 ranks. tensor_split() would then hand ranks 2 and 3
+    # empty shards and all_to_all rejects them, so the heads have to be repeated first.
+    captured = []
+
+    def fake_all2all(_group, tensor, *_args):
+        captured.append(tensor)
+        return tensor
+
+    monkeypatch.setattr(ulysses.SeqAllToAll4D, "apply", fake_all2all)
+    monkeypatch.setattr(ulysses, "get_ulysses_sequence_parallel_world_size", lambda _: 4)
+    monkeypatch.setattr(ulysses.dist, "all_gather", lambda outputs, tensor, **_: [o.copy_(tensor) for o in outputs])
+
+    attention = ulysses.UlyssesAttention(sequence_process_group=object(), attn_fn=lambda query, *_, **__: query)
+    query = torch.zeros(1, 4, 8, 2)
+    key = torch.arange(2, dtype=torch.float32).view(1, 1, 2, 1).expand(1, 4, 2, 2).contiguous()
+
+    attention(query, key, key.clone(), None, 16)
+
+    query_sent, key_sent, value_sent = captured[:3]
+    assert [query_sent.shape[2], key_sent.shape[2], value_sent.shape[2]] == [8, 4, 4]
+    # Each rank owns two of the eight query heads, so it needs the KV head backing that
+    # group: ranks 0-1 take KV head 0 and ranks 2-3 take KV head 1.
+    assert key_sent[0, 0, :, 0].tolist() == [0.0, 0.0, 1.0, 1.0]
+    assert value_sent[0, 0, :, 0].tolist() == [0.0, 0.0, 1.0, 1.0]
+
+
+def test_kv_heads_matching_cp_size_are_left_alone(monkeypatch: pytest.MonkeyPatch):
+    captured = []
+
+    monkeypatch.setattr(ulysses.SeqAllToAll4D, "apply", lambda _g, tensor, *_a: captured.append(tensor) or tensor)
+    monkeypatch.setattr(ulysses, "get_ulysses_sequence_parallel_world_size", lambda _: 2)
+    monkeypatch.setattr(ulysses.dist, "all_gather", lambda outputs, tensor, **_: [o.copy_(tensor) for o in outputs])
+
+    attention = ulysses.UlyssesAttention(sequence_process_group=object(), attn_fn=lambda query, *_, **__: query)
+    key = torch.zeros(1, 4, 4, 2)
+
+    attention(torch.zeros(1, 4, 8, 2), key, key.clone(), None, 8)
+
+    assert [captured[1].shape[2], captured[2].shape[2]] == [4, 4]
+
+
 def _test_sequence_parallel_loss(
     local_rank: int, world_size: int, master_port: int, cp_size: int, dp_size: int, batch_size: int
 ):


### PR DESCRIPTION
### What's the problem

`apply_sequence_parallel` accepts a model when its KV head count *divides* `cp_size`, not just when `cp_size` divides it:

```python
assert num_key_value_heads % cp_size == 0 or cp_size % num_key_value_heads == 0
```

So a 2-KV-head model is allowed on 4 ranks. But `all_to_all_tensor` splits the head dim with `torch.tensor_split`, which for 2 heads over 4 ranks yields `[1, 1, 0, 0]` — two empty shards — while the receive buffers are all sized from `input_list[0]`. `all_to_all` rejects the mismatch:

```
RuntimeError: ProcessGroupGloo::alltoall: invalid tensor size at index 2
              (expected (1, 4, 1, 8), got (1, 4, 0, 8))
```

Every rank dies at the first attention layer. The assert promises a configuration the all2all can't serve.

Models in the cache here that land in that gap:

| model | q heads | kv heads | crashes at |
| --- | --- | --- | --- |
| Qwen/Qwen2.5-VL-3B-Instruct | 16 | 2 | `cp_size` 4, 8 |
| Qwen/Qwen2-VL-2B-Instruct | 12 | 2 | `cp_size` 4 |
| Qwen/Qwen3-VL-30B-A3B-Instruct | 32 | 4 | `cp_size` 8 |
| llamafactory/tiny-random-Llama-4 | 8 | 2 | `cp_size` 4, 8 |

### The fix

Repeat each KV head across the ranks that own its query group, before the all2all. On this path `cp_size % num_kv_heads == 0`, so the repeat lands exactly one head per rank.

`repeat_interleave` and not `repeat`: with 8 q heads / 2 kv heads on 4 ranks, rank *r* is scattered q heads `[2r, 2r+2)`, whose KV group is `r // 2`. Interleaving gives `[kv0, kv0, kv1, kv1]`, so `tensor_split` hands rank *r* exactly `kv[r // 2]`. `repeat` would give `[kv0, kv1, kv0, kv1]` and silently pair half the ranks with the wrong KV head. Same call `gdn_attention.py` already uses for its CP path.

Nothing changes when `num_kv_heads >= cp_size` — the branch doesn't fire.

### Memory cost

This is not free, so to be explicit about the trade-off: K and V are widened
from `num_kv_heads` to `cp_size` heads, on every layer of every forward, and
the widened tensors are kept for backward. That multiplies the KV activation
by `cp_size // num_kv_heads` — 4x for a 2-KV-head model at `cp_size=8`.

The alternative is to have the assert reject these shapes outright. That is
cheaper but it removes configurations the code currently advertises as
supported, so this PR keeps them working instead. Q is untouched, and the
branch is skipped entirely once `num_kv_heads >= cp_size`.

While here: the assert's message still read "num_key_value_heads must be
divisible by cp_size" even though the condition also admits the reverse —
the very case this PR makes work. Corrected in a second commit.

### Verification

Ran the real `UlyssesAttention` under 4 gloo ranks against a single-process GQA reference, forward and backward:

before (`origin/main`)
```
num_q_heads=8  num_kv_heads=2  cp_size=4  seq=16
rank 0  FAILED -> RuntimeError: ProcessGroupGloo::alltoall: invalid tensor size at index 2 (expected (1, 4, 1, 8), got (1, 4, 0, 8))
rank 1  FAILED -> ...   rank 2  FAILED -> ...   rank 3  FAILED -> ...
```

after
```
                                     max err (fwd + dq/dk/dv)
  nq=8  nkv=2  cp=4                            9.537e-07   OK   <- was a crash
  nq=8  nkv=1  cp=2                            1.907e-06   OK   <- was a crash
  nq=8  nkv=4  cp=8                            0.000e+00   OK   <- was a crash
  nq=8  nkv=2  cp=8                            0.000e+00   OK   <- was a crash
  nq=8  nkv=4  cp=4                            0.000e+00   OK
  nq=8  nkv=8  cp=4                            0.000e+00   OK
  nq=8  nkv=2  cp=2                            0.000e+00   OK
  nq=8  nkv=8  cp=8                            0.000e+00   OK
```

The four previously-working shapes are bit-identical, so no regression there.

Tests: two CPU cases added to `test_ulysses_cp.py` — one pins the repeated layout (fails on `origin/main` with `assert [8, 2, 2] == [8, 4, 4]`), one pins that an already-divisible model is left untouched.

```
tests_v1/ ......  70 passed, 9 skipped, 1 xfailed
ruff check / format --check   clean
```

(Two files, `test_gdn_kernel_resolution.py` and `test_dpo_loss_precision.py`, don't collect in my env — a broken `torchaudio` .so — so they're excluded from that run. Unrelated to this change.)

