### PR TITLE
fix: correct raise print(...) and negative __len__ in streaming data engine

### DIFF
--- a/scripts/convert_ckpt/llamafy_baichuan2.py
+++ b/scripts/convert_ckpt/llamafy_baichuan2.py
@@ -102,7 +102,7 @@ def llamafy_baichuan2(
     try:
         os.makedirs(output_dir, exist_ok=False)
     except Exception as e:
-        raise print("Output dir already exists", e)
+        raise ValueError("Output dir already exists") from e
 
     save_weight(input_dir, output_dir, shard_size, save_safetensors)
     save_config(input_dir, output_dir)

--- a/scripts/convert_ckpt/llamafy_qwen.py
+++ b/scripts/convert_ckpt/llamafy_qwen.py
@@ -155,7 +155,7 @@ def llamafy_qwen(
     try:
         os.makedirs(output_dir, exist_ok=False)
     except Exception as e:
-        raise print("Output dir already exists", e)
+        raise ValueError("Output dir already exists") from e
 
     torch_dtype = save_weight(input_dir, output_dir, shard_size, save_safetensors)
     save_config(input_dir, output_dir, torch_dtype)

--- a/src/llamafactory/v1/core/data_engine.py
+++ b/src/llamafactory/v1/core/data_engine.py
@@ -165,7 +165,7 @@ class DataEngine(Dataset):
             int: Dataset length.
         """
         if self.streaming:
-            return -1
+            raise ValueError("Streaming dataset does not support len().")
         else:
             return len(self.data_index)
 


### PR DESCRIPTION
Two small correctness fixes:

1. `scripts/convert_ckpt/llamafy_baichuan2.py` and `llamafy_qwen.py` both do `raise print("Output dir already exists", e)` — `print()` returns `None`, so this prints the message and then raises `TypeError: exceptions must derive from BaseException`. Changed to `raise ValueError(...) from e`.
2. `src/llamafactory/v1/core/data_engine.py`: `__len__` returns `-1` for streaming datasets, which makes `len(engine)` itself raise `ValueError: __len__() should return >= 0`. The class docstring promises `len()` reflects the sample count; raise a clear `ValueError("Streaming dataset does not support len().")` instead, mirroring `__getitem__`'s handling.