### PR TITLE
[data] add minicpm5 template with XML tool calling

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Read technical notes:
 | [LLaVA-NeXT](https://huggingface.co/llava-hf)                     | 7B/8B/13B/34B/72B/110B           | llava_next           |
 | [LLaVA-NeXT-Video](https://huggingface.co/llava-hf)               | 7B/34B                           | llava_next_video     |
 | [MiMo](https://huggingface.co/XiaomiMiMo)                         | 7B/309B                          | mimo/mimo_v2         |
-| [MiniCPM 4/5](https://huggingface.co/openbmb)                     | 0.5B/1B/8B                       | cpm4/empty           |
+| [MiniCPM 4/5](https://huggingface.co/openbmb)                     | 0.5B/1B/8B                       | cpm4/minicpm5        |
 | [MiniCPM-o/MiniCPM-V 4.5](https://huggingface.co/openbmb)         | 8B/9B                            | minicpm_o/minicpm_v  |
 | [MiniCPM-V 4.6](https://huggingface.co/openbmb)                   | 3B/8B                            | minicpm_v_4_6        |
 | [MiniMax-M1/MiniMax-M2](https://huggingface.co/MiniMaxAI/models)  | 229B/456B                        | minimax1/minimax2    |

--- a/README_zh.md
+++ b/README_zh.md
@@ -316,7 +316,7 @@ https://github.com/user-attachments/assets/43b700c6-a178-41db-b1f8-8190a5d3fcfc
 | [LLaVA-NeXT](https://huggingface.co/llava-hf)                     | 7B/8B/13B/34B/72B/110B           | llava_next           |
 | [LLaVA-NeXT-Video](https://huggingface.co/llava-hf)               | 7B/34B                           | llava_next_video     |
 | [MiMo](https://huggingface.co/XiaomiMiMo)                         | 7B/309B                          | mimo/mimo_v2         |
-| [MiniCPM 4/5](https://huggingface.co/openbmb)                     | 0.5B/1B/8B                       | cpm4/empty           |
+| [MiniCPM 4/5](https://huggingface.co/openbmb)                     | 0.5B/1B/8B                       | cpm4/minicpm5        |
 | [MiniCPM-o/MiniCPM-V 4.5](https://huggingface.co/openbmb)         | 8B/9B                            | minicpm_o/minicpm_v  |
 | [MiniCPM-V 4.6](https://huggingface.co/openbmb)                   | 3B/8B                            | minicpm_v_4_6        |
 | [MiniMax-M1/MiniMax-M2](https://huggingface.co/MiniMaxAI/models)  | 229B/456B                        | minimax1/minimax2    |

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -150,6 +150,12 @@ class Template:
                 elements += self.format_prefix.apply()
                 if system or tools:
                     tool_text = self.format_tools.apply(content=tools)[0] if tools else ""
+                    if tools and not system:
+                        # Tool prompts that separate themselves from the system message with a
+                        # leading newline would otherwise emit a blank line when there is no
+                        # system message to separate from.
+                        tool_text = tool_text.lstrip("\n")
+
                     elements += self.format_system.apply(content=(system + tool_text))
 
             if message["role"] == Role.USER:
@@ -1820,6 +1826,23 @@ register_template(
     stop_words=["<|im_end|>"],
     default_system="You are a helpful assistant. You can accept audio and text input and output voice and text.",
     mm_plugin=get_mm_plugin(name="minicpm_v", image_token="<image>", video_token="<video>", audio_token="<audio>"),
+)
+
+
+register_template(
+    name="minicpm5",
+    format_user=StringFormatter(slots=["<|im_start|>user\n{{content}}<|im_end|>\n<|im_start|>assistant\n"]),
+    format_assistant=StringFormatter(slots=["{{content}}<|im_end|>\n"]),
+    format_system=StringFormatter(slots=["<|im_start|>system\n{{content}}<|im_end|>\n"]),
+    format_function=FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="minicpm5"),
+    format_observation=StringFormatter(
+        slots=["<|im_start|>user\n<tool_response>\n{{content}}\n</tool_response><|im_end|>\n<|im_start|>assistant\n"]
+    ),
+    format_tools=ToolFormatter(tool_format="minicpm5"),
+    format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
+    stop_words=["<|im_end|>"],
+    replace_eos=True,
+    template_class=ReasoningTemplate,
 )
 
 

--- a/src/llamafactory/data/tool_utils.py
+++ b/src/llamafactory/data/tool_utils.py
@@ -119,6 +119,17 @@ LING_TOOL_PROMPT = (
 
 LFM2_TOOL_PROMPT = "List of tools: <|tool_list_start|>{tool_text}<|tool_list_end|>"
 
+MINICPM5_TOOL_PROMPT = (
+    "\n\n# Tools\n\nYou are provided with function signatures within <tools></tools> XML tags:\n"
+    "<tools>{tool_text}\n</tools>\n\nTool usage guidelines:\n"
+    "- You may call zero or more functions. If no function calls are needed, just answer normally "
+    "and do not include any <function ... </function>.\n"
+    "- When calling a function, return an XML object within <function ... </function> using:\n"
+    '<function name="function-name"><param name="param-name">param-value</param></function>\n'
+    "- param-value may be multi-line. If it contains <, & or newline characters, wrap it in a "
+    'CDATA block: <param name="param-name"><![CDATA[...multi-line value...]]></param>'
+)
+
 
 @dataclass
 class ToolUtils(ABC):
@@ -551,6 +562,72 @@ class MiniMaxM2ToolUtils(ToolUtils):
         return results
 
 
+class MiniCPM5ToolUtils(ToolUtils):
+    r"""MiniCPM-5 tool using template."""
+
+    @override
+    @staticmethod
+    def tool_formatter(tools: list[dict[str, Any]]) -> str:
+        tool_text = ""
+        for tool in tools:
+            if tool.get("type") != "function":
+                tool = {"type": "function", "function": tool}
+
+            tool_text += "\n" + json.dumps(tool, ensure_ascii=False)
+
+        return MINICPM5_TOOL_PROMPT.format(tool_text=tool_text)
+
+    @override
+    @staticmethod
+    def function_formatter(functions: list["FunctionCall"]) -> str:
+        function_texts = []
+        for name, arguments in functions:
+            prompt = f'<function name="{name}">'
+            for key, value in json.loads(arguments).items():
+                prompt += f'<param name="{key}">'
+                if isinstance(value, str):
+                    if "<" in value or "&" in value or "\n" in value:
+                        prompt += f"<![CDATA[{value}]]>"
+                    else:
+                        prompt += value
+                else:
+                    prompt += str(value)
+
+                prompt += "</param>"
+
+            prompt += "</function>"
+            function_texts.append(prompt)
+
+        return "\n".join(function_texts)
+
+    @override
+    @staticmethod
+    def tool_extractor(content: str) -> Union[str, list["FunctionCall"]]:
+        results = []
+        regex = re.compile(r'<function name="(.*?)">((?:<!\[CDATA\[.*?\]\]>|.)*?)</function>', re.DOTALL)
+        for func_name, params_block in re.findall(regex, content):
+            args_dict = {}
+            param_pattern = re.compile(r'<param name="(.*?)">(<!\[CDATA\[.*?\]\]>|.*?)</param>', re.DOTALL)
+            for key, raw_value in re.findall(param_pattern, params_block):
+                cdata = re.fullmatch(r"<!\[CDATA\[(.*?)\]\]>", raw_value, re.DOTALL)
+                if cdata:
+                    args_dict[key] = cdata.group(1)
+                    continue
+
+                value = raw_value.strip()
+                try:
+                    args_dict[key] = json.loads(value)
+                except json.JSONDecodeError:
+                    try:
+                        args_dict[key] = ast.literal_eval(value)
+                    except Exception:
+                        args_dict[key] = raw_value
+
+            results.append(FunctionCall(func_name, json.dumps(args_dict, ensure_ascii=False)))
+
+        return results if results else content
+
+
 class MistralToolUtils(ToolUtils):
     r"""Mistral v0.3 tool using template."""
 
@@ -887,6 +964,7 @@ TOOLS = {
     "glm4": GLM4ToolUtils(),
     "llama3": Llama3ToolUtils(),
     "lfm2": LFM2ToolUtils(),
+    "minicpm5": MiniCPM5ToolUtils(),
     "minimax1": MiniMaxM1ToolUtils(),
     "minimax2": MiniMaxM2ToolUtils(),
     "mistral": MistralToolUtils(),

--- a/src/llamafactory/extras/constants.py
+++ b/src/llamafactory/extras/constants.py
@@ -1961,7 +1961,7 @@ register_model_group(
             DownloadSource.MODELSCOPE: "OpenBMB/MiniCPM5-1B",
         },
     },
-    template="empty",
+    template="minicpm5",
 )
 
 

--- a/tests/data/test_formatter.py
+++ b/tests/data/test_formatter.py
@@ -380,3 +380,79 @@ def test_lfm2_tool_round_trip():
     assert len(extracted) == 1
     assert extracted[0][0] == original["name"]
     assert json.loads(extracted[0][1]) == original["arguments"]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_minicpm5_function_formatter():
+    formatter = FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="minicpm5")
+    tool_calls = json.dumps(FUNCTION)
+    assert formatter.apply(content=tool_calls) == [
+        '<function name="tool_name"><param name="foo">bar</param><param name="size">10</param></function><|im_end|>\n'
+    ]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_minicpm5_multi_function_formatter():
+    formatter = FunctionFormatter(slots=["{{content}}<|im_end|>\n"], tool_format="minicpm5")
+    tool_calls = json.dumps([FUNCTION] * 2)
+    assert formatter.apply(content=tool_calls) == [
+        '<function name="tool_name"><param name="foo">bar</param>'
+        '<param name="size">10</param></function>\n'
+        '<function name="tool_name"><param name="foo">bar</param>'
+        '<param name="size">10</param></function><|im_end|>\n'
+    ]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_minicpm5_tool_formatter():
+    formatter = ToolFormatter(tool_format="minicpm5")
+    wrapped = json.dumps({"type": "function", "function": TOOLS[0]}, ensure_ascii=False)
+    assert formatter.apply(content=json.dumps(TOOLS)) == [
+        "\n\n# Tools\n\nYou are provided with function signatures within <tools></tools> XML tags:\n"
+        f"<tools>\n{wrapped}\n</tools>\n\nTool usage guidelines:\n"
+        "- You may call zero or more functions. If no function calls are needed, just answer "
+        "normally and do not include any <function ... </function>.\n"
+        "- When calling a function, return an XML object within <function ... </function> using:\n"
+        '<function name="function-name"><param name="param-name">param-value</param></function>\n'
+        "- param-value may be multi-line. If it contains <, & or newline characters, wrap it in a "
+        'CDATA block: <param name="param-name"><![CDATA[...multi-line value...]]></param>'
+    ]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_minicpm5_tool_extractor():
+    formatter = ToolFormatter(tool_format="minicpm5")
+    result = '<function name="test_tool"><param name="foo">bar</param><param name="size">10</param></function>'
+    assert formatter.extract(result) == [("test_tool", """{"foo": "bar", "size": 10}""")]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_minicpm5_tool_extractor_cdata():
+    formatter = ToolFormatter(tool_format="minicpm5")
+    result = '<function name="test_tool"><param name="foo"><![CDATA[a < b\nsecond line]]></param></function>'
+    assert formatter.extract(result) == [("test_tool", json.dumps({"foo": "a < b\nsecond line"}))]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_minicpm5_tool_extractor_malformed_value():
+    formatter = ToolFormatter(tool_format="minicpm5")
+    result = '<function name="test_tool"><param name="foo">{[1, 2], [3, 4]}</param></function>'
+    assert formatter.extract(result) == [("test_tool", json.dumps({"foo": "{[1, 2], [3, 4]}"}))]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"foo": "x </param> y"},
+        {"foo": "see </function> here"},
+        {"foo": "  padded  "},
+        {"foo": "a < b", "bar": "tom & jerry"},
+        {"foo": True, "bar": [1, 2], "baz": {"k": "v"}},
+    ],
+)
+def test_minicpm5_tool_round_trip(arguments):
+    formatter = ToolFormatter(tool_format="minicpm5")
+    function_formatter = FunctionFormatter(slots=["{{content}}"], tool_format="minicpm5")
+    rendered = function_formatter.apply(content=json.dumps({"name": "test_tool", "arguments": arguments}))[0]
+    assert formatter.extract(rendered) == [("test_tool", json.dumps(arguments, ensure_ascii=False))]


### PR DESCRIPTION
# What does this PR do?

Adds a `minicpm5` chat template and the matching XML tool-calling format, and points the MiniCPM5 model group at it.

MiniCPM5 is currently registered with `template="empty"`. That is not a delegation to the tokenizer's own `chat_template.jinja` — `empty` is a real, empty template: bare `{{content}}` slots, no role markers, no EOS replacement, and tools falling back to ReAct `Action:` / `Action Input:`. Training under it silently produces a token layout the model has never seen.

## Changes

- `data/tool_utils.py` — `MINICPM5_TOOL_PROMPT` + `MiniCPM5ToolUtils`, registered as `"minicpm5"` in `TOOLS`
- `data/template.py` — register the `minicpm5` template (`ReasoningTemplate`, `replace_eos=True`, `stop_words=["<|im_end|>"]`), plus a two-line fix in `Template._encode` (see below)
- `extras/constants.py` — `template="empty"` → `"minicpm5"`
- `README.md` / `README_zh.md` — template column for MiniCPM 4/5
- `tests/data/test_formatter.py` — 11 new tests, no network required

## Correctness

Verified against `openbmb/MiniCPM5-1B`'s own `chat_template.jinja` on 300 real tool-calling samples: the rendered prompt is byte-identical to `apply_chat_template(history, add_generation_prompt=True, enable_thinking=False)` in all 300, with and without a system message.

Tests are formatter-level rather than `_check_template`-style. MiniCPM5's jinja does not emit the empty `<think></think>` block for a non-CoT assistant turn — unlike Qwen3's, which is why `test_qwen3_template` can use `_check_template` — so a plain `apply_chat_template(messages)` round trip does not apply here.

## Why `template: empty` is not a working alternative

Controlled A/B on `openbmb/MiniCPM5-1B`: identical data (3000 tool-calling samples), hyper-parameters and seed, `template` the only variable, `empty` run against an unmodified upstream checkout. Full fine-tuning, 200-sample held-out set:

| template               | parseable | function name | arguments exact |
| ---------------------- | --------- | ------------- | --------------- |
| *(untrained baseline)* | 99.0%     | 98.5%         | 79.5%           |
| `empty`                | **33.0%** | **33.0%**     | **17.5%**       |
| `minicpm5`             | **100%**  | **100%**      | **83.0%**       |

McNemar (paired, n=200): baseline → `empty` is 2 better / 126 worse (z=10.87, p<0.01); `empty` → `minicpm5` is 132 / 1 (z=11.27, p<0.01); baseline → `minicpm5` is not significant.

Trained under `empty`, the model learns the ReAct serialization and at inference emits only the `Action Input:` half, dropping the function name entirely — hence 98.5% → 33.0%.

Two reasons this has gone unnoticed: **LoRA masks it** (r=16 gives 98.5% function name, statistically indistinguishable from the untrained baseline; 81% of outputs are byte-identical to it), and **eval loss gives no warning** (0.0519 vs 0.0469 — an 11% gap alongside a 4.7x capability gap).

## Note on `_encode`

`MINICPM5_TOOL_PROMPT` starts with `\n\n` to separate itself from a user-supplied system message, matching the model's jinja. `Template._encode` therefore needs to strip it when there is no system message:

```python
if tools and not system:
    tool_text = tool_text.lstrip("\n")
```

`MossVLTemplate._encode` already carries these exact two lines — the same issue was previously worked around by duplicating the whole method into a subclass.

Hoisting it to the base class touches the 14 templates whose tool prompt starts with a newline *and* which have no `default_system` (`qwen3*`, `glm4_moe`, `glm4_7`, `glm4_5v`, `keye_vl`, `moss_vl`), and for them it is a fix rather than a behaviour change: `qwen3` with tools and no system message rendered `<|im_start|>system\n\n\n# Tools` where its own jinja emits `<|im_start|>system\n# Tools`. Both now agree, and the full `tests/data/` suite passes unchanged (128 passed, 6 skipped, 3 xpassed).

## Before submitting

- [x] Did you read the [[contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?