### PR TITLE
Fix checkpoint dropdown missing nested/intermediate checkpoints

### DIFF
--- a/src/llamafactory/webui/common.py
+++ b/src/llamafactory/webui/common.py
@@ -57,7 +57,15 @@ def abort_process(pid: int) -> None:
 
 
 def get_save_dir(*paths: str) -> os.PathLike:
-    r"""Get the path to saved model checkpoints."""
+    r"""Get the path to saved model checkpoints.
+
+    Only an absolute last component bypasses the save dir. A relative one is always joined under
+    `saves/<model>/<finetuning_type>/`, including a user-typed relative output_dir such as
+    `my/custom/dir`, which earlier resolved against the cwd instead. That is deliberate: the
+    checkpoint dropdown now hands back nested values like `<run_dir>/checkpoint-<step>`, and
+    bypassing on any embedded separator would make those resolve outside the save dir (#9766).
+    Use an absolute path for a custom output location.
+    """
     if os.path.isabs(paths[-1]):
         logger.warning_rank0("Found complex path, some features may be not available.")
         return paths[-1]

--- a/src/llamafactory/webui/common.py
+++ b/src/llamafactory/webui/common.py
@@ -58,7 +58,7 @@ def abort_process(pid: int) -> None:
 
 def get_save_dir(*paths: str) -> os.PathLike:
     r"""Get the path to saved model checkpoints."""
-    if os.path.sep in paths[-1]:
+    if os.path.isabs(paths[-1]):
         logger.warning_rank0("Found complex path, some features may be not available.")
         return paths[-1]
 

--- a/src/llamafactory/webui/control.py
+++ b/src/llamafactory/webui/control.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import re
 from typing import Any
 
 from transformers.trainer_utils import get_last_checkpoint
@@ -157,6 +158,24 @@ def get_trainer_info(lang: str, output_path: os.PathLike, do_train: bool) -> tup
     return running_log, running_progress, running_info
 
 
