### PR TITLE
[api] fix: map repetition_penalty from its own request field, not presence_penalty

### DIFF
--- a/src/llamafactory/api/chat.py
+++ b/src/llamafactory/api/chat.py
@@ -207,7 +207,7 @@ async def create_chat_completion_response(
         top_p=request.top_p,
         max_new_tokens=request.max_tokens,
         num_return_sequences=request.n,
-        repetition_penalty=request.presence_penalty,
+        repetition_penalty=request.repetition_penalty,
         stop=request.stop,
     )
 
@@ -269,7 +269,7 @@ async def create_stream_chat_completion_response(
         temperature=request.temperature,
         top_p=request.top_p,
         max_new_tokens=request.max_tokens,
-        repetition_penalty=request.presence_penalty,
+        repetition_penalty=request.repetition_penalty,
         stop=request.stop,
     ):
         if len(new_token) != 0:

--- a/src/llamafactory/api/protocol.py
+++ b/src/llamafactory/api/protocol.py
@@ -103,6 +103,7 @@ class ChatCompletionRequest(BaseModel):
     top_p: float | None = None
     n: int = 1
     presence_penalty: float | None = None
+    repetition_penalty: float | None = None
     max_tokens: int | None = None
     stop: str | list[str] | None = None
     stream: bool = False

--- a/tests/api/test_chat_penalty_mapping.py
+++ b/tests/api/test_chat_penalty_mapping.py
@@ -1,0 +1,70 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression test for issue #9213.
+
+The OpenAI-compatible API used to map ``repetition_penalty=request.presence_penalty``.
+``presence_penalty`` (OpenAI default 0.0) and ``repetition_penalty`` (default 1.0) are
+different controls, and no chat engine consumes ``presence_penalty`` at all, so the
+misrouting silently changed decoding and made ``repetition_penalty`` unreachable from
+the API (and could feed 0.0 into an engine that requires > 0). This test pins that the
+request's ``repetition_penalty`` field is what flows to the engine.
+"""
+
+import asyncio
+
+from llamafactory.api.chat import create_chat_completion_response
+from llamafactory.api.protocol import ChatCompletionRequest, ChatMessage, Role
+from llamafactory.chat.base_engine import Response
+
+
+class _RecordingChatModel:
+    """Minimal ChatModel stand-in that records the kwargs achat receives."""
+
+    def __init__(self):
+        self.captured_kwargs = None
+
+    async def achat(self, messages, system=None, tools=None, images=None, videos=None, audios=None, **input_kwargs):
+        self.captured_kwargs = input_kwargs
+        return [Response(response_text="hi", response_length=1, prompt_length=1, finish_reason="stop")]
+
+
+def _request(**overrides):
+    base = {"model": "test", "messages": [ChatMessage(role=Role.USER, content="hello")]}
+    base.update(overrides)
+    return ChatCompletionRequest(**base)
+
+
+def _run(request, model):
+    return asyncio.run(create_chat_completion_response(request, model))
+
+
+def test_repetition_penalty_field_flows_to_engine():
+    model = _RecordingChatModel()
+    _run(_request(repetition_penalty=1.3, presence_penalty=0.5), model)
+    # repetition_penalty must come from the repetition_penalty field, not presence_penalty.
+    assert model.captured_kwargs["repetition_penalty"] == 1.3
+
+
+def test_presence_penalty_no_longer_leaks_into_repetition_penalty():
+    model = _RecordingChatModel()
+    # Only presence_penalty is set; it must NOT become repetition_penalty.
+    _run(_request(presence_penalty=0.5), model)
+    assert model.captured_kwargs["repetition_penalty"] is None
+
+
+def test_repetition_penalty_defaults_to_none():
+    model = _RecordingChatModel()
+    _run(_request(), model)
+    # None lets each engine fall back to its configured default (1.0).
+    assert model.captured_kwargs["repetition_penalty"] is None


### PR DESCRIPTION
# What does this PR do?

Fixes #9213. The OpenAI-compatible API mapped `repetition_penalty=request.presence_penalty` in both `create_chat_completion_response` and `create_stream_chat_completion_response` (`src/llamafactory/api/chat.py`).

`presence_penalty` (OpenAI default `0.0`) and `repetition_penalty` (default `1.0`) are different controls with different valid ranges, and **no** chat engine consumes `presence_penalty` (the `hf`, `vllm`, and `sglang` engines all read `repetition_penalty` from `input_kwargs`). So the old mapping:

- silently turned `presence_penalty` into a repetition penalty (the confusing behavior reported),
- made `repetition_penalty` unreachable through the API, and
- could feed `0.0` into `repetition_penalty`, which `hf_engine` passes straight to `generate()` where it must be `> 0`.

This PR adds a dedicated `repetition_penalty` field to `ChatCompletionRequest` — the same extension vLLM's own OpenAI-compatible server exposes — and maps it directly. `presence_penalty` stays in the schema (OpenAI-standard, still accepted) and is simply no longer misrouted. `None` lets each engine fall back to its configured default (`1.0`).

I verified the mismapping is still on `main` (both call sites) before fixing.

## Behavior note

Clients that previously (ab)used `presence_penalty` to control repetition will need to send `repetition_penalty` instead — which is exactly the separation the issue asks for, and matches OpenAI/vLLM semantics.

## Test

New `tests/api/test_chat_penalty_mapping.py` drives the real `create_chat_completion_response` with a recording chat-model stub:

- `repetition_penalty` flows from the `repetition_penalty` field,
- `presence_penalty` no longer leaks into `repetition_penalty`,
- an unset `repetition_penalty` passes `None` so the engine default applies.

The discriminating tests **fail on the pre-fix code** and **pass after**. `ruff check` / `ruff format --check` (pinned 0.15.5) and `tests/check_license.py` pass on the changed files.

## Before submitting

- [x] Did you read the contributor guideline?
- [x] Did you write any new necessary tests? (`tests/api/test_chat_penalty_mapping.py`)
