### PR TITLE
Show a WebUI warning when dataset_info.json is invalid

### DIFF
--- a/src/llamafactory/webui/common.py
+++ b/src/llamafactory/webui/common.py
@@ -138,17 +138,31 @@ def is_multimodal(model_name: str) -> bool:
 
 
 def load_dataset_info(dataset_dir: str) -> dict[str, dict[str, Any]]:
-    r"""Load dataset_info.json."""
+    r"""Load dataset_info.json.
+
+    Raises:
+        ValueError: if dataset_info.json exists but contains invalid JSON or invalid dataset entries.
+    """
     if dataset_dir == "ONLINE" or dataset_dir.startswith("REMOTE:"):
         logger.info_rank0(f"dataset_dir is {dataset_dir}, using online dataset.")
         return {}
 
+    dataset_info_path = os.path.join(dataset_dir, DATA_CONFIG)
     try:
-        with open(os.path.join(dataset_dir, DATA_CONFIG), encoding="utf-8") as f:
-            return json.load(f)
-    except Exception as err:
-        logger.warning_rank0(f"Cannot open {os.path.join(dataset_dir, DATA_CONFIG)} due to {str(err)}.")
+        with open(dataset_info_path, encoding="utf-8") as f:
+            dataset_info = json.load(f)
+    except OSError as err:
+        logger.warning_rank0(f"Cannot open {dataset_info_path} due to {str(err)}.")
         return {}
+    except json.JSONDecodeError as err:
+        logger.warning_rank0(f"Cannot open {dataset_info_path} due to {str(err)}.")
+        raise ValueError(f"Failed to parse {DATA_CONFIG}: {err}") from err
+
+    if not isinstance(dataset_info, dict) or not all(isinstance(value, dict) for value in dataset_info.values()):
+        logger.warning_rank0(f"Invalid dataset entries found in {dataset_info_path}.")
+        raise ValueError(f"Invalid dataset entries found in {DATA_CONFIG}, each dataset must be a JSON object.")
+
+    return dataset_info
 
 
 def load_args(config_path: str) -> dict[str, Any] | None:

--- a/src/llamafactory/webui/common.py
+++ b/src/llamafactory/webui/common.py
@@ -141,7 +141,8 @@ def load_dataset_info(dataset_dir: str) -> dict[str, dict[str, Any]]:
     r"""Load dataset_info.json.
 
     Raises:
-        ValueError: if dataset_info.json exists but contains invalid JSON or invalid dataset entries.
+        ValueError: if dataset_info.json exists but cannot be decoded, contains invalid JSON,
+            or contains invalid dataset entries. The caller is expected to report it to the user.
     """
     if dataset_dir == "ONLINE" or dataset_dir.startswith("REMOTE:"):
         logger.info_rank0(f"dataset_dir is {dataset_dir}, using online dataset.")
@@ -154,13 +155,13 @@ def load_dataset_info(dataset_dir: str) -> dict[str, dict[str, Any]]:
     except OSError as err:
         logger.warning_rank0(f"Cannot open {dataset_info_path} due to {str(err)}.")
         return {}
-    except json.JSONDecodeError as err:
-        logger.warning_rank0(f"Cannot open {dataset_info_path} due to {str(err)}.")
-        raise ValueError(f"Failed to parse {DATA_CONFIG}: {err}") from err
+    except (json.JSONDecodeError, UnicodeDecodeError) as err:
+        # UnicodeDecodeError comes from the read inside open(), not from json; it subclasses ValueError,
+        # so it would reach the caller either way, but naming it here makes the contract explicit.
+        raise ValueError(f"Failed to parse {dataset_info_path}: {err}") from err
 
     if not isinstance(dataset_info, dict) or not all(isinstance(value, dict) for value in dataset_info.values()):
-        logger.warning_rank0(f"Invalid dataset entries found in {dataset_info_path}.")
-        raise ValueError(f"Invalid dataset entries found in {DATA_CONFIG}, each dataset must be a JSON object.")
+        raise ValueError(f"Invalid dataset entries found in {dataset_info_path}, each dataset must be a JSON object.")
 
     return dataset_info
 

--- a/src/llamafactory/webui/components/eval.py
+++ b/src/llamafactory/webui/components/eval.py
@@ -98,6 +98,7 @@ def create_eval_tab(engine: "Engine") -> dict[str, "Component"]:
     stop_btn.click(engine.runner.set_abort)
     resume_btn.change(engine.runner.monitor, outputs=output_elems, concurrency_limit=None)
 
