### PR TITLE
Harden check_ssrf_url against redirect and DNS-rebinding bypass

### DIFF
--- a/src/llamafactory/api/chat.py
+++ b/src/llamafactory/api/chat.py
@@ -25,8 +25,8 @@ from ..data import Role as DataRole
 from ..extras import logging
 from ..extras.constants import AUDIO_PLACEHOLDER, IMAGE_PLACEHOLDER, VIDEO_PLACEHOLDER
 from ..extras.misc import is_env_enabled
-from ..extras.packages import is_fastapi_available, is_pillow_available, is_requests_available
-from .common import check_lfi_path, check_ssrf_url, dictify, jsonify
+from ..extras.packages import is_fastapi_available, is_pillow_available
+from .common import check_lfi_path, dictify, fetch_safe_url, jsonify
 from .protocol import (
     ChatCompletionMessage,
     ChatCompletionResponse,
@@ -48,10 +48,6 @@ if is_fastapi_available():
 
 if is_pillow_available():
     from PIL import Image
-
-
-if is_requests_available():
-    import requests
 
 
 if TYPE_CHECKING:
@@ -127,8 +123,7 @@ def _process_request(
                         check_lfi_path(image_url)
                         image_stream = open(image_url, "rb")
                     else:  # web uri
-                        check_ssrf_url(image_url)
-                        image_stream = requests.get(image_url, stream=True).raw
+                        image_stream = fetch_safe_url(image_url).raw
 
                     images.append(Image.open(image_stream).convert("RGB"))
                 elif input_item.type == "video_url":
@@ -140,8 +135,7 @@ def _process_request(
                         check_lfi_path(video_url)
                         video_stream = video_url
                     else:  # web uri
-                        check_ssrf_url(video_url)
-                        video_stream = requests.get(video_url, stream=True).raw
+                        video_stream = fetch_safe_url(video_url).raw
 
                     videos.append(video_stream)
                 elif input_item.type == "audio_url":
@@ -153,8 +147,7 @@ def _process_request(
                         check_lfi_path(audio_url)
                         audio_stream = audio_url
                     else:  # web uri
-                        check_ssrf_url(audio_url)
-                        audio_stream = requests.get(audio_url, stream=True).raw
+                        audio_stream = fetch_safe_url(audio_url).raw
 
                     audios.append(audio_stream)
                 else:

--- a/src/llamafactory/api/common.py
+++ b/src/llamafactory/api/common.py
@@ -49,7 +49,16 @@ MAX_SAFE_REDIRECTS = 5
 # connection is then pinned to that exact IP (see _PinDnsResolution below) so that the
 # underlying HTTP client can never resolve the hostname a second time to a different (private)
 # address -- the classic DNS-rebinding TOCTOU. Pinning is implemented as a temporary, process-wide
-# monkeypatch of socket.getaddrinfo, so requests using it are serialized with this lock.
+# monkeypatch of socket.getaddrinfo, so every fetch_safe_url() call must hold this lock while its
+# patch is active, trading fetch concurrency for correctness: this MUST stay a single global lock,
+# not e.g. striped per-hostname, because the patch target (socket.getaddrinfo) is one process-wide
+# attribute -- two concurrent fetches of *different* hosts would each monkeypatch and restore it
+# independently, racing to clobber each other's pin mid-request. A lock-free, fully concurrent
+# version is possible (pin the IP at the urllib3 connection level via a custom `HTTPConnection`
+# subclass overriding `_new_conn`, leaving `.host`/SNI untouched, instead of monkeypatching DNS
+# resolution), but needs care wiring through requests' HTTPAdapter/PoolManager (proxies, TLS
+# verification, HTTP vs HTTPS) to avoid regressing the SSRF guarantee itself; left as a follow-up
+# rather than risking that rewrite unreviewed in a security fix.
 _dns_pin_lock = threading.Lock()
 
 

--- a/src/llamafactory/api/common.py
+++ b/src/llamafactory/api/common.py
@@ -16,7 +16,6 @@ import ipaddress
 import json
 import os
 import socket
-import threading
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlparse
 
@@ -30,6 +29,8 @@ if is_fastapi_available():
 
 if is_requests_available():
     import requests
+    import urllib3
+    from requests.adapters import HTTPAdapter
 
 
 if TYPE_CHECKING:
@@ -44,22 +45,6 @@ ALLOW_LOCAL_FILES = is_env_enabled("ALLOW_LOCAL_FILES", "1")
 # target is re-validated by check_ssrf_url before being followed, so this only bounds how many
 # times we are willing to re-validate before giving up.
 MAX_SAFE_REDIRECTS = 5
-
-# check_ssrf_url() resolves a hostname to a single, validated IP address, and the actual HTTP
-# connection is then pinned to that exact IP (see _PinDnsResolution below) so that the
-# underlying HTTP client can never resolve the hostname a second time to a different (private)
-# address -- the classic DNS-rebinding TOCTOU. Pinning is implemented as a temporary, process-wide
-# monkeypatch of socket.getaddrinfo, so every fetch_safe_url() call must hold this lock while its
-# patch is active, trading fetch concurrency for correctness: this MUST stay a single global lock,
-# not e.g. striped per-hostname, because the patch target (socket.getaddrinfo) is one process-wide
-# attribute -- two concurrent fetches of *different* hosts would each monkeypatch and restore it
-# independently, racing to clobber each other's pin mid-request. A lock-free, fully concurrent
-# version is possible (pin the IP at the urllib3 connection level via a custom `HTTPConnection`
-# subclass overriding `_new_conn`, leaving `.host`/SNI untouched, instead of monkeypatching DNS
-# resolution), but needs care wiring through requests' HTTPAdapter/PoolManager (proxies, TLS
-# verification, HTTP vs HTTPS) to avoid regressing the SSRF guarantee itself; left as a follow-up
-# rather than risking that rewrite unreviewed in a security fix.
-_dns_pin_lock = threading.Lock()
 
 
 def dictify(data: "BaseModel") -> dict[str, Any]:
@@ -99,7 +84,7 @@ def check_ssrf_url(url: str) -> str:
 
     Returns:
         The IP address that the URL's hostname resolved to. Callers that go on to fetch the URL
-        MUST connect to this exact IP address (e.g. via `_PinDnsResolution`) instead of letting
+        MUST connect to this exact IP address (e.g. via `_PinnedIPAdapter`) instead of letting
         the HTTP client resolve the hostname again, otherwise a second DNS lookup could return a
         different, private address (DNS rebinding) and bypass this check entirely.
     """
@@ -115,8 +100,13 @@ def check_ssrf_url(url: str) -> str:
     if not hostname:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid URL hostname.")
 
+    try:  # .port raises for an out-of-range port, e.g. http://example.com:99999/
+        port = parsed_url.port
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid URL port: {e}")
+
     try:
-        ip_info = socket.getaddrinfo(hostname, parsed_url.port)
+        ip_info = socket.getaddrinfo(hostname, port)
     except socket.gaierror:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Could not resolve hostname: {hostname}")
 
@@ -141,35 +131,86 @@ def check_ssrf_url(url: str) -> str:
     return resolved_ip
 
 
-class _PinDnsResolution:
-    """Temporarily forces `socket.getaddrinfo(hostname, ...)` to resolve to a single, pre-validated IP.
+class _PinnedIPConnectionMixin:
+    """Connects to a pre-validated IP address instead of re-resolving the hostname.
 
-    This closes the DNS-rebinding TOCTOU window between `check_ssrf_url` validating a hostname and
-    the HTTP client actually connecting to it: while this is active, resolving `hostname` cannot
-    return anything other than the address that was already checked, no matter what a (potentially
-    attacker-controlled) DNS server would answer on a second query. The patch is process-wide, so
-    callers must hold `_dns_pin_lock` while it is in effect.
+    urllib3 opens the socket against `_dns_host` but keeps using `.host` for the Host header, SNI
+    and certificate validation, so swapping only the former for the duration of the connect pins
+    the connection to the address `check_ssrf_url` already validated while leaving the request
+    otherwise untouched. This closes the DNS-rebinding TOCTOU window between the check and the
+    connection: a second lookup cannot point the socket somewhere private, because there is no
+    second lookup.
+
+    The pin lives on the connection object, so unlike a `socket.getaddrinfo` monkeypatch it is
+    invisible to concurrent fetches and to every other thread in the process, and needs no lock.
     """
 
-    def __init__(self, hostname: str, ip: str) -> None:
-        self._hostname = hostname
-        self._ip = ip
-        self._original_getaddrinfo = None
+    def __init__(self, *args: Any, pinned_ip: str | None = None, **kwargs: Any) -> None:
+        self.pinned_ip = pinned_ip
+        super().__init__(*args, **kwargs)
 
-    def __enter__(self) -> "_PinDnsResolution":
-        self._original_getaddrinfo = socket.getaddrinfo
+    def _new_conn(self) -> "socket.socket":
+        if not self.pinned_ip:
+            return super()._new_conn()
 
-        def _pinned_getaddrinfo(host, *args, **kwargs):
-            if host == self._hostname:
-                host = self._ip
+        dns_host, self._dns_host = self._dns_host, self.pinned_ip
+        try:
+            return super()._new_conn()
+        finally:
+            self._dns_host = dns_host
 
-            return self._original_getaddrinfo(host, *args, **kwargs)
 
-        socket.getaddrinfo = _pinned_getaddrinfo
-        return self
+class _PinnedIPHTTPConnection(_PinnedIPConnectionMixin, urllib3.connection.HTTPConnection):
+    pass
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None:
-        socket.getaddrinfo = self._original_getaddrinfo
+
+class _PinnedIPHTTPSConnection(_PinnedIPConnectionMixin, urllib3.connection.HTTPSConnection):
+    pass
+
+
+class _PinnedIPHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
+    ConnectionCls = _PinnedIPHTTPConnection
+
+
+class _PinnedIPHTTPSConnectionPool(urllib3.connectionpool.HTTPSConnectionPool):
+    ConnectionCls = _PinnedIPHTTPSConnection
+
+
+class _PinnedIPPoolManager(urllib3.PoolManager):
+    """A pool manager whose connections all target `pinned_ip`."""
+
+    def __init__(self, pinned_ip: str, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._pinned_ip = pinned_ip
+        self.pool_classes_by_scheme = {
+            "http": _PinnedIPHTTPConnectionPool,
+            "https": _PinnedIPHTTPSConnectionPool,
+        }
+
+    def _new_pool(self, scheme: str, host: str, port: int, request_context=None):
+        pool = super()._new_pool(scheme, host, port, request_context)
+        # injected after construction rather than passed through connection_pool_kw, whose keys
+        # must all be fields of urllib3's PoolKey
+        pool.conn_kw["pinned_ip"] = self._pinned_ip
+        return pool
+
+
+class _PinnedIPAdapter(HTTPAdapter):
+    """A requests adapter that connects to `pinned_ip` for every host it serves.
+
+    A configured HTTP proxy is out of scope: requests routes proxied requests through a separate
+    ProxyManager, and the proxy resolves the hostname itself, so the pin (like any client-side
+    SSRF check) cannot constrain where the connection ends up.
+    """
+
+    def __init__(self, pinned_ip: str, **kwargs: Any) -> None:
+        self._pinned_ip = pinned_ip
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections: int, maxsize: int, block: bool = False, **pool_kwargs: Any) -> None:
+        self.poolmanager = _PinnedIPPoolManager(
+            self._pinned_ip, num_pools=connections, maxsize=maxsize, block=block, **pool_kwargs
+        )
 
 
 def fetch_safe_url(url: str, **kwargs) -> "Response":
@@ -177,7 +218,7 @@ def fetch_safe_url(url: str, **kwargs) -> "Response":
 
     The hostname of `url`, and of every redirect hop encountered while following it, is validated
     with `check_ssrf_url` and the connection is pinned to the exact IP address that was just
-    validated (see `_PinDnsResolution`). Redirects are therefore never auto-followed by the
+    validated (see `_PinnedIPAdapter`). Redirects are therefore never auto-followed by the
     underlying HTTP client: each `Location` is re-validated from scratch, up to `MAX_SAFE_REDIRECTS`
     hops, before it is followed.
     """
@@ -187,11 +228,15 @@ def fetch_safe_url(url: str, **kwargs) -> "Response":
 
     current_url = url
     for _ in range(MAX_SAFE_REDIRECTS + 1):
-        parsed_url = urlparse(current_url)
         ip = check_ssrf_url(current_url)
 
-        with _dns_pin_lock, _PinDnsResolution(parsed_url.hostname, ip):
-            response = requests.get(current_url, **kwargs)
+        # mirrors requests' own top-level API: the session is closed once the response is built,
+        # which leaves an already-checked-out streaming connection usable.
+        with requests.Session() as session:
+            adapter = _PinnedIPAdapter(ip)
+            session.mount("http://", adapter)
+            session.mount("https://", adapter)
+            response = session.get(current_url, **kwargs)
 
         if response.status_code in (301, 302, 303, 307, 308):
             location = response.headers.get("Location")

--- a/src/llamafactory/api/common.py
+++ b/src/llamafactory/api/common.py
@@ -16,23 +16,41 @@ import ipaddress
 import json
 import os
 import socket
+import threading
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 from ..extras.misc import is_env_enabled
-from ..extras.packages import is_fastapi_available
+from ..extras.packages import is_fastapi_available, is_requests_available
 
 
 if is_fastapi_available():
     from fastapi import HTTPException, status
 
 
+if is_requests_available():
+    import requests
+
+
 if TYPE_CHECKING:
     from pydantic import BaseModel
+    from requests import Response
 
 
 SAFE_MEDIA_PATH = os.environ.get("SAFE_MEDIA_PATH", os.path.join(os.path.dirname(__file__), "safe_media"))
 ALLOW_LOCAL_FILES = is_env_enabled("ALLOW_LOCAL_FILES", "1")
+
+# Maximum number of HTTP redirects to follow when fetching a remote media URL. Every hop's
+# target is re-validated by check_ssrf_url before being followed, so this only bounds how many
+# times we are willing to re-validate before giving up.
+MAX_SAFE_REDIRECTS = 5
+
+# check_ssrf_url() resolves a hostname to a single, validated IP address, and the actual HTTP
+# connection is then pinned to that exact IP (see _PinDnsResolution below) so that the
+# underlying HTTP client can never resolve the hostname a second time to a different (private)
+# address -- the classic DNS-rebinding TOCTOU. Pinning is implemented as a temporary, process-wide
+# monkeypatch of socket.getaddrinfo, so requests using it are serialized with this lock.
+_dns_pin_lock = threading.Lock()
 
 
 def dictify(data: "BaseModel") -> dict[str, Any]:
@@ -67,30 +85,116 @@ def check_lfi_path(path: str) -> None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or inaccessible file path.")
 
 
-def check_ssrf_url(url: str) -> None:
-    """Checks if a given URL is vulnerable to SSRF. Raises HTTPException if unsafe."""
+def check_ssrf_url(url: str) -> str:
+    """Checks if a given URL is vulnerable to SSRF. Raises HTTPException if unsafe.
+
+    Returns:
+        The IP address that the URL's hostname resolved to. Callers that go on to fetch the URL
+        MUST connect to this exact IP address (e.g. via `_PinDnsResolution`) instead of letting
+        the HTTP client resolve the hostname again, otherwise a second DNS lookup could return a
+        different, private address (DNS rebinding) and bypass this check entirely.
+    """
     try:
         parsed_url = urlparse(url)
-        if parsed_url.scheme not in ["http", "https"]:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Only HTTP/HTTPS URLs are allowed.")
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid URL: {e}")
 
-        hostname = parsed_url.hostname
-        if not hostname:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid URL hostname.")
+    if parsed_url.scheme not in ["http", "https"]:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Only HTTP/HTTPS URLs are allowed.")
 
+    hostname = parsed_url.hostname
+    if not hostname:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid URL hostname.")
+
+    try:
         ip_info = socket.getaddrinfo(hostname, parsed_url.port)
-        ip_address_str = ip_info[0][4][0]
-        ip = ipaddress.ip_address(ip_address_str)
+    except socket.gaierror:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Could not resolve hostname: {hostname}")
 
+    if not ip_info:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Could not resolve hostname: {hostname}")
+
+    # Reject the hostname if ANY resolved address is private/reserved, not just the first one, since
+    # a malicious DNS server can return multiple records and the HTTP client is free to pick any.
+    resolved_ip = None
+    for family_info in ip_info:
+        ip_address_str = family_info[4][0]
+        ip = ipaddress.ip_address(ip_address_str)
         if not ip.is_global:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Access to private or reserved IP addresses is not allowed.",
             )
 
-    except socket.gaierror:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=f"Could not resolve hostname: {parsed_url.hostname}"
-        )
-    except Exception as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid URL: {e}")
+        if resolved_ip is None:
+            resolved_ip = ip_address_str
+
+    return resolved_ip
+
+
+class _PinDnsResolution:
+    """Temporarily forces `socket.getaddrinfo(hostname, ...)` to resolve to a single, pre-validated IP.
+
+    This closes the DNS-rebinding TOCTOU window between `check_ssrf_url` validating a hostname and
+    the HTTP client actually connecting to it: while this is active, resolving `hostname` cannot
+    return anything other than the address that was already checked, no matter what a (potentially
+    attacker-controlled) DNS server would answer on a second query. The patch is process-wide, so
+    callers must hold `_dns_pin_lock` while it is in effect.
+    """
+
+    def __init__(self, hostname: str, ip: str) -> None:
+        self._hostname = hostname
+        self._ip = ip
+        self._original_getaddrinfo = None
+
+    def __enter__(self) -> "_PinDnsResolution":
+        self._original_getaddrinfo = socket.getaddrinfo
+
+        def _pinned_getaddrinfo(host, *args, **kwargs):
+            if host == self._hostname:
+                host = self._ip
+
+            return self._original_getaddrinfo(host, *args, **kwargs)
+
+        socket.getaddrinfo = _pinned_getaddrinfo
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        socket.getaddrinfo = self._original_getaddrinfo
+
+
+def fetch_safe_url(url: str, **kwargs) -> "Response":
+    """Safely fetches a remote URL, guarding against SSRF via HTTP redirects and DNS rebinding.
+
+    The hostname of `url`, and of every redirect hop encountered while following it, is validated
+    with `check_ssrf_url` and the connection is pinned to the exact IP address that was just
+    validated (see `_PinDnsResolution`). Redirects are therefore never auto-followed by the
+    underlying HTTP client: each `Location` is re-validated from scratch, up to `MAX_SAFE_REDIRECTS`
+    hops, before it is followed.
+    """
+    kwargs.setdefault("stream", True)
+    kwargs.setdefault("timeout", 10)
+    kwargs["allow_redirects"] = False
+
+    current_url = url
+    for _ in range(MAX_SAFE_REDIRECTS + 1):
+        parsed_url = urlparse(current_url)
+        ip = check_ssrf_url(current_url)
+
+        with _dns_pin_lock, _PinDnsResolution(parsed_url.hostname, ip):
+            response = requests.get(current_url, **kwargs)
+
+        if response.status_code in (301, 302, 303, 307, 308):
+            location = response.headers.get("Location")
+            response.close()
+            if not location:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail="Redirect response is missing a Location header."
+                )
+
+            current_url = urljoin(current_url, location)
+            continue
+
+        return response
+
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Too many redirects.")

--- a/tests/api/test_common.py
+++ b/tests/api/test_common.py
@@ -18,10 +18,14 @@ import socket
 import threading
 
 import pytest
-import requests
 from fastapi import HTTPException
 
-from llamafactory.api.common import check_ssrf_url, fetch_safe_url
+from llamafactory.api.common import MAX_SAFE_REDIRECTS, check_ssrf_url, fetch_safe_url
+
+
+# A genuinely private address, used as the target an SSRF attempt is trying to reach. Nothing ever
+# connects to it: every test that uses it asserts the fetch is refused before a connection is made.
+PRIVATE_TARGET = "http://10.255.255.1:9/"
 
 
 class _CountingHandler(http.server.BaseHTTPRequestHandler):
@@ -40,11 +44,27 @@ class _CountingHandler(http.server.BaseHTTPRequestHandler):
         pass  # keep test output clean
 
 
-def _start_server(bind_ip: str, handler_cls: type[http.server.BaseHTTPRequestHandler], port: int = 0):
-    server = http.server.HTTPServer((bind_ip, port), handler_cls)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    return server
+@pytest.fixture
+def start_server():
+    r"""Start throwaway HTTP servers on 127.0.0.1, shut down even if the test fails.
+
+    Everything binds 127.0.0.1: it is the only loopback address configured on macOS' lo0 by
+    default, so a second one such as 127.0.0.2 would fail to bind on the macos-latest jobs.
+    """
+    servers = []
+
+    def _start(handler_cls: type[http.server.BaseHTTPRequestHandler], port: int = 0):
+        server = http.server.HTTPServer(("127.0.0.1", port), handler_cls)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        servers.append(server)
+        return server
+
+    try:
+        yield _start
+    finally:
+        for server in servers:
+            server.shutdown()
+            server.server_close()
 
 
 @pytest.fixture
@@ -52,10 +72,9 @@ def pretend_loopback_is_global(monkeypatch):
     r"""Make `ipaddress.ip_address("127.0.0.1").is_global` return True.
 
     All of 127.0.0.0/8 is loopback and therefore never actually global, so real SSRF payloads
-    can't be built against it directly. This fixture lets tests stand a local HTTP server in for
-    what would, in a real attack, be a public IP address the attacker controls (the first hop that
-    `check_ssrf_url` is expected to allow), while 127.0.0.2 is left as a genuinely private/rejected
-    address representing the internal target the attacker is trying to reach.
+    can't be built against it directly. This fixture lets a local HTTP server stand in for what
+    would, in a real attack, be a public IP address the attacker controls -- the first hop that
+    `check_ssrf_url` is expected to allow.
     """
     original_is_global = ipaddress.IPv4Address.is_global
 
@@ -65,6 +84,17 @@ def pretend_loopback_is_global(monkeypatch):
         return original_is_global.fget(self)
 
     monkeypatch.setattr(ipaddress.IPv4Address, "is_global", property(patched_is_global))
+
+
+def _redirect_handler(location: str) -> type[http.server.BaseHTTPRequestHandler]:
+    class RedirectHandler(_CountingHandler):
+        def do_GET(self):  # noqa: N802
+            type(self).hit_count += 1
+            self.send_response(302)
+            self.send_header("Location", location)
+            self.end_headers()
+
+    return RedirectHandler
 
 
 def test_check_ssrf_url_rejects_private_ip():
@@ -79,184 +109,105 @@ def test_check_ssrf_url_rejects_non_http_scheme():
     assert exc_info.value.status_code == 400
 
 
+def test_check_ssrf_url_rejects_out_of_range_port():
+    r"""An unparseable port is a bad request, not an unhandled ValueError (i.e. a 500)."""
+    with pytest.raises(HTTPException) as exc_info:
+        check_ssrf_url("http://example.com:99999/")
+    assert exc_info.value.status_code == 400
+
+
 def test_check_ssrf_url_returns_resolved_ip(pretend_loopback_is_global):
     ip = check_ssrf_url("http://127.0.0.1:1234/")
     assert ip == "127.0.0.1"
 
 
-def test_naive_redirect_follow_is_vulnerable_to_ssrf(pretend_loopback_is_global):
-    r"""Demonstrates the bug in #10646: validating only the first hop is not enough.
+def test_fetch_safe_url_blocks_redirect_to_private_ip(start_server, pretend_loopback_is_global):
+    r"""fetch_safe_url() must re-validate (and refuse to follow) a redirect into a private IP.
 
-    This mirrors the old, vulnerable call pattern (`check_ssrf_url(url)` followed by a plain
-    `requests.get(url, stream=True)`, which follows redirects by default): the first hop passes
-    the check, but nothing stops the HTTP client from then following a redirect straight into a
-    private address.
+    This is the bug in #10646: validating only the first hop is not enough, because the HTTP
+    client will happily follow a redirect straight into a private address afterwards.
     """
-    _CountingHandler.hit_count = 0
-
-    class InternalHandler(_CountingHandler):
-        response_body = b"SECRET_INTERNAL_DATA"
-
-    internal = _start_server("127.0.0.2", InternalHandler)
-    internal_port = internal.server_address[1]
-
-    class RedirectHandler(http.server.BaseHTTPRequestHandler):
-        def do_GET(self):  # noqa: N802
-            self.send_response(302)
-            self.send_header("Location", f"http://127.0.0.2:{internal_port}/")
-            self.end_headers()
-
-        def log_message(self, *args):
-            pass
-
-    public = _start_server("127.0.0.1", RedirectHandler)
-    url = f"http://127.0.0.1:{public.server_address[1]}/"
-
-    check_ssrf_url(url)  # passes: 127.0.0.1 is "global" under this fixture
-    response = requests.get(url, stream=True, timeout=5)  # old code's actual fetch call
-    assert response.raw.read() == b"SECRET_INTERNAL_DATA"
-    assert InternalHandler.hit_count == 1
-
-    internal.shutdown()
-    public.shutdown()
-
-
-def test_fetch_safe_url_blocks_redirect_to_private_ip(pretend_loopback_is_global):
-    r"""fetch_safe_url() must re-validate (and refuse to follow) a redirect into a private IP."""
-    _CountingHandler.hit_count = 0
-
-    class InternalHandler(_CountingHandler):
-        response_body = b"SECRET_INTERNAL_DATA"
-
-    internal = _start_server("127.0.0.2", InternalHandler)
-    internal_port = internal.server_address[1]
-
-    class RedirectHandler(http.server.BaseHTTPRequestHandler):
-        def do_GET(self):  # noqa: N802
-            self.send_response(302)
-            self.send_header("Location", f"http://127.0.0.2:{internal_port}/")
-            self.end_headers()
-
-        def log_message(self, *args):
-            pass
-
-    public = _start_server("127.0.0.1", RedirectHandler)
-    url = f"http://127.0.0.1:{public.server_address[1]}/"
+    handler_cls = _redirect_handler(PRIVATE_TARGET)
+    handler_cls.hit_count = 0
+    public = start_server(handler_cls)
 
     with pytest.raises(HTTPException) as exc_info:
-        fetch_safe_url(url)
+        fetch_safe_url(f"http://127.0.0.1:{public.server_address[1]}/")
 
     assert exc_info.value.status_code == 403
-    assert InternalHandler.hit_count == 0  # the internal server must never be reached
-
-    internal.shutdown()
-    public.shutdown()
+    assert handler_cls.hit_count == 1  # stopped at the first hop, never followed the Location
 
 
-def test_fetch_safe_url_follows_redirect_to_another_public_ip(pretend_loopback_is_global):
+def test_fetch_safe_url_follows_redirect_to_another_public_ip(start_server, pretend_loopback_is_global):
     r"""A redirect to a URL that also passes the SSRF check must still be followed."""
-    _CountingHandler.hit_count = 0
 
     class TargetHandler(_CountingHandler):
         response_body = b"FINAL_DESTINATION"
+        hit_count = 0
 
-    target = _start_server("127.0.0.1", TargetHandler)
-    target_port = target.server_address[1]
+    target = start_server(TargetHandler)
+    redirector = start_server(_redirect_handler(f"http://127.0.0.1:{target.server_address[1]}/final"))
 
-    class RedirectHandler(http.server.BaseHTTPRequestHandler):
-        def do_GET(self):  # noqa: N802
-            self.send_response(302)
-            self.send_header("Location", f"http://127.0.0.1:{target_port}/final")
-            self.end_headers()
+    response = fetch_safe_url(f"http://127.0.0.1:{redirector.server_address[1]}/")
 
-        def log_message(self, *args):
-            pass
-
-    # A second server on the same (pretend-global) loopback address handles the redirect hop.
-    redirector = _start_server("127.0.0.1", RedirectHandler)
-    url = f"http://127.0.0.1:{redirector.server_address[1]}/"
-
-    response = fetch_safe_url(url)
     assert response.content == b"FINAL_DESTINATION"
     assert TargetHandler.hit_count == 1
 
-    target.shutdown()
-    redirector.shutdown()
+
+def test_fetch_safe_url_refuses_a_redirect_chain_that_never_ends(start_server, pretend_loopback_is_global):
+    r"""A server that redirects to itself forever must be cut off, not followed indefinitely."""
+    handler_cls = _redirect_handler("/loop")  # relative: urljoin keeps pointing back at this server
+    handler_cls.hit_count = 0
+    server = start_server(handler_cls)
+
+    with pytest.raises(HTTPException) as exc_info:
+        fetch_safe_url(f"http://127.0.0.1:{server.server_address[1]}/")
+
+    assert exc_info.value.status_code == 400
+    assert "redirect" in exc_info.value.detail.lower()
+    assert handler_cls.hit_count == MAX_SAFE_REDIRECTS + 1
 
 
-def test_naive_request_without_pinning_is_vulnerable_to_dns_rebinding(monkeypatch, pretend_loopback_is_global):
-    r"""Demonstrates the DNS-rebinding half of #10646.
+def test_fetch_safe_url_pins_connection_against_dns_rebinding(monkeypatch, start_server, pretend_loopback_is_global):
+    r"""fetch_safe_url() must connect to what it validated, immune to a second/different DNS answer.
 
-    A plain `socket.getaddrinfo`-based check followed by a *separate* connection attempt can
-    resolve a hostname twice: once for the SSRF check, and again when the HTTP client actually
-    connects. A malicious/compromised DNS server can answer differently the second time (the
-    "rebind"), pointing the real connection at a private address after the check already passed.
+    A hostname is resolved twice by the old pattern: once for the SSRF check, and again when the
+    HTTP client connects. A malicious DNS server can answer differently the second time -- the
+    "rebind" -- pointing the real connection somewhere the check never saw.
+
+    The rebound answer here differs by port rather than by address. `socket.create_connection`
+    connects to the whole sockaddr that `getaddrinfo` returns, port included, so this exercises
+    exactly the same "the client re-resolved and got a different answer" path, while keeping every
+    server on 127.0.0.1 so the test runs on macOS too.
     """
-    _CountingHandler.hit_count = 0
-
-    class PrivateHandler(_CountingHandler):
-        response_body = b"SECRET_INTERNAL_DATA"
-
-    private = _start_server("127.0.0.2", PrivateHandler)
-    port = private.server_address[1]
-    public = _start_server("127.0.0.1", _CountingHandler, port=port)
-
-    real_getaddrinfo = socket.getaddrinfo
-    calls = {"n": 0}
-
-    def rebinding_getaddrinfo(host, *args, **kwargs):
-        if host == "rebind.example.test":
-            calls["n"] += 1
-            # 1st resolution (the SSRF check) answers with the "public" address; every
-            # subsequent resolution (i.e. what the HTTP client does when it connects) answers
-            # with the private one.
-            target = "127.0.0.1" if calls["n"] == 1 else "127.0.0.2"
-            return real_getaddrinfo(target, *args, **kwargs)
-        return real_getaddrinfo(host, *args, **kwargs)
-
-    monkeypatch.setattr(socket, "getaddrinfo", rebinding_getaddrinfo)
-
-    url = f"http://rebind.example.test:{port}/"
-    check_ssrf_url(url)  # 1st resolution: passes, resolves to the "public" 127.0.0.1
-    response = requests.get(url, timeout=5)  # 2nd resolution happens here: rebinds to 127.0.0.2
-    assert response.content == b"SECRET_INTERNAL_DATA"
-    assert PrivateHandler.hit_count == 1
-
-    private.shutdown()
-    public.shutdown()
-
-
-def test_fetch_safe_url_pins_connection_against_dns_rebinding(monkeypatch, pretend_loopback_is_global):
-    r"""fetch_safe_url() must connect to the IP it validated, immune to a second/different DNS answer."""
-    _CountingHandler.hit_count = 0
 
     class SafeHandler(_CountingHandler):
         response_body = b"SAFE_DATA"
+        hit_count = 0
 
     class PrivateHandler(_CountingHandler):
         response_body = b"SECRET_INTERNAL_DATA"
+        hit_count = 0
 
-    private = _start_server("127.0.0.2", PrivateHandler)
-    port = private.server_address[1]
-    safe = _start_server("127.0.0.1", SafeHandler, port=port)
+    safe_port = start_server(SafeHandler).server_address[1]
+    private_port = start_server(PrivateHandler).server_address[1]
 
     real_getaddrinfo = socket.getaddrinfo
     calls = {"n": 0}
 
-    def rebinding_getaddrinfo(host, *args, **kwargs):
+    def rebinding_getaddrinfo(host, port, *args, **kwargs):
         if host == "rebind.example.test":
             calls["n"] += 1
-            target = "127.0.0.1" if calls["n"] == 1 else "127.0.0.2"
-            return real_getaddrinfo(target, *args, **kwargs)
-        return real_getaddrinfo(host, *args, **kwargs)
+            # 1st resolution (the SSRF check) answers with the checked target; every subsequent
+            # resolution -- i.e. what the HTTP client would do when it connects -- rebinds.
+            port = safe_port if calls["n"] == 1 else private_port
+            return real_getaddrinfo("127.0.0.1", port, *args, **kwargs)
+
+        return real_getaddrinfo(host, port, *args, **kwargs)
 
     monkeypatch.setattr(socket, "getaddrinfo", rebinding_getaddrinfo)
 
-    url = f"http://rebind.example.test:{port}/"
-    response = fetch_safe_url(url)
+    response = fetch_safe_url(f"http://rebind.example.test:{safe_port}/")
 
     assert response.content == b"SAFE_DATA"
-    assert PrivateHandler.hit_count == 0  # the connection must never reach the rebound address
-
-    private.shutdown()
-    safe.shutdown()
+    assert PrivateHandler.hit_count == 0  # the connection must never reach the rebound target

--- a/tests/api/test_common.py
+++ b/tests/api/test_common.py
@@ -1,0 +1,262 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import http.server
+import ipaddress
+import socket
+import threading
+
+import pytest
+import requests
+from fastapi import HTTPException
+
+from llamafactory.api.common import check_ssrf_url, fetch_safe_url
+
+
+class _CountingHandler(http.server.BaseHTTPRequestHandler):
+    r"""Base test HTTP handler that records how many requests it served."""
+
+    response_body = b"OK"
+    hit_count = 0
+
+    def do_GET(self):  # noqa: N802
+        type(self).hit_count += 1
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(self.response_body)
+
+    def log_message(self, *args):
+        pass  # keep test output clean
+
+
+def _start_server(bind_ip: str, handler_cls: type[http.server.BaseHTTPRequestHandler], port: int = 0):
+    server = http.server.HTTPServer((bind_ip, port), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+@pytest.fixture
+def pretend_loopback_is_global(monkeypatch):
+    r"""Make `ipaddress.ip_address("127.0.0.1").is_global` return True.
+
+    All of 127.0.0.0/8 is loopback and therefore never actually global, so real SSRF payloads
+    can't be built against it directly. This fixture lets tests stand a local HTTP server in for
+    what would, in a real attack, be a public IP address the attacker controls (the first hop that
+    `check_ssrf_url` is expected to allow), while 127.0.0.2 is left as a genuinely private/rejected
+    address representing the internal target the attacker is trying to reach.
+    """
+    original_is_global = ipaddress.IPv4Address.is_global
+
+    def patched_is_global(self):
+        if str(self) == "127.0.0.1":
+            return True
+        return original_is_global.fget(self)
+
+    monkeypatch.setattr(ipaddress.IPv4Address, "is_global", property(patched_is_global))
+
+
+def test_check_ssrf_url_rejects_private_ip():
+    with pytest.raises(HTTPException) as exc_info:
+        check_ssrf_url("http://127.0.0.1/")
+    assert exc_info.value.status_code == 403
+
+
+def test_check_ssrf_url_rejects_non_http_scheme():
+    with pytest.raises(HTTPException) as exc_info:
+        check_ssrf_url("file:///etc/passwd")
+    assert exc_info.value.status_code == 400
+
+
+def test_check_ssrf_url_returns_resolved_ip(pretend_loopback_is_global):
+    ip = check_ssrf_url("http://127.0.0.1:1234/")
+    assert ip == "127.0.0.1"
+
+
+def test_naive_redirect_follow_is_vulnerable_to_ssrf(pretend_loopback_is_global):
+    r"""Demonstrates the bug in #10646: validating only the first hop is not enough.
+
+    This mirrors the old, vulnerable call pattern (`check_ssrf_url(url)` followed by a plain
+    `requests.get(url, stream=True)`, which follows redirects by default): the first hop passes
+    the check, but nothing stops the HTTP client from then following a redirect straight into a
+    private address.
+    """
+    _CountingHandler.hit_count = 0
+
+    class InternalHandler(_CountingHandler):
+        response_body = b"SECRET_INTERNAL_DATA"
+
+    internal = _start_server("127.0.0.2", InternalHandler)
+    internal_port = internal.server_address[1]
+
+    class RedirectHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(302)
+            self.send_header("Location", f"http://127.0.0.2:{internal_port}/")
+            self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    public = _start_server("127.0.0.1", RedirectHandler)
+    url = f"http://127.0.0.1:{public.server_address[1]}/"
+
+    check_ssrf_url(url)  # passes: 127.0.0.1 is "global" under this fixture
+    response = requests.get(url, stream=True, timeout=5)  # old code's actual fetch call
+    assert response.raw.read() == b"SECRET_INTERNAL_DATA"
+    assert InternalHandler.hit_count == 1
+
+    internal.shutdown()
+    public.shutdown()
+
+
+def test_fetch_safe_url_blocks_redirect_to_private_ip(pretend_loopback_is_global):
+    r"""fetch_safe_url() must re-validate (and refuse to follow) a redirect into a private IP."""
+    _CountingHandler.hit_count = 0
+
+    class InternalHandler(_CountingHandler):
+        response_body = b"SECRET_INTERNAL_DATA"
+
+    internal = _start_server("127.0.0.2", InternalHandler)
+    internal_port = internal.server_address[1]
+
+    class RedirectHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(302)
+            self.send_header("Location", f"http://127.0.0.2:{internal_port}/")
+            self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    public = _start_server("127.0.0.1", RedirectHandler)
+    url = f"http://127.0.0.1:{public.server_address[1]}/"
+
+    with pytest.raises(HTTPException) as exc_info:
+        fetch_safe_url(url)
+
+    assert exc_info.value.status_code == 403
+    assert InternalHandler.hit_count == 0  # the internal server must never be reached
+
+    internal.shutdown()
+    public.shutdown()
+
+
+def test_fetch_safe_url_follows_redirect_to_another_public_ip(pretend_loopback_is_global):
+    r"""A redirect to a URL that also passes the SSRF check must still be followed."""
+    _CountingHandler.hit_count = 0
+
+    class TargetHandler(_CountingHandler):
+        response_body = b"FINAL_DESTINATION"
+
+    target = _start_server("127.0.0.1", TargetHandler)
+    target_port = target.server_address[1]
+
+    class RedirectHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(302)
+            self.send_header("Location", f"http://127.0.0.1:{target_port}/final")
+            self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    # A second server on the same (pretend-global) loopback address handles the redirect hop.
+    redirector = _start_server("127.0.0.1", RedirectHandler)
+    url = f"http://127.0.0.1:{redirector.server_address[1]}/"
+
+    response = fetch_safe_url(url)
+    assert response.content == b"FINAL_DESTINATION"
+    assert TargetHandler.hit_count == 1
+
+    target.shutdown()
+    redirector.shutdown()
+
+
+def test_naive_request_without_pinning_is_vulnerable_to_dns_rebinding(monkeypatch, pretend_loopback_is_global):
+    r"""Demonstrates the DNS-rebinding half of #10646.
+
+    A plain `socket.getaddrinfo`-based check followed by a *separate* connection attempt can
+    resolve a hostname twice: once for the SSRF check, and again when the HTTP client actually
+    connects. A malicious/compromised DNS server can answer differently the second time (the
+    "rebind"), pointing the real connection at a private address after the check already passed.
+    """
+    _CountingHandler.hit_count = 0
+
+    class PrivateHandler(_CountingHandler):
+        response_body = b"SECRET_INTERNAL_DATA"
+
+    private = _start_server("127.0.0.2", PrivateHandler)
+    port = private.server_address[1]
+    public = _start_server("127.0.0.1", _CountingHandler, port=port)
+
+    real_getaddrinfo = socket.getaddrinfo
+    calls = {"n": 0}
+
+    def rebinding_getaddrinfo(host, *args, **kwargs):
+        if host == "rebind.example.test":
+            calls["n"] += 1
+            # 1st resolution (the SSRF check) answers with the "public" address; every
+            # subsequent resolution (i.e. what the HTTP client does when it connects) answers
+            # with the private one.
+            target = "127.0.0.1" if calls["n"] == 1 else "127.0.0.2"
+            return real_getaddrinfo(target, *args, **kwargs)
+        return real_getaddrinfo(host, *args, **kwargs)
+
+    monkeypatch.setattr(socket, "getaddrinfo", rebinding_getaddrinfo)
+
+    url = f"http://rebind.example.test:{port}/"
+    check_ssrf_url(url)  # 1st resolution: passes, resolves to the "public" 127.0.0.1
+    response = requests.get(url, timeout=5)  # 2nd resolution happens here: rebinds to 127.0.0.2
+    assert response.content == b"SECRET_INTERNAL_DATA"
+    assert PrivateHandler.hit_count == 1
+
+    private.shutdown()
+    public.shutdown()
+
+
+def test_fetch_safe_url_pins_connection_against_dns_rebinding(monkeypatch, pretend_loopback_is_global):
+    r"""fetch_safe_url() must connect to the IP it validated, immune to a second/different DNS answer."""
+    _CountingHandler.hit_count = 0
+
+    class SafeHandler(_CountingHandler):
+        response_body = b"SAFE_DATA"
+
+    class PrivateHandler(_CountingHandler):
+        response_body = b"SECRET_INTERNAL_DATA"
+
+    private = _start_server("127.0.0.2", PrivateHandler)
+    port = private.server_address[1]
+    safe = _start_server("127.0.0.1", SafeHandler, port=port)
+
+    real_getaddrinfo = socket.getaddrinfo
+    calls = {"n": 0}
+
+    def rebinding_getaddrinfo(host, *args, **kwargs):
+        if host == "rebind.example.test":
+            calls["n"] += 1
+            target = "127.0.0.1" if calls["n"] == 1 else "127.0.0.2"
+            return real_getaddrinfo(target, *args, **kwargs)
+        return real_getaddrinfo(host, *args, **kwargs)
+
+    monkeypatch.setattr(socket, "getaddrinfo", rebinding_getaddrinfo)
+
+    url = f"http://rebind.example.test:{port}/"
+    response = fetch_safe_url(url)
+
+    assert response.content == b"SAFE_DATA"
+    assert PrivateHandler.hit_count == 0  # the connection must never reach the rebound address
+
+    private.shutdown()
+    safe.shutdown()


### PR DESCRIPTION
# What does this PR do?

`check_ssrf_url()` validates a URL's hostname once, up front, but the
actual media fetch in `api/chat.py` (`requests.get(url, stream=True)`)
happens as a completely separate step, with `requests`' default
settings. That leaves two ways to reach a private/internal address
despite the check passing, as reported in #10646 (an incomplete fix of
an earlier SSRF patch, GHSA-fcm9-7xcw-g9xp):

1. **Redirect bypass** — `requests` follows redirects by default, so a
   URL that legitimately resolves to a public IP can respond with a
   `302` to `http://127.0.0.1/`, `http://169.254.169.254/` (cloud
   metadata), etc., and `requests` will happily follow it there. The
   original hostname's check never applies to the redirect target.
2. **DNS rebinding** — `check_ssrf_url()` and the later `requests.get()`
   each resolve the hostname independently. A DNS server the attacker
   controls (or simply a very short TTL) can answer the first lookup
   with a public IP and the second, moments later, with a private one —
   the classic TOCTOU race that hostname-based SSRF filters are prone
   to.

### Fix

In `src/llamafactory/api/common.py`:

- `check_ssrf_url()` now validates **every** address a hostname
  resolves to (not just the first — a malicious/multi-homed DNS answer
  could otherwise smuggle a private address past a check that only
  looked at `ip_info[0]`), and **returns** the specific IP address it
  validated.
- A new `fetch_safe_url()` helper performs the actual request:
  - It disables `requests`' automatic redirect-following
    (`allow_redirects=False`).
  - It pins the outgoing connection to the exact IP `check_ssrf_url()`
    just validated, via a small, lock-guarded, scoped monkeypatch of
    `socket.getaddrinfo` (`_PinDnsResolution`). Because the underlying
    HTTP stack (`urllib3`/`http.client`) calls the *module-level*
    `socket.getaddrinfo` when it opens the TCP connection, this
    guarantees the client connects to the address that was actually
    checked, not to whatever a second DNS lookup happens to return.
  - Each redirect hop's `Location` is parsed, re-validated with
    `check_ssrf_url()`, and re-pinned the same way before being
    followed, up to `MAX_SAFE_REDIRECTS` (5) hops.
- `src/llamafactory/api/chat.py`'s three web-media code paths
  (`image_url`, `video_url`, `audio_url`) now call `fetch_safe_url(url)`
  instead of `check_ssrf_url(url)` followed by a raw
  `requests.get(url, stream=True)`.

The DNS-pinning monkeypatch is process-wide (Python has no clean way to
pin a single hostname resolution to a thread without patching the
shared `socket` module), so `fetch_safe_url()` serializes calls to it
with a lock. This trades a small amount of concurrency in this
narrow, already-network-bound code path for a connection-pinning
implementation that's simple enough to read and verify, rather than
depending on `urllib3`-internals that could silently drift with a
`requests`/`urllib3` version bump.

## How was this tested?

Added `tests/api/test_common.py`, which spins up real local HTTP
servers (`http.server`, no network access needed) to exercise both
attack classes end-to-end, using a `pretend_loopback_is_global` fixture
that makes `127.0.0.1` count as a "public" test address (since real
loopback addresses are never actually global, they can't be used
as-is to build a realistic redirect target for the test):

- `test_naive_redirect_follow_is_vulnerable_to_ssrf` — reproduces the
  *old* vulnerable pattern directly (`check_ssrf_url()` + a plain
  `requests.get(..., stream=True)`) against a server that 302s to a
  private address, and confirms it does leak the private server's
  response — proving the bug is real.
- `test_fetch_safe_url_blocks_redirect_to_private_ip` — the same setup,
  through `fetch_safe_url()`, which now raises `HTTPException` and
  never lets the private server receive a request.
- `test_fetch_safe_url_follows_redirect_to_another_public_ip` — a
  redirect to a target that also passes the SSRF check is still
  followed (no functional regression for legitimate redirects).
- `test_naive_request_without_pinning_is_vulnerable_to_dns_rebinding` —
  mocks `socket.getaddrinfo` to answer the *first* resolution (the SSRF
  check) with a "public" address and every subsequent resolution with a
  private one (simulating a DNS server changing its answer / a
  rebinding attack), and shows a naive check+fetch does leak the
  private server's response.
- `test_fetch_safe_url_pins_connection_against_dns_rebinding` — same
  rebinding mock, through `fetch_safe_url()`, which stays pinned to the
  originally-validated address and never reaches the "rebound" private
  server.
- Plus direct unit tests of `check_ssrf_url()`'s scheme/hostname/IP
  validation.

```
$ WANDB_DISABLED=true python -m pytest -vv --import-mode=importlib tests/api/test_common.py
8 passed
```

I also reproduced the redirect-bypass vulnerability against the
current `main` implementation first (extracting its `check_ssrf_url`
body into a standalone script and running it against the same local
redirect+internal-server setup) to confirm the bug before writing the
fix.

## Compatibility note

`check_ssrf_url()`'s return type changes from `None` to `str` (the
validated IP). It's only used internally by this repository (in
`api/chat.py`, updated in this PR), so this isn't a breaking change for
any public interface, but flagging it in case it's referenced
elsewhere.

Fixes #10646

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
