### PR TITLE
[data] add semantic-aware packing strategy for SFT

### DIFF
--- a/requirements/sentence-transformers.txt
+++ b/requirements/sentence-transformers.txt
@@ -1,0 +1,1 @@
+sentence-transformers>=3.0.0

--- a/src/llamafactory/data/processor/processor_utils.py
+++ b/src/llamafactory/data/processor/processor_utils.py
@@ -14,11 +14,20 @@
 
 import bisect
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from dataclasses import dataclass
+from functools import cache
 from typing import TYPE_CHECKING, Any, Optional
+
+from scipy.cluster.hierarchy import fcluster, linkage
+from scipy.spatial.distance import pdist
+
+from ...extras.packages import is_sentence_transformers_available
 
 
 if TYPE_CHECKING:
+    import numpy as np
+    from sentence_transformers import SentenceTransformer
     from transformers import PreTrainedTokenizer, ProcessorMixin
 
     from ...hparams import DataArguments
@@ -69,6 +78,93 @@ def greedy_knapsack(numbers: list[int], capacity: int) -> list[list[int]]:
             current_knapsack.append(numbers.pop(index))  # add the number to knapsack
 
         knapsacks.append(current_knapsack)
+
+    return knapsacks
+
+
+def greedy_knapsack_indices(indices: list[int], lengths: list[int], capacity: int) -> list[list[int]]:
+    r"""Run `greedy_knapsack` over `lengths` and translate the packed length groups back to `indices`.
+
+    `greedy_knapsack` returns groups of length *values*, which is ambiguous when two different
+    indices share the same length (the caller cannot tell which one was actually packed where).
+    This wraps it with an index lookup so the result unambiguously identifies which sequences ended
+    up in which knapsack.
+    """
+    length2indexes = defaultdict(list)
+    for index, length in zip(indices, lengths):
+        length2indexes[length].append(index)
+
+    knapsacks = []
+    for knapsack_lengths in greedy_knapsack(list(lengths), capacity):
+        knapsacks.append([length2indexes[length].pop() for length in knapsack_lengths])
+
+    return knapsacks
+
+
+@cache
+def _load_sentence_transformer(embedding_model: str) -> "SentenceTransformer":
+    from sentence_transformers import SentenceTransformer
+
+    return SentenceTransformer(embedding_model)
+
+
+def compute_embeddings(texts: list[str], embedding_model: str) -> "np.ndarray":
+    r"""Encode `texts` into L2-normalized sentence embeddings using a sentence-transformers model."""
+    if not is_sentence_transformers_available():
+        raise ImportError("Please install `sentence-transformers` to use semantic-aware packing.")
+
+    model = _load_sentence_transformer(embedding_model)
+    return model.encode(texts, normalize_embeddings=True, show_progress_bar=False)
+
+
+def cluster_by_similarity(embeddings: "np.ndarray", threshold: float) -> list[list[int]]:
+    r"""Group embedding indices into clusters using average-linkage clustering on cosine distance.
+
+    Two sequences end up in the same cluster when their average pairwise cosine similarity stays at
+    or above `threshold` (equivalently, cosine distance at or below `1 - threshold`).
+
+    e.g.
+    ```python
+    # input
+    embeddings = [[1, 0], [1, 0], [0, 1]], threshold = 0.5
+    # output
+    [[0, 1], [2]]
+    ```
+    """
+    num_samples = len(embeddings)
+    if num_samples <= 1:
+        return [list(range(num_samples))]
+
+    distances = pdist(embeddings, metric="cosine")
+    cluster_ids = fcluster(linkage(distances, method="average"), t=1 - threshold, criterion="distance")
+
+    clusters = defaultdict(list)
+    for index, cluster_id in enumerate(cluster_ids):
+        clusters[cluster_id].append(index)
+
+    return list(clusters.values())
+
+
+def semantic_aware_knapsack(
+    sequences: list[dict[str, Any]], capacity: int, embedding_model: str, similarity_threshold: float = 0.7
+) -> list[list[int]]:
+    r"""Group `sequences` into knapsacks of at most `capacity` tokens, keeping related sequences together.
+
+    Each element of `sequences` must be a dict with a `text` key (used to compute the embedding) and
+    an `input_ids` key (used as the packed length). Sequences are first clustered by cosine
+    similarity of their text embedding (see `cluster_by_similarity`), then the length-based greedy
+    knapsack is applied within each cluster so that every knapsack still respects `capacity` while
+    grouping semantically related sequences first. Returns a list of knapsacks, each a list of
+    indices into `sequences`.
+    """
+    texts = [sequence["text"] for sequence in sequences]
+    embeddings = compute_embeddings(texts, embedding_model)
+    clusters = cluster_by_similarity(embeddings, similarity_threshold)
+
+    knapsacks = []
+    for cluster in clusters:
+        cluster_lengths = [len(sequences[index]["input_ids"]) for index in cluster]
+        knapsacks.extend(greedy_knapsack_indices(cluster, cluster_lengths, capacity))
 
     return knapsacks
 

--- a/src/llamafactory/data/processor/supervised.py
+++ b/src/llamafactory/data/processor/supervised.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from ...extras import logging
 from ...extras.constants import IGNORE_INDEX
-from .processor_utils import DatasetProcessor, greedy_knapsack, infer_seqlen
+from .processor_utils import DatasetProcessor, greedy_knapsack_indices, infer_seqlen, semantic_aware_knapsack
 
 
 if TYPE_CHECKING:
@@ -28,6 +28,11 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 MAX_SU_SEQ_IDX = 2**32  # maximum sub-sequence index
+
+
+def _messages_to_text(messages: list[dict[str, str]]) -> str:
+    r"""Join the string content of chat messages into a single text blob for embedding purposes."""
+    return "\n".join(message["content"] for message in messages if isinstance(message.get("content"), str))
 
 
 @dataclass
@@ -151,7 +156,8 @@ class PackedSupervisedDatasetProcessor(SupervisedDatasetProcessor):
         valid_num = 0
         batch_input_ids, batch_labels, batch_images, batch_videos, batch_audios = [], [], [], [], []
         lengths = []
-        length2indexes = defaultdict(list)
+        batch_texts = []
+        use_semantic_packing = self.data_args.packing_strategy == "semantic_aware"
         for i in range(len(examples["_prompt"])):
             if len(examples["_prompt"][i]) % 2 != 1 or len(examples["_response"][i]) != 1:
                 logger.warning_rank0(
@@ -173,7 +179,9 @@ class PackedSupervisedDatasetProcessor(SupervisedDatasetProcessor):
                 logger.warning_rank0(f"Dropped lengthy example with length {length} > {self.data_args.cutoff_len}.")
             else:
                 lengths.append(length)
-                length2indexes[length].append(valid_num)
+                if use_semantic_packing:
+                    batch_texts.append(_messages_to_text(examples["_prompt"][i] + examples["_response"][i]))
+
                 batch_input_ids.append(input_ids)
                 batch_labels.append(labels)
                 batch_images.append(examples["_images"][i] or [])
@@ -183,7 +191,19 @@ class PackedSupervisedDatasetProcessor(SupervisedDatasetProcessor):
 
         model_inputs = defaultdict(list)
         requires_packing_params = self.data_args.neat_packing
-        knapsacks = greedy_knapsack(lengths, self.data_args.cutoff_len)
+        if use_semantic_packing:
+            sequences = [
+                {"text": text, "input_ids": input_ids} for text, input_ids in zip(batch_texts, batch_input_ids)
+            ]
+            knapsacks = semantic_aware_knapsack(
+                sequences,
+                self.data_args.cutoff_len,
+                self.data_args.packing_embedding_model,
+                self.data_args.packing_similarity_threshold,
+            )
+        else:
+            knapsacks = greedy_knapsack_indices(list(range(valid_num)), lengths, self.data_args.cutoff_len)
+
         for knapsack in knapsacks:
             packed_input_ids, packed_attention_masks, packed_position_ids, packed_labels = [], [], [], []
             packed_images, packed_videos, packed_audios = [], [], []
@@ -193,8 +213,7 @@ class PackedSupervisedDatasetProcessor(SupervisedDatasetProcessor):
                 video_subseq_ids: list[int] = []
                 audio_subseq_ids: list[int] = []
 
-            for i, length in enumerate(knapsack):
-                index = length2indexes[length].pop()
+            for i, index in enumerate(knapsack):
                 packed_input_ids += batch_input_ids[index]
                 packed_position_ids += list(range(len(batch_input_ids[index])))  # NOTE: pad_to_multiple_of ignore this
                 packed_labels += batch_labels[index]

--- a/src/llamafactory/extras/packages.py
+++ b/src/llamafactory/extras/packages.py
@@ -110,6 +110,10 @@ def is_safetensors_available():
     return _is_package_available("safetensors")
 
 
+def is_sentence_transformers_available():
+    return _is_package_available("sentence_transformers")
+
+
 def is_sglang_available():
     return _is_package_available("sglang")
 

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -113,6 +113,26 @@ class DataArguments:
         default=False,
         metadata={"help": "Enable sequence packing without cross-attention."},
     )
+    packing_strategy: Literal["length", "semantic_aware"] = field(
+        default="length",
+        metadata={
+            "help": (
+                "Strategy used to group sequences before packing. `length` (default) packs sequences "
+                "greedily by length only. `semantic_aware` first clusters sequences by embedding "
+                "similarity, then applies the length-based knapsack within each cluster."
+            )
+        },
+    )
+    packing_similarity_threshold: float = field(
+        default=0.7,
+        metadata={"help": "Cosine similarity threshold used to cluster sequences under `semantic_aware` packing."},
+    )
+    packing_embedding_model: str = field(
+        default="sentence-transformers/all-MiniLM-L6-v2",
+        metadata={
+            "help": "Sentence embedding model used to compute sequence similarity under `semantic_aware` packing."
+        },
+    )
     tool_format: str | None = field(
         default=None,
         metadata={"help": "Tool format to use for constructing function calling examples."},
@@ -184,6 +204,12 @@ class DataArguments:
 
         if self.neat_packing:
             self.packing = True
+
+        if self.packing_strategy == "semantic_aware":
+            self.packing = True
+
+        if not (0 < self.packing_similarity_threshold <= 1):
+            raise ValueError("`packing_similarity_threshold` should be in the range (0, 1].")
 
         if self.packing:
             self.cutoff_len -= 1  # avoid pad_to_multiple_of, needs improve

--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -34,7 +34,11 @@ from transformers.utils import is_torch_bf16_gpu_available, is_torch_npu_availab
 from ..extras import logging
 from ..extras.constants import CHECKPOINT_NAMES, EngineName
 from ..extras.misc import check_dependencies, check_version, get_current_device, is_env_enabled
-from ..extras.packages import is_mcore_adapter_available, is_megatron_bridge_available
+from ..extras.packages import (
+    is_mcore_adapter_available,
+    is_megatron_bridge_available,
+    is_sentence_transformers_available,
+)
 from .data_args import DataArguments
 from .evaluation_args import EvaluationArguments
 from .finetuning_args import FinetuningArguments
@@ -422,8 +426,14 @@ def get_train_args(args: dict[str, Any] | list[str] | None = None) -> _TRAIN_CLS
         if data_args.neat_packing:
             raise ValueError("`neat_packing` cannot be set as True except SFT.")
 
+        if data_args.packing_strategy == "semantic_aware":
+            raise ValueError("`packing_strategy=semantic_aware` cannot be set except SFT.")
+
         if data_args.train_on_prompt or data_args.mask_history:
             raise ValueError("`train_on_prompt` or `mask_history` cannot be set as True except SFT.")
+
+    if data_args.packing_strategy == "semantic_aware" and not is_sentence_transformers_available():
+        raise ValueError("Please install `sentence-transformers` to use `packing_strategy=semantic_aware`.")
 
     if finetuning_args.stage == "sft" and training_args.do_predict and not training_args.predict_with_generate:
         raise ValueError("Please enable `predict_with_generate` to save model predictions.")

--- a/tests/data/processor/test_processor_utils.py
+++ b/tests/data/processor/test_processor_utils.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 
+import numpy as np
 import pytest
 
-from llamafactory.data.processor.processor_utils import infer_seqlen
+from llamafactory.data.processor.processor_utils import cluster_by_similarity, greedy_knapsack_indices, infer_seqlen
 
 
 @pytest.mark.runs_on(["cpu", "mps"])
@@ -33,3 +34,39 @@ from llamafactory.data.processor.processor_utils import infer_seqlen
 )
 def test_infer_seqlen(test_input: tuple[int, int, int], test_output: tuple[int, int]):
     assert test_output == infer_seqlen(*test_input)
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_greedy_knapsack_indices_preserves_index_identity():
+    # two different sequences (indices 11 and 13) share the same length on purpose: a naive
+    # length-keyed lookup shared across independent groups could swap them.
+    indices = [10, 11, 12, 13]
+    length_by_index = {10: 50, 11: 50, 12: 30, 13: 80}
+    lengths = [length_by_index[index] for index in indices]
+
+    knapsacks = greedy_knapsack_indices(indices, lengths, capacity=100)
+
+    packed_indices = sorted(index for knapsack in knapsacks for index in knapsack)
+    assert packed_indices == sorted(indices)
+    for knapsack in knapsacks:
+        assert sum(length_by_index[index] for index in knapsack) <= 100
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_cluster_by_similarity_groups_similar_vectors():
+    embeddings = np.array(
+        [
+            [1.0, 0.0],
+            [0.9, 0.1],
+            [0.0, 1.0],
+        ]
+    )
+    clusters = cluster_by_similarity(embeddings, threshold=0.8)
+    cluster_sets = sorted(sorted(cluster) for cluster in clusters)
+    assert cluster_sets == [[0, 1], [2]]
+
+
+@pytest.mark.runs_on(["cpu", "mps"])
+def test_cluster_by_similarity_single_sample():
+    embeddings = np.array([[1.0, 0.0]])
+    assert cluster_by_similarity(embeddings, threshold=0.5) == [[0]]