-    dataset.focus(list_datasets, [dataset_dir], [dataset], queue=False)
+    lang = engine.manager.get_elem_by_id("top.lang")
+    dataset.focus(list_datasets, [lang, dataset_dir], [dataset], queue=False)
 
     return elem_dict

--- a/src/llamafactory/webui/components/train.py
+++ b/src/llamafactory/webui/components/train.py
@@ -451,7 +451,7 @@ def create_train_tab(engine: "Engine") -> dict[str, "Component"]:
         engine.runner.load_args, [lang, config_path], list(input_elems) + [output_box], concurrency_limit=None
     )
 
-    dataset.focus(list_datasets, [dataset_dir, training_stage], [dataset], queue=False)
+    dataset.focus(list_datasets, [lang, dataset_dir, training_stage], [dataset], queue=False)
     training_stage.change(change_stage, [training_stage], [dataset, packing], queue=False)
     reward_model.focus(list_checkpoints, [model_name, finetuning_type], [reward_model], queue=False)
     model_name.change(list_output_dirs, [model_name, finetuning_type, current_time], [output_dir], queue=False)

--- a/src/llamafactory/webui/control.py
+++ b/src/llamafactory/webui/control.py
@@ -194,13 +194,20 @@ def list_config_paths(current_time: str) -> "gr.Dropdown":
     return gr.Dropdown(choices=config_files)
 
 
-def list_datasets(dataset_dir: str = None, training_stage: str = list(TRAINING_STAGES.keys())[0]) -> "gr.Dropdown":
+def list_datasets(
+    lang: str = "en", dataset_dir: str = None, training_stage: str = list(TRAINING_STAGES.keys())[0]
+) -> "gr.Dropdown":
     r"""List all available datasets in the dataset dir for the training stage.
 
-    Inputs: *.dataset_dir, *.training_stage
+    Inputs: top.lang, *.dataset_dir, *.training_stage
     Outputs: *.dataset
     """
-    dataset_info = load_dataset_info(dataset_dir if dataset_dir is not None else DEFAULT_DATA_DIR)
+    try:
+        dataset_info = load_dataset_info(dataset_dir if dataset_dir is not None else DEFAULT_DATA_DIR)
+    except ValueError:
+        gr.Warning(ALERTS["err_dataset_info"][lang])
+        return gr.Dropdown(choices=[])
+
     ranking = TRAINING_STAGES[training_stage] in STAGES_USE_PAIR_DATA
     datasets = [k for k, v in dataset_info.items() if v.get("ranking", False) == ranking]
     return gr.Dropdown(choices=datasets)

--- a/src/llamafactory/webui/locales.py
+++ b/src/llamafactory/webui/locales.py
@@ -3101,6 +3101,13 @@ ALERTS = {
         "ko": "데모 모드에서는 훈련을 사용할 수 없습니다. 먼저 프라이빗 레포지토리로 작업 공간을 복제하십시오.",
         "ja": "デモモードではトレーニングは利用できません。最初にプライベートスペースに複製してください。",
     },
