### PR TITLE
[model] fix: use the transformers 5 name for the gpt-oss attention kernel

### DIFF
--- a/src/llamafactory/model/model_utils/attention.py
+++ b/src/llamafactory/model/model_utils/attention.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 
 from ...extras import logging
 from ...extras.constants import AttentionFunction
-from ...extras.packages import is_torch_version_greater_than
+from ...extras.packages import is_torch_version_greater_than, is_transformers_version_greater_than
 
 
 if TYPE_CHECKING:
@@ -32,10 +32,16 @@ def configure_attn_implementation(config: "PretrainedConfig", model_args: "Model
     from transformers.utils import is_flash_attn_2_available
 
     if getattr(config, "model_type", None) == "gpt_oss":
-        from transformers.integrations.hub_kernels import load_and_register_kernel
+        # transformers 5.0 renamed this to load_and_register_attn_kernel. Both take the
+        # attn_implementation as their first positional argument; the 5.x signature only adds
+        # two arguments that default to the old behaviour.
+        if is_transformers_version_greater_than("5.0.0"):
+            from transformers.integrations.hub_kernels import load_and_register_attn_kernel as register_attn_kernel
+        else:
+            from transformers.integrations.hub_kernels import load_and_register_kernel as register_attn_kernel
 
         flash_attn3_kernel = "kernels-community/vllm-flash-attn3"
-        load_and_register_kernel(flash_attn3_kernel)
+        register_attn_kernel(flash_attn3_kernel)
         setattr(config, "_attn_implementation", flash_attn3_kernel)
         setattr(config, "_attn_implementation_internal", flash_attn3_kernel)
         model_args.flash_attn = AttentionFunction.FA3

--- a/tests/model/model_utils/test_attention.py
+++ b/tests/model/model_utils/test_attention.py
@@ -27,7 +27,12 @@ except ImportError:
         return True
 
 
+from transformers import PretrainedConfig
+
+from llamafactory.extras.constants import AttentionFunction
 from llamafactory.extras.packages import is_transformers_version_greater_than
+from llamafactory.hparams import ModelArguments
+from llamafactory.model.model_utils.attention import configure_attn_implementation
 from llamafactory.train.test_utils import load_infer_model
 
 
@@ -58,3 +63,29 @@ def test_attention():
         for module in model.modules():
             if "Attention" in module.__class__.__name__:
                 assert module.__class__.__name__ == llama_attention_classes[requested_attention]
+
+
+def test_gpt_oss_registers_the_flash_attention_3_kernel(monkeypatch: pytest.MonkeyPatch):
+    """The gpt-oss branch imports the kernel registrar by name, with no fallback.
+
+    transformers 5.0 renamed `load_and_register_kernel` to `load_and_register_attn_kernel`, so
+    reaching for the wrong one ends every gpt-oss run at load time with an ImportError.
+    """
+    from transformers.integrations import hub_kernels
+
+    registrar = (
+        "load_and_register_attn_kernel"
+        if is_transformers_version_greater_than("5.0.0")
+        else "load_and_register_kernel"
+    )
+    registered = []
+    monkeypatch.setattr(hub_kernels, registrar, registered.append)
+
+    config = PretrainedConfig(model_type="gpt_oss")
+    model_args = ModelArguments(model_name_or_path=TINY_LLAMA3)
+
+    configure_attn_implementation(config, model_args)
+
+    assert registered == ["kernels-community/vllm-flash-attn3"]
+    assert config._attn_implementation == "kernels-community/vllm-flash-attn3"
+    assert model_args.flash_attn == AttentionFunction.FA3


### PR DESCRIPTION
# What does this PR do?

Loading any gpt-oss model fails on transformers 5.x, which is most of the range `pyproject.toml`
declares (`transformers>=4.55.0,<=5.8.0`).

`configure_attn_implementation` imports the kernel registrar by name, with no fallback:

```python
if getattr(config, "model_type", None) == "gpt_oss":
    from transformers.integrations.hub_kernels import load_and_register_kernel
```

transformers 5.0 renamed that function to `load_and_register_attn_kernel`. On the pin ceiling:

```
$ python -c "from transformers import PretrainedConfig; ..."
transformers 5.8.0
ImportError: cannot import name 'load_and_register_kernel' from
             'transformers.integrations.hub_kernels'
```

It is raised before anything is attempted, so there is no degraded path — the run just ends.

Where the name lives, across the declared range:

| transformers | `load_and_register_kernel` | `load_and_register_attn_kernel` |
| --- | --- | --- |
| 4.55.0 | — | — |
| 4.56.0, 4.57.x | yes | — |
| 5.0.0 … 5.16.1 | — | yes |

So the current code works only on 4.56/4.57 and is broken on every 5.x release in the pin.

## The change

Pick the name by version, the way `npu_fused_moe.py` already splits v4 from v5:

```python
if is_transformers_version_greater_than("5.0.0"):
    from transformers.integrations.hub_kernels import load_and_register_attn_kernel as register_attn_kernel
else:
    from transformers.integrations.hub_kernels import load_and_register_kernel as register_attn_kernel
```

Both take `attn_implementation` as their first positional argument. The 5.x signature only adds
`attention_wrapper=None` and `allow_all_kernels=False`, whose defaults are the old behaviour —
and `kernels-community/...` is inside the trusted set, so `allow_all_kernels` stays off.

Nothing else in the repo calls it; this is the only site.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

`test_gpt_oss_registers_the_flash_attention_3_kernel` stubs the registrar and asserts it is
reached with the right kernel id, so it covers the name resolution without downloading a kernel.
It picks the expected name from the installed version, so it holds on both sides of the rename.

Load-bearing — the same test file run against a clean `origin/main` worktree, same environment:

```
$ pytest tests/model/model_utils/test_attention.py::test_gpt_oss_registers_the_flash_attention_3_kernel
    from transformers.integrations.hub_kernels import load_and_register_kernel
E   ImportError: cannot import name 'load_and_register_kernel' from ...
1 failed

$ pytest tests/model/model_utils/test_attention.py          # this branch
1 passed, 1 xfailed

$ make quality        # ruff 0.15.5, as pinned in the Makefile
All checks passed!
```
