### PR TITLE
[train] fix duplicated tied weights in distributed saves

### DIFF
--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -30,7 +30,7 @@ from ...extras import logging
 from ...extras.constants import IGNORE_INDEX
 from ..callbacks import SaveProcessorCallback
 from ..fp8_utils import configure_fp8_environment, patch_accelerator_for_fp8, verify_fp8_status
-from ..trainer_utils import create_custom_optimizer, create_custom_scheduler
+from ..trainer_utils import create_custom_optimizer, create_custom_scheduler, restore_tied_weights_state_dict
 
 
 if TYPE_CHECKING:
@@ -146,6 +146,13 @@ class CustomSeq2SeqTrainer(Seq2SeqTrainer):
             return torch.utils.data.SequentialSampler(self.train_dataset)
 
         return super()._get_train_sampler(*args, **kwargs)
+
+    @override
+    def _save(self, output_dir: Optional[str] = None, state_dict: Optional[dict[str, "torch.Tensor"]] = None) -> None:
+        if state_dict is not None:
+            restore_tied_weights_state_dict(self.model, state_dict)
+
+        super()._save(output_dir, state_dict)
 
     @override
     def compute_loss(self, model, inputs, *args, **kwargs):

--- a/src/llamafactory/train/trainer_utils.py
+++ b/src/llamafactory/train/trainer_utils.py
@@ -65,6 +65,31 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
+def restore_tied_weights_state_dict(model: "torch.nn.Module", state_dict: dict[str, "torch.Tensor"]) -> None:
+    r"""Restore storage aliases that may be lost while gathering a distributed state dict."""
+    parameter_aliases: dict[int, list[str]] = {}
+    for name, parameter in model.named_parameters(remove_duplicate=False):
+        parameter_aliases.setdefault(id(parameter), []).append(name)
+
+    for names in parameter_aliases.values():
+        present_names = [name for name in names if name in state_dict]
+        if len(present_names) < 2:
+            continue
+
+        reference = state_dict[present_names[0]]
+        if not isinstance(reference, torch.Tensor):
+            continue
+
+        for name in present_names[1:]:
+            tensor = state_dict[name]
+            if (
+                isinstance(tensor, torch.Tensor)
+                and tensor.shape == reference.shape
+                and tensor.dtype == reference.dtype
+            ):
+                state_dict[name] = reference
+
+
 class DummyOptimizer(torch.optim.Optimizer):
     r"""A dummy optimizer used for the GaLore or APOLLO algorithm."""
 

--- a/tests/train/test_trainer_utils.py
+++ b/tests/train/test_trainer_utils.py
@@ -1,0 +1,57 @@
+# Copyright 2026 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from safetensors import safe_open
+from transformers import Qwen3Config, Qwen3ForCausalLM
+
+from llamafactory.train.trainer_utils import restore_tied_weights_state_dict
+
+
+def get_tiny_qwen3_model(tie_word_embeddings: bool):
+    return Qwen3ForCausalLM(
+        Qwen3Config(
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            tie_word_embeddings=tie_word_embeddings,
+        )
+    )
+
+
+def test_restore_tied_weights_state_dict(tmp_path):
+    model = get_tiny_qwen3_model(tie_word_embeddings=True)
+    state_dict = {name: tensor.clone() for name, tensor in model.state_dict().items()}
+    assert state_dict["model.embed_tokens.weight"].data_ptr() != state_dict["lm_head.weight"].data_ptr()
+
+    restore_tied_weights_state_dict(model, state_dict)
+
+    assert state_dict["model.embed_tokens.weight"].data_ptr() == state_dict["lm_head.weight"].data_ptr()
+    model.save_pretrained(tmp_path, state_dict=state_dict)
+    with safe_open(tmp_path / "model.safetensors", framework="pt", device="cpu") as checkpoint:
+        checkpoint_keys = set(checkpoint.keys())
+
+    assert "model.embed_tokens.weight" in checkpoint_keys
+    assert "lm_head.weight" not in checkpoint_keys
+
+
+def test_restore_tied_weights_state_dict_ignores_untied_weights():
+    model = get_tiny_qwen3_model(tie_word_embeddings=False)
+    state_dict = {name: tensor.clone() for name, tensor in model.state_dict().items()}
+
+    restore_tied_weights_state_dict(model, state_dict)
+
+    assert state_dict["model.embed_tokens.weight"].data_ptr() != state_dict["lm_head.weight"].data_ptr()


### PR DESCRIPTION
# What does this PR do?

Fixes #10560.

DeepSpeed ZeRO-1/2 clones tensors while gathering a model state dict, which breaks the storage alias between tied input and output embeddings. Transformers then sees two independent tensors and serializes both `model.embed_tokens.weight` and `lm_head.weight`, even when `tie_word_embeddings=true`.

This change:

- restores aliases in an externally supplied SFT state dict from the model's actual shared parameters before saving;
- leaves genuinely untied parameters unchanged;
- adds a download-free tiny Qwen3 regression test that checks the saved safetensors keys.

## Validation

- Targeted CPU tests with Transformers 4.55.0: 2 passed
- Targeted CPU tests with Transformers 5.8.0: 2 passed
- Pre-commit hooks: passed
- License check: passed

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?