+    "err_dataset_info": {
+        "en": "Failed to load dataset_info.json, please check the file for invalid JSON or invalid dataset entries.",
+        "ru": "Не удалось загрузить dataset_info.json, проверьте файл на наличие недопустимого JSON или недопустимых записей набора данных.",
+        "zh": "dataset_info.json 加载失败，请检查文件中是否存在无效的 JSON 或无效的数据集条目。",
+        "ko": "dataset_info.json을(를) 불러오지 못했습니다. 파일에 잘못된 JSON 또는 잘못된 데이터 세트 항목이 있는지 확인하십시오.",
+        "ja": "dataset_info.json の読み込みに失敗しました。ファイルに無効な JSON または無効なデータセットエントリがないか確認してください。",
+    },
     "err_tool_name": {
         "en": "Tool name not found.",
         "ru": "Имя инструмента не найдено.",

--- a/tests/webui/test_common.py
+++ b/tests/webui/test_common.py
@@ -48,3 +48,10 @@ def test_load_dataset_info_non_dict_root_raises(tmp_path):
     (tmp_path / "dataset_info.json").write_text(json.dumps(["alpaca"]), encoding="utf-8")
     with pytest.raises(ValueError):
         load_dataset_info(str(tmp_path))
+
+
+def test_load_dataset_info_non_utf8_raises(tmp_path):
+    r"""A dataset_info.json that is not valid UTF-8 must raise, not fall through as a silent empty dict."""
+    (tmp_path / "dataset_info.json").write_bytes(b'{"alpaca": {"file_name": "\xff\xfe.json"}}')
+    with pytest.raises(ValueError):
+        load_dataset_info(str(tmp_path))

--- a/tests/webui/test_common.py
+++ b/tests/webui/test_common.py
@@ -1,0 +1,50 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from llamafactory.webui.common import load_dataset_info
+
+
+def test_load_dataset_info_valid(tmp_path):
+    dataset_info = {"alpaca": {"file_name": "alpaca.json"}}
+    (tmp_path / "dataset_info.json").write_text(json.dumps(dataset_info), encoding="utf-8")
+    assert load_dataset_info(str(tmp_path)) == dataset_info
+
+
+def test_load_dataset_info_missing_file_returns_empty(tmp_path):
+    r"""A dataset dir without a dataset_info.json is not an error, just no datasets to list."""
+    assert load_dataset_info(str(tmp_path)) == {}
+
+
+def test_load_dataset_info_malformed_json_raises(tmp_path):
+    r"""Malformed JSON must raise instead of failing silently (see #9060)."""
+    (tmp_path / "dataset_info.json").write_text("{ invalid json,,, }", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_dataset_info(str(tmp_path))
+
+
+def test_load_dataset_info_invalid_entry_raises(tmp_path):
+    r"""A dataset entry that is not a JSON object must raise instead of failing silently (see #9060)."""
+    (tmp_path / "dataset_info.json").write_text(json.dumps({"alpaca": "not_an_object"}), encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_dataset_info(str(tmp_path))
+
+
+def test_load_dataset_info_non_dict_root_raises(tmp_path):
+    (tmp_path / "dataset_info.json").write_text(json.dumps(["alpaca"]), encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_dataset_info(str(tmp_path))

--- a/tests/webui/test_control.py
+++ b/tests/webui/test_control.py
@@ -1,0 +1,40 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+from llamafactory.webui.control import list_datasets
+
+
+def test_list_datasets_warns_on_malformed_json(tmp_path, monkeypatch):
+    r"""The dataset dropdown must surface a user-facing warning instead of failing silently (see #9060)."""
+    (tmp_path / "dataset_info.json").write_text("{ invalid json,,, }", encoding="utf-8")
+
+    warnings = []
+    monkeypatch.setattr("llamafactory.webui.control.gr.Warning", lambda msg, *args, **kwargs: warnings.append(msg))
+
+    result = list_datasets("en", str(tmp_path), "Supervised Fine-Tuning")
+
+    assert len(warnings) == 1
+    assert result.choices == []
+
+
+def test_list_datasets_valid(tmp_path):
+    dataset_info = {"alpaca": {"file_name": "alpaca.json"}}
+    with open(os.path.join(tmp_path, "dataset_info.json"), "w", encoding="utf-8") as f:
+        json.dump(dataset_info, f)
+
+    result = list_datasets("en", str(tmp_path), "Supervised Fine-Tuning")
+    assert result.choices == [("alpaca", "alpaca")]


### PR DESCRIPTION
# What does this PR do?

The WebUI's dataset dropdown loads dataset choices from `dataset_info.json`
via `load_dataset_info()`. That function previously caught *every*
exception (malformed JSON syntax, dataset entries that aren't JSON
objects, etc.) and simply logged a server-side warning before returning
`{}`. As a result, when `dataset_info.json` was invalid, the dataset
dropdown just silently ended up empty in the WebUI with no indication to
the user of what went wrong (#9060).

This PR:
- Makes `load_dataset_info()` distinguish between a *missing* file (still
  benign, returns `{}` as before — e.g. a fresh `dataset_dir` without a
  config yet) and an *invalid* one (malformed JSON, or a dataset entry
  that isn't a JSON object), which now raises `ValueError`.
- Makes `list_datasets()` catch that `ValueError` and show a localized
  `gr.Warning` popup to the user (added a new `err_dataset_info` entry to
  `ALERTS`/`locales.py` in all 5 supported languages), in addition to the
  existing server-side log line.
- Threads `top.lang` through to `list_datasets()` (from both the train
  and eval tabs) so the warning can be localized like the rest of the
  WebUI's alerts.

### How was this tested?

The WebUI itself isn't covered by the existing test suite (`tests/` has
no `webui/` tests today), so I added `tests/webui/test_common.py` and
`tests/webui/test_control.py`, which unit-test `load_dataset_info()` and
`list_datasets()` directly (no Gradio server needed) against valid,
missing, and malformed `dataset_info.json` fixtures, and assert the
user-facing `gr.Warning` is actually raised for the malformed cases.

```
$ WANDB_DISABLED=true python -m pytest -vv --import-mode=importlib tests/webui/
7 passed
```

I also reproduced the original silent-failure against `main` with a small
script before making any changes, confirming only a server log line was
emitted and nothing surfaced to the (simulated) UI.

Fixes #9060

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
