### PR TITLE
[data] fix TypeError in packed-mrope collator: pass sample_idx as batch_idx

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -261,7 +261,7 @@ class MultiModalDataCollatorForSeq2Seq(DataCollatorForSeq2Seq):
                     "attention_mask": features["attention_mask"][sample_idx : sample_idx + 1],
                 }
                 mm_inputs_for_sample = _slice_mm_inputs_for_sample(
-                    mm_inputs, batch_imglens, batch_vidlens, sample_idx=sample_idx
+                    mm_inputs, batch_imglens, batch_vidlens, batch_idx=sample_idx
                 )
                 self._compute_rope_position_ids(sample_features, mm_inputs_for_sample)
                 all_position_ids.append(sample_features["position_ids"])


### PR DESCRIPTION
### Problem

In `MultiModalDataCollatorForSeq2Seq._compute_rope_position_ids_with_packing`, the branch that handles a sample with no sub-sequences calls `_slice_mm_inputs_for_sample` with a keyword the callee does not accept:

```python
            if num_sub_seqs <= 1:
                ...
                mm_inputs_for_sample = _slice_mm_inputs_for_sample(
                    mm_inputs, batch_imglens, batch_vidlens, sample_idx=sample_idx   # <-- TypeError
                )
```

The callee's fourth parameter is named `batch_idx`, and it takes no `**kwargs`:

```python
def _slice_mm_inputs_for_sample(
    mm_inputs: dict[str, Any],
    batch_imglens: list[int],
    batch_vidlens: list[int],
    batch_idx: int,
    images_per_subseq: Optional[list[int]] = None,
    videos_per_subseq: Optional[list[int]] = None,
    subseq_idx: Optional[int] = None,
) -> dict[str, Any]:
```

so the call raises `TypeError: _slice_mm_inputs_for_sample() got an unexpected keyword argument 'sample_idx'` / `missing a required argument: 'batch_idx'`.

The sibling call ~20 lines below, in the `else` (packed) branch, passes the same value **positionally** and is correct:

```python
                    mm_inputs_for_subseq = _slice_mm_inputs_for_sample(
                        mm_inputs,
                        batch_imglens,
                        batch_vidlens,
                        sample_idx,          # <-- correct: binds to batch_idx
                        images_per_subseq,
                        videos_per_subseq,
                        subseq_idx,
                    )
```

**When it fires.** `_compute_rope_position_ids_with_packing` runs only when `has_packing` is true, i.e. `any(b is not None and len(b) > 2 ...)` over the batch — *at least one* sample is packed into ≥2 sub-sequences. The loop then walks every sample in that batch, and any sample whose `sequence_boundaries` yields `num_sub_seqs <= 1` takes the broken branch. So a mixed batch under `neat_packing` with an mrope VLM (`get_rope_func is not None`) — some samples packed, at least one not — crashes in the collator.

### Fix

Pass the value as `batch_idx=sample_idx`, keeping the author's keyword form but binding the parameter that actually exists. One line.

### Verification

No GPU/VLM runtime here, so I verified by binding the two real call sites against the real signature — both extracted straight out of `collator.py` on `main` with `ast`, then replayed through `inspect.Signature.bind`:

```
signature: _slice_mm_inputs_for_sample(mm_inputs, batch_imglens, batch_vidlens, batch_idx,
                                       images_per_subseq=None, videos_per_subseq=None, subseq_idx=None)

  RAISES line 265: 3 positional + ['sample_idx']
         -> TypeError: missing a required argument: 'batch_idx'
  OK     line 283: 7 positional + no kwargs

patched call site (batch_idx=sample_idx):
  OK
```

Line 283 is the sibling in the packed branch — it binds cleanly, which is what makes the check non-vacuous: only the one call site changes behaviour.

<sub>Note: my fork is behind `main`, so the branch is built on the fork tip. The three-dot diff above is exactly the one line — no other file is touched.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