### PR DESCRIPTION
# What does this PR do?

Fixes #10673

Adds an optional `semantic_aware` packing strategy as an alternative to the existing length-only `greedy_knapsack` packing used for SFT.

Today `packing: true` groups sequences into knapsacks purely by length via `greedy_knapsack`, ignoring their content (unrelated examples can end up packed into the same sequence). This PR adds `packing_strategy: semantic_aware`, which first clusters sequences by embedding similarity (via `sentence-transformers`) and then applies the same length-based knapsack within each cluster, so a packed sequence contains topically related examples instead of arbitrary ones.

New `DataArguments`:
- `packing_strategy: "length" | "semantic_aware"` (default `"length"`, no behavior change)
- `packing_similarity_threshold: float` (default `0.7`)
- `packing_embedding_model: str` (default `sentence-transformers/all-MiniLM-L6-v2`)

`semantic_aware` requires the new optional `sentence-transformers` dependency (`requirements/sentence-transformers.txt`, guarded via `is_sentence_transformers_available()`) and is currently only supported for `stage: sft` (same restriction as `neat_packing`).

## Verification

Trained `Qwen/Qwen2-0.5B-Instruct` (LoRA) on a mixed-domain dataset (`identity + alpaca_en_demo + glaive_toolcall_en_demo`) with both strategies, same seed/steps/hyperparameters, only `packing_strategy` differing — trains cleanly with both, no shape/collator errors.

## Benchmark

Ran 8 independent seeds per strategy (fixed train/eval split, only `packing_strategy` differs) on `Qwen/Qwen2-0.5B-Instruct` + LoRA:

<img width="1050" height="675" alt="loss_comparison" src="https://github.com/user-attachments/assets/9a444e2e-716c-40c7-af0f-0eec0c3a5aaa" />

| | eval_loss (mean ± 95% CI, n=8) |
|---|---|
| `length` | 1.1590 ± 0.0038 |
| `semantic_aware` | 1.0309 ± 0.0021 |

The improvement comes at a cost: `semantic_aware` packs sequences less densely when clusters are small (more padding per pack), so it uses more compute per epoch than `length` for the same raw data.The two config fields (`packing_similarity_threshold`, `packing_embedding_model`) let users trade off coherence against packing efficiency depending on their dataset.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?