+def _is_checkpoint_dir(path: str) -> bool:
+    r"""Whether a directory holds a saved checkpoint."""
+    return any(os.path.isfile(os.path.join(path, name)) for name in CHECKPOINT_NAMES)
+
+
+def _checkpoint_sort_key(checkpoint: str) -> tuple[str, int, int, str]:
+    r"""Order checkpoints by trailing step number so that checkpoint-200 precedes checkpoint-1000.
+
+    Names without a trailing step fall back to a lexicographic sort, after the numbered ones.
+    """
+    parent, name = os.path.split(checkpoint)
+    match = re.search(r"-(\d+)$", name)
+    if match:
+        return (parent, 0, int(match.group(1)), "")
+
+    return (parent, 1, 0, name)
+
+
 def list_checkpoints(model_name: str, finetuning_type: str) -> "gr.Dropdown":
     r"""List all available checkpoints.
 
@@ -167,14 +186,25 @@ def list_checkpoints(model_name: str, finetuning_type: str) -> "gr.Dropdown":
     if model_name:
         save_dir = get_save_dir(model_name, finetuning_type)
         if save_dir and os.path.isdir(save_dir):
-            # walk recursively: a checkpoint may either sit directly under save_dir (a finished run)
-            # or be nested one level deeper as `<run_dir>/checkpoint-<step>` (an intermediate save),
-            # both of which should show up in the dropdown
-            for root, _, files in os.walk(save_dir):
-                if any(name in files for name in CHECKPOINT_NAMES):
-                    checkpoints.append(os.path.relpath(root, save_dir))
+            # a checkpoint sits either directly under save_dir (`<run_dir>`, the final save of a
+            # finished run) or one level deeper (`<run_dir>/checkpoint-<step>`, an intermediate
+            # save_steps save). Both should show up, so scan exactly those two levels rather than
+            # walking the tree: save dirs also hold `runs/`, `wandb/` and exported models, and
+            # list_checkpoints fires on every model / finetuning-type change in the UI.
+            for run_name in sorted(os.listdir(save_dir)):
+                run_dir = os.path.join(save_dir, run_name)
+                if not os.path.isdir(run_dir):
+                    continue
 
-    checkpoints = sorted(checkpoints)
+                if _is_checkpoint_dir(run_dir):
+                    checkpoints.append(run_name)
+
+                for step_name in os.listdir(run_dir):
+                    step_dir = os.path.join(run_dir, step_name)
+                    if os.path.isdir(step_dir) and _is_checkpoint_dir(step_dir):
+                        checkpoints.append(os.path.join(run_name, step_name))
+
+    checkpoints = sorted(checkpoints, key=_checkpoint_sort_key)
     if finetuning_type in PEFT_METHODS:
         return gr.Dropdown(value=[], choices=checkpoints, multiselect=True)
     else:

--- a/src/llamafactory/webui/control.py
+++ b/src/llamafactory/webui/control.py
@@ -167,12 +167,14 @@ def list_checkpoints(model_name: str, finetuning_type: str) -> "gr.Dropdown":
     if model_name:
         save_dir = get_save_dir(model_name, finetuning_type)
         if save_dir and os.path.isdir(save_dir):
-            for checkpoint in os.listdir(save_dir):
-                if os.path.isdir(os.path.join(save_dir, checkpoint)) and any(
-                    os.path.isfile(os.path.join(save_dir, checkpoint, name)) for name in CHECKPOINT_NAMES
-                ):
-                    checkpoints.append(checkpoint)
+            # walk recursively: a checkpoint may either sit directly under save_dir (a finished run)
+            # or be nested one level deeper as `<run_dir>/checkpoint-<step>` (an intermediate save),
+            # both of which should show up in the dropdown
+            for root, _, files in os.walk(save_dir):
+                if any(name in files for name in CHECKPOINT_NAMES):
+                    checkpoints.append(os.path.relpath(root, save_dir))
 
+    checkpoints = sorted(checkpoints)
     if finetuning_type in PEFT_METHODS:
         return gr.Dropdown(value=[], choices=checkpoints, multiselect=True)
     else:

--- a/tests/webui/test_control_checkpoints.py
+++ b/tests/webui/test_control_checkpoints.py
@@ -1,0 +1,67 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from llamafactory.webui import common as webui_common
+from llamafactory.webui.control import list_checkpoints
+
+
+def test_list_checkpoints_finds_nested_and_top_level(tmp_path, monkeypatch):
+    r"""The checkpoint dropdown must list both top-level and nested (intermediate) checkpoints (see #9766).
+
+    A training run that finished normally saves its final adapter directly under the run dir
+    (`<run_dir>/adapter_model.safetensors`), while a run that was interrupted before completion only
+    has its intermediate `save_steps` checkpoints nested one level deeper as
+    `<run_dir>/checkpoint-<step>/adapter_model.safetensors`. Both must show up in the dropdown.
+    """
+    monkeypatch.setattr(webui_common, "DEFAULT_SAVE_DIR", str(tmp_path))
+
+    save_dir = tmp_path / "mymodel" / "lora"
+    (save_dir / "train_completed").mkdir(parents=True)
+    (save_dir / "train_completed" / "adapter_model.safetensors").touch()
+
+    (save_dir / "train_interrupted" / "checkpoint-100").mkdir(parents=True)
+    (save_dir / "train_interrupted" / "checkpoint-100" / "adapter_model.safetensors").touch()
+    (save_dir / "train_interrupted" / "checkpoint-200").mkdir(parents=True)
+    (save_dir / "train_interrupted" / "checkpoint-200" / "adapter_model.safetensors").touch()
+
+    result = list_checkpoints("mymodel", "lora")
+    choices = [value for _, value in result.choices]
+    assert set(choices) == {
+        "train_completed",
+        os.path.join("train_interrupted", "checkpoint-100"),
+        os.path.join("train_interrupted", "checkpoint-200"),
+    }
+
+
+def test_list_checkpoints_no_save_dir_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(webui_common, "DEFAULT_SAVE_DIR", str(tmp_path))
+    result = list_checkpoints("nonexistent_model", "lora")
+    assert result.choices == []
+
+
+def test_get_save_dir_resolves_nested_checkpoint(monkeypatch):
+    r"""A nested checkpoint value returned by list_checkpoints must still resolve under the save dir."""
+    monkeypatch.setattr(webui_common, "DEFAULT_SAVE_DIR", "saves")
+    nested = os.path.join("train_interrupted", "checkpoint-100")
+    expected = os.path.join("saves", "mymodel", "lora", "train_interrupted", "checkpoint-100")
+    assert str(webui_common.get_save_dir("mymodel", "lora", nested)) == expected
+
+
+def test_get_save_dir_still_bypasses_for_absolute_custom_path(monkeypatch):
+    r"""A user-typed absolute custom path (see #4292) must still bypass the save dir entirely."""
+    monkeypatch.setattr(webui_common, "DEFAULT_SAVE_DIR", "saves")
+    absolute_path = os.path.abspath(os.path.join(os.sep, "abs", "custom", "path"))
+    assert webui_common.get_save_dir("mymodel", "lora", absolute_path) == absolute_path

--- a/tests/webui/test_control_checkpoints.py
+++ b/tests/webui/test_control_checkpoints.py
@@ -65,3 +65,64 @@ def test_get_save_dir_still_bypasses_for_absolute_custom_path(monkeypatch):
     monkeypatch.setattr(webui_common, "DEFAULT_SAVE_DIR", "saves")
     absolute_path = os.path.abspath(os.path.join(os.sep, "abs", "custom", "path"))
     assert webui_common.get_save_dir("mymodel", "lora", absolute_path) == absolute_path
+
+
+def test_list_checkpoints_sorts_by_step_number(tmp_path, monkeypatch):
+    r"""checkpoint-200 must come before checkpoint-1000, which a lexicographic sort gets wrong."""
+    monkeypatch.setattr(webui_common, "DEFAULT_SAVE_DIR", str(tmp_path))
+
+    run_dir = tmp_path / "mymodel" / "lora" / "train_run"
+    for step in (100, 200, 1000):
+        (run_dir / f"checkpoint-{step}").mkdir(parents=True)
+        (run_dir / f"checkpoint-{step}" / "adapter_model.safetensors").touch()
+
+    result = list_checkpoints("mymodel", "lora")
+    assert [value for _, value in result.choices] == [
+        os.path.join("train_run", "checkpoint-100"),
+        os.path.join("train_run", "checkpoint-200"),
+        os.path.join("train_run", "checkpoint-1000"),
+    ]
+
+
+def test_list_checkpoints_skips_the_save_dir_itself(tmp_path, monkeypatch):
+    r"""A checkpoint sitting in the save dir itself must not surface as a "." dropdown entry."""
+    monkeypatch.setattr(webui_common, "DEFAULT_SAVE_DIR", str(tmp_path))
+
+    save_dir = tmp_path / "mymodel" / "lora"
+    save_dir.mkdir(parents=True)
+    (save_dir / "adapter_model.safetensors").touch()
+
+    result = list_checkpoints("mymodel", "lora")
+    assert [value for _, value in result.choices] == []
+
+
+def test_list_checkpoints_ignores_unrelated_dirs(tmp_path, monkeypatch):
+    r"""Logging and export dirs under the save dir hold no checkpoint files and must not be listed."""
+    monkeypatch.setattr(webui_common, "DEFAULT_SAVE_DIR", str(tmp_path))
+
+    save_dir = tmp_path / "mymodel" / "lora"
+    (save_dir / "runs" / "Jan01_00-00-00").mkdir(parents=True)
+    (save_dir / "runs" / "Jan01_00-00-00" / "events.out.tfevents.1").touch()
+    (save_dir / "wandb" / "latest-run").mkdir(parents=True)
+    (save_dir / "train_run").mkdir(parents=True)
+    (save_dir / "train_run" / "adapter_model.safetensors").touch()
+
+    result = list_checkpoints("mymodel", "lora")
+    assert [value for _, value in result.choices] == ["train_run"]
+
+
+def test_list_checkpoints_lists_intermediate_saves_of_a_finished_run(tmp_path, monkeypatch):
+    r"""A finished run keeps its intermediate checkpoints selectable alongside its final save."""
+    monkeypatch.setattr(webui_common, "DEFAULT_SAVE_DIR", str(tmp_path))
+
+    run_dir = tmp_path / "mymodel" / "lora" / "train_run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "adapter_model.safetensors").touch()
+    (run_dir / "checkpoint-100").mkdir()
+    (run_dir / "checkpoint-100" / "adapter_model.safetensors").touch()
+
+    result = list_checkpoints("mymodel", "lora")
+    assert [value for _, value in result.choices] == [
+        "train_run",
+        os.path.join("train_run", "checkpoint-100"),
+    ]


### PR DESCRIPTION
# What does this PR do?

`list_checkpoints()` (used to populate the checkpoint-path dropdown in
the WebUI) only listed the *immediate* children of the model/finetuning
save dir and checked each one directly for adapter weight files. That
matches a run that finished normally, since its final adapter is saved
directly under the run directory (`<run_dir>/adapter_model.safetensors`).
It does **not** match an intermediate `save_steps` checkpoint, which is
saved one level deeper as `<run_dir>/checkpoint-<step>/adapter_model.safetensors`
— e.g. exactly what's left behind when a run is interrupted (ctrl-c)
before it reaches its final save. Those nested checkpoints were silently
skipped, so with multiple runs in the output directory the dropdown
appeared to only show part of what was actually on disk (#9766).

This PR:
- Changes `list_checkpoints()` to scan the two levels under `save_dir`
  that can hold a checkpoint — `<run_dir>` and `<run_dir>/checkpoint-<step>`
  — instead of a single `os.listdir()`, so both top-level (finished-run)
  and nested (intermediate) checkpoints are discovered. The scan is
  deliberately bounded rather than an `os.walk`: save dirs also hold
  `runs/`, `wandb/` and exported models, and `list_checkpoints` fires on
  every model / finetuning-type change in the UI.
- Sorts on the trailing step number when it parses, so `checkpoint-200`
  precedes `checkpoint-1000` in the dropdown instead of following it.
- Fixes `get_save_dir()`, which previously used "does the checkpoint
  value contain a path separator" as a proxy for "is this a
  custom/absolute path the user typed in" (added in #4292 to support
  pasting an absolute path into the `allow_custom_value` dropdown).
  That heuristic also matched the newly-surfaced nested relative
  checkpoint values (e.g. `train_xxx/checkpoint-100`), which would have
  made `get_save_dir()` return them as-is instead of joining them under
  `saves/<model>/<finetuning_type>/`, breaking checkpoint resolution.
  Switched the check to `os.path.isabs()`, which only matches genuine
  absolute paths — #4292's original behavior is preserved (verified
  with a regression test), while relative nested checkpoint paths now
  resolve correctly.

### Behavior change worth calling out

`get_save_dir()` previously bypassed the save dir for *any* last component
containing a path separator, so a user-typed **relative** custom path
(`output_dir: my/custom/dir`, from the free-text `train.output_dir` /
`eval.output_dir` boxes) resolved against the cwd. With the `os.path.isabs()`
check it is now joined under `saves/<model>/<finetuning_type>/` like any other
relative value. This is deliberate — the dropdown now hands back nested
relative values, and bypassing on an embedded separator would send those
outside the save dir — but it is user-visible. An absolute path is the way to
opt out, and `get_save_dir`'s docstring now says so.

## How was this tested?

Added `tests/webui/test_control_checkpoints.py`:
- `list_checkpoints()` finds both a top-level (finished-run) checkpoint
  and nested intermediate checkpoints in a fixture directory tree that
  mirrors the report (a completed run + an interrupted run with only
  `checkpoint-100`/`checkpoint-200` subfolders).
- `list_checkpoints()` still returns an empty list when there's nothing
  to find.
- `get_save_dir()` correctly resolves a nested relative checkpoint path
  under the save dir.
- `get_save_dir()` still bypasses the save dir entirely for an absolute
  custom path (regression guard for #4292).
- `checkpoint-100`/`checkpoint-200`/`checkpoint-1000` come back in step
  order, not lexicographic order.
- A checkpoint sitting in `save_dir` itself does not surface as a `"."`
  dropdown entry.
- `runs/` and `wandb/` under the save dir are not listed.
- A finished run keeps its intermediate checkpoints selectable alongside
  its final save.

```
$ WANDB_DISABLED=true python -m pytest -vv --import-mode=importlib tests/webui/test_control_checkpoints.py
8 passed
```

I also reproduced the bug against `main` first with a small script
building the same fixture tree, confirming only the finished-run
checkpoint was listed and the two nested ones were missing.

Fixes #9766

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
