### PR TITLE
fix(webui): handle incomplete user config

### DIFF
--- a/src/llamafactory/webui/common.py
+++ b/src/llamafactory/webui/common.py
@@ -73,11 +73,21 @@ def _get_config_path() -> os.PathLike:
 
 def load_config() -> dict[str, str | dict[str, Any]]:
     r"""Load user config if exists."""
+    default_config = {"lang": None, "hub_name": None, "last_model": None, "path_dict": {}, "cache_dir": None}
     try:
         with open(_get_config_path(), encoding="utf-8") as f:
-            return safe_load(f)
+            user_config = safe_load(f)
     except Exception:
-        return {"lang": None, "hub_name": None, "last_model": None, "path_dict": {}, "cache_dir": None}
+        return default_config
+
+    if not isinstance(user_config, dict):
+        return default_config
+
+    default_config.update(user_config)
+    if not isinstance(default_config["path_dict"], dict):
+        default_config["path_dict"] = {}
+
+    return default_config
 
 
 def save_config(

--- a/tests/webui/test_common.py
+++ b/tests/webui/test_common.py
@@ -1,0 +1,45 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from llamafactory.webui import common
+
+
+def test_load_config_with_empty_file(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(common, "DEFAULT_CACHE_DIR", str(tmp_path))
+    (tmp_path / common.USER_CONFIG).write_text("", encoding="utf-8")
+
+    assert common.load_config() == {
+        "lang": None,
+        "hub_name": None,
+        "last_model": None,
+        "path_dict": {},
+        "cache_dir": None,
+    }
+
+
+def test_save_config_with_incomplete_file(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(common, "DEFAULT_CACHE_DIR", str(tmp_path))
+    (tmp_path / common.USER_CONFIG).write_text("lang: zh\n", encoding="utf-8")
+
+    common.save_config("", model_name="custom", model_path="path/to/model")
+
+    assert common.load_config() == {
+        "lang": "zh",
+        "hub_name": None,
+        "last_model": "custom",
+        "path_dict": {"custom": "path/to/model"},
+        "cache_dir": None,
+    }


### PR DESCRIPTION
# What does this PR do?

Fixes a WebUI crash when `user_config.yaml` is empty, does not contain a mapping, or is missing expected fields.

`yaml.safe_load()` returns `None` for an empty YAML file without raising an exception. Previously, callers such as `save_config()` would then fail with a `TypeError`. This change falls back to the default configuration for non-mapping content, fills in missing default fields, and normalizes an invalid `path_dict`.

## Tests

- Added regression coverage for loading an empty config file.
- Added regression coverage for saving over an incomplete config file.
- `WANDB_DISABLED=true pytest -q --import-mode=importlib tests/webui/test_common.py`
- Ruff lint and format checks for the changed files.
- License check.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?