### PR TITLE
fix(kto): forward precomputed mrope position_ids to the model

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -630,6 +630,12 @@ class KTODataCollatorWithPadding(MultiModalDataCollatorForSeq2Seq):
         batch["kl_input_ids"] = kl_batch["input_ids"]
         batch["kl_attention_mask"] = kl_batch["attention_mask"]
         batch["kl_labels"] = kl_batch["labels"]
+        # mrope models: parent __call__ computed position_ids/rope_deltas per batch;
+        # the kl sequences differ from the target ones, so carry the kl pair too
+        # (the KTO trainer forwards them per prefix).
+        for key in ("position_ids", "rope_deltas"):
+            if key in kl_batch:
+                batch[f"kl_{key}"] = kl_batch[key]
         if "cross_attention_mask" in kl_batch:  # for mllama inputs
             batch["kl_cross_attention_mask"] = kl_batch["cross_attention_mask"]
 

--- a/src/llamafactory/train/kto/trainer.py
+++ b/src/llamafactory/train/kto/trainer.py
@@ -176,6 +176,17 @@ class CustomKTOTrainer(KTOTrainer):
         if f"{prefix}cross_attention_mask" in batch:
             model_inputs["cross_attention_mask"] = batch[f"{prefix}cross_attention_mask"]
 
+        # mrope models (qwen2vl/qwen3.5 family): the collator precomputes position_ids /
+        # rope_deltas via get_rope_index. They must reach the forward — without them the
+        # model recomputes 3D positions itself, and on transformers >= 5.10 that path
+        # requires mm_token_type_ids and raises (the collator's dummy-image workaround
+        # puts image_grid_thw in every text-only batch, so the mrope path always runs).
+        if f"{prefix}position_ids" in batch:
+            model_inputs["position_ids"] = batch[f"{prefix}position_ids"]
+
+        if f"{prefix}rope_deltas" in batch:
+            model_inputs["rope_deltas"] = batch[f"{prefix}rope_deltas"]
+
         logits = model(**model_inputs, return_dict=True, use_cache=False).logits.to(torch.float32)
         logps, valid_length = get_batch_logps(logits=logits, labels=batch[f"{prefix}labels"])
         return logits, logps, logps / valid_length


### PR DESCRIPTION
### 这个 PR 做了什么

修复 **KTO** 在 **mrope 架构**模型（Qwen3.5 系列等）上第 0 步 forward 即崩溃的问题。SFT / DPO 不受影响，只有 KTO 中招。

Closes #10817

### 现象

```text
File "transformers/models/qwen3_5/modeling_qwen3_5.py", line 1502, in compute_3d_position_ids
    raise ValueError(
ValueError: Multimodal data was passed (via `image_grid_thw` or `video_grid_thw`) but `mm_token_type_ids` is missing. ...
```

纯文本 KTO 也必现——collator 的 dummy-image workaround（zero3/FSDP 防挂死）让每个 batch 都带 `image_grid_thw`。

### 根因

collator 已经通过 `get_rope_index` 预计算了 `position_ids` / `rope_deltas`，但 KTO trainer 的 `forward()` 用显式白名单构造 `model_inputs`：转发了 `image_grid_thw`，**却不转发 `position_ids` / `rope_deltas`**；`kl_` 侧更是从未被 `KTODataCollatorWithPadding` 从 kl batch 带出。于是模型 forward 看到 `position_ids=None` + `image_grid_thw` 非 None，走 `compute_3d_position_ids` 重算路径，该路径要求无人提供的 `mm_token_type_ids` → raise。

SFT 用标准 Trainer 全量透传（`position_ids` 到达 forward）所以正常；DPO 的 `concatenated_forward` 是 `model(**batch)` 所以也正常。

### 修复

两处，缺一不可（只补 trainer 时 `kl_` forward 仍崩，已实测）：

1. `KTODataCollatorWithPadding.__call__`：把 kl batch 的 `position_ids` / `rope_deltas` 以 `kl_position_ids` / `kl_rope_deltas` 带出（target batch 的本来就在 features 里）。
2. KTO trainer `forward()`：透传 `{prefix}position_ids` / `{prefix}rope_deltas`。`position_ids` 到达 forward 后，模型跳过整个 3D 位置重算路径。仅在 key 存在时转发，非 mrope 模型行为不变。

### 验证

`Qwen/Qwen3.5-0.8B` LoRA KTO，单卡，真实偏好数据（44 条 desirable/undesirable，28 步）：

- **修复前**：第 0 步崩溃（上述 ValueError；多卡 Qwen3.5-4B 同样复现）。
- **只补 trainer**：`kl_` 前缀的 forward 仍崩——证明 collator 半边必要。
- **完整修复**：训练完整收敛（train_loss 0.45），插桩确认两个 prefix 的 `model_inputs` 均携带 `position_ids` / `rope_deltas`。
