### PR TITLE
[hparams] reject out-of-range top_p instead of silently rewriting it to 1.0

### DIFF
--- a/scripts/vllm_infer.py
+++ b/scripts/vllm_infer.py
@@ -131,7 +131,7 @@ def vllm_infer(
     sampling_params = SamplingParams(
         repetition_penalty=generating_args.repetition_penalty or 1.0,  # repetition_penalty must > 0
         temperature=generating_args.temperature,
-        top_p=generating_args.top_p or 1.0,  # top_p must > 0
+        top_p=generating_args.top_p,
         top_k=generating_args.top_k or -1,  # top_k must > 0
         stop_token_ids=template_obj.get_stop_token_ids(tokenizer),
         max_tokens=generating_args.max_new_tokens,

--- a/src/llamafactory/chat/sglang_engine.py
+++ b/src/llamafactory/chat/sglang_engine.py
@@ -193,7 +193,7 @@ class SGLangEngine(BaseEngine):
 
         sampling_params = {
             "temperature": temperature if temperature is not None else self.generating_args["temperature"],
-            "top_p": (top_p if top_p is not None else self.generating_args["top_p"]) or 1.0,  # top_p must > 0
+            "top_p": top_p if top_p is not None else self.generating_args["top_p"],
             "top_k": (top_k if top_k is not None else self.generating_args["top_k"]) or -1,  # top_k must > 0
             "stop": stop,
             "stop_token_ids": self.template.get_stop_token_ids(self.tokenizer),

--- a/src/llamafactory/chat/vllm_engine.py
+++ b/src/llamafactory/chat/vllm_engine.py
@@ -171,7 +171,7 @@ class VllmEngine(BaseEngine):
             )
             or 1.0,  # repetition_penalty must > 0
             temperature=temperature if temperature is not None else self.generating_args["temperature"],
-            top_p=(top_p if top_p is not None else self.generating_args["top_p"]) or 1.0,  # top_p must > 0
+            top_p=top_p if top_p is not None else self.generating_args["top_p"],
             top_k=(top_k if top_k is not None else self.generating_args["top_k"]) or -1,  # top_k must > 0
             stop=stop,
             stop_token_ids=self.template.get_stop_token_ids(self.tokenizer),

--- a/src/llamafactory/hparams/generating_args.py
+++ b/src/llamafactory/hparams/generating_args.py
@@ -67,6 +67,10 @@ class GeneratingArguments:
         metadata={"help": "Whether or not to remove special tokens in the decoding."},
     )
 
+    def __post_init__(self):
+        if not 0.0 < self.top_p <= 1.0:
+            raise ValueError(f"`top_p` should be in (0.0, 1.0], got {self.top_p}.")
+
     def to_dict(self, obey_generation_config: bool = False) -> dict[str, Any]:
         args = asdict(self)
         if args.get("max_new_tokens", -1) > 0:

--- a/tests/test_generating_args.py
+++ b/tests/test_generating_args.py
@@ -1,0 +1,41 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from llamafactory.hparams.generating_args import GeneratingArguments
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+@pytest.mark.parametrize("top_p", [0.0, -0.1, 1.5])
+def test_top_p_out_of_range_is_rejected(top_p: float):
+    with pytest.raises(ValueError, match="top_p"):
+        GeneratingArguments(top_p=top_p)
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+@pytest.mark.parametrize("top_p", [1e-6, 0.1, 0.7, 1.0])
+def test_top_p_in_range_is_preserved(top_p: float):
+    assert GeneratingArguments(top_p=top_p).top_p == top_p
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_zero_temperature_is_preserved():
+    r"""`temperature=0.0` requests greedy decoding and must not be rewritten."""
+    assert GeneratingArguments(temperature=0.0).temperature == 0.0
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_to_dict_preserves_valid_top_p():
+    assert GeneratingArguments(top_p=0.1).to_dict()["top_p"] == 0.1


### PR DESCRIPTION
## What this fixes

Fixes #10709.

`GeneratingArguments.top_p` is a plain `float` with no validator, so `top_p: 0.0`
is accepted from YAML/CLI. Three separate call sites then coerce it with `or 1.0`:

- `src/llamafactory/chat/vllm_engine.py`
- `src/llamafactory/chat/sglang_engine.py`
- `scripts/vllm_infer.py`

Because `0.0` is falsy, a request for the *narrowest possible* nucleus silently
becomes `top_p=1.0` — i.e. no nucleus filtering at all, the exact opposite of
what was asked for. Nothing warns, so the run looks fine and only the outputs
are wrong.

The issue reports the vLLM path. While tracing it I found the same guard in
`sglang_engine.py`, which the report doesn't mention, so this PR fixes all three.

## Approach

Reject invalid values at the boundary instead of rewriting them, matching the
existing `__post_init__` + `raise ValueError` pattern used elsewhere in
`src/llamafactory/hparams/`:

```python
def __post_init__(self):
    if not 0.0 < self.top_p <= 1.0:
        raise ValueError(f"`top_p` should be in (0.0, 1.0], got {self.top_p}.")
```

`(0.0, 1.0]` is the range vLLM, SGLang and `transformers` all accept. With the
value validated up front, the three `or 1.0` guards become dead and are removed.

Two things deliberately left alone:

- **`top_k`'s `or -1` guards.** Mapping `0` to `-1` is vLLM's documented
  "disabled" sentinel, not a bug.
- **`temperature=0.0`.** That legitimately means greedy decoding, so it must
  keep passing through untouched. There's a test pinning this.

## Scope note

`GenerationRequest.top_p` in `src/llamafactory/api/protocol.py` is
`float | None = None` with no bounds, so a per-request API override can still
pass `0.0` and bypass this validation. I left it out to keep this PR focused on
the reported path — happy to follow up if you'd like it covered here instead.

## Tests

New `tests/test_generating_args.py`, 9 tests, CPU-only
(`@pytest.mark.runs_on(["cpu", "mps"])`):

- `top_p` in `{0.0, -0.1, 1.5}` raises `ValueError`
- `top_p` in `{1e-6, 0.1, 0.7, 1.0}` is preserved exactly
- `temperature=0.0` is preserved (guards the greedy-decoding case)
- `to_dict()` round-trips a valid `top_p`

Verified the tests aren't vacuous: reverting the validator turns 3 of the 9 red.

```
$ pytest tests/test_generating_args.py -q
9 passed
```

`ruff check` / `ruff format --check` clean on all touched files; license header
added to the new file.
