### PR TITLE
[v1] fix non-persistent buffer sync for init_on_rank0

### DIFF
--- a/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
+++ b/src/llamafactory/v1/plugins/trainer_plugins/distributed/fsdp2.py
@@ -373,6 +373,8 @@ class FSDP2Engine:
         init_mode = getattr(model, "_init_mode", "init_on_default")
 
         if init_mode == "init_on_rank0":
+            non_persistent_buffers = self._save_non_persistent_buffers(model) if self.rank == 0 else {}
+
             if getattr(model.config, "tie_word_embeddings", False):
                 model.tie_weights()
 
@@ -391,6 +393,13 @@ class FSDP2Engine:
             # Broadcast the full state dict from the global rank-0 process to all ranks in this group.
             options = StateDictOptions(full_state_dict=True, cpu_offload=True, broadcast_from_rank0=True)
             set_model_state_dict(model, full_sd, options=options)
+            self._restore_non_persistent_buffers(model, non_persistent_buffers)
+            if self.world_size > 1:
+                for module in model.modules():
+                    for buffer_name in sorted(module._non_persistent_buffers_set):
+                        buffer = getattr(module, buffer_name, None)
+                        if buffer is not None:
+                            torch.distributed.broadcast(buffer, src=0)
 
             if self.rank == 0:
                 logger.info("init_on_rank0 sync complete.")

--- a/tests_v1/plugins/trainer_plugins/distributed/test_fsdp2.py
+++ b/tests_v1/plugins/trainer_plugins/distributed/test_fsdp2.py
@@ -18,12 +18,15 @@ Validates that the FSDP2 meta loading path behaves correctly for tied weights
 and non-persistent buffers by comparing it with the standard non-meta path.
 """
 
+from types import SimpleNamespace
+
 import torch
 from transformers import AutoConfig
 
 from llamafactory.v1.accelerator.interface import DistributedInterface
 from llamafactory.v1.config.arg_parser import get_args
 from llamafactory.v1.core.model_engine import ModelEngine
+from llamafactory.v1.plugins.trainer_plugins.distributed import fsdp2 as fsdp2_module
 from llamafactory.v1.plugins.trainer_plugins.distributed.fsdp2 import FSDP2Engine
 
 
@@ -40,6 +43,50 @@ def collect_non_persistent_buffers(model):
             if buf is not None:
                 result[fqn] = buf.detach().cpu().clone()
     return result
+
+
+def test_fsdp2_rank0_syncs_non_persistent_buffers(monkeypatch):
+    expected = torch.tensor([1.0, 0.5, 0.25])
+
+    class Rank0Model(torch.nn.Module):
+        def __init__(self, rank):
+            super().__init__()
+            self.config = SimpleNamespace(tie_word_embeddings=False)
+            self._init_mode = "init_on_rank0"
+            self.weight = torch.nn.Parameter(torch.ones(1))
+            buffer = expected.clone() if rank == 0 else torch.empty_like(expected, device="meta")
+            self.register_buffer("inv_freq", buffer, persistent=False)
+
+        def to_empty(self, *, device, recurse=True):
+            self.inv_freq = torch.zeros_like(expected, device=device)
+            return self
+
+    def set_model_state_dict(model, state_dict, **kwargs):
+        assert torch.count_nonzero(model.inv_freq) == 0
+
+    monkeypatch.setattr(fsdp2_module, "get_current_accelerator", lambda: torch.device("cpu"))
+    monkeypatch.setattr(fsdp2_module, "set_model_state_dict", set_model_state_dict)
+
+    for rank in (0, 1):
+        engine = object.__new__(FSDP2Engine)
+        engine.rank = rank
+        engine.world_size = 2
+        monkeypatch.setattr(engine, "prepare_model", lambda model: model)
+        monkeypatch.setattr(engine, "_warmup_grad_norm", lambda model: None)
+
+        def broadcast(buffer, src):
+            assert src == 0
+            if rank == 0:
+                assert torch.equal(buffer, expected)
+            else:
+                assert torch.count_nonzero(buffer) == 0
+                buffer.copy_(expected)
+
+        monkeypatch.setattr(torch.distributed, "broadcast", broadcast)
+        model = engine.shard_model(Rank0Model(rank))
+
+        assert "inv_freq" not in model.state_dict()
+        assert torch.equal(model.inv_freq, expected)
 
 
 def test_fsdp2_meta_loading_buffers_and_tied_weights():


### PR DESCRIPTION
# What does this PR do?
Preserve non-persistent buffers when initializing v1 FSDP2 models with `init_on_rank0`, including the FSDPTurbo expert-parallel path.

## Summary
`model.to_empty()` reallocates both parameters and buffers. Loading the full state dict restores parameters and persistent buffers, but does not restore buffers registered with `persistent=False`, such as RoPE frequencies. Training can therefore continue with incorrect buffer values without raising an exception.

## Changes
- Save non-persistent buffers on global rank 0 before materialization, using the existing helper.
- Restore them on rank 0 after loading the state dict, then broadcast them to all ranks in a consistent order.
- Add a focused regression test covering rank-0 restoration and nonzero-rank synchronization.

## Validation
Local Ascend validation used Transformers 5.9.0, PyTorch 2.7.1, torch_npu 2.7.1.post4, Accelerate 1.11.0, and CANN 9.0.0.
Shared short-run settings: `offload_params=false`, `flash_attention_2`, BF16 compute, no activation checkpointing, sequence length 128, micro batch size 1, global batch size 8, learning rate 1e-4, and seed 42.

| Scenario | Comparison | Observed result |
| --- | --- | --- |
| Qwen3.5-35B-A3B, 16 ranks, DP=8 / CP=2 / EP=4 / EFSDP=2, eager dispatcher, native FSDP | Meta, pre-fix rank0, fixed rank0 | Both pre-fix and fixed runs completed their training steps. Pre-fix buffers contained incorrect values; fixed buffer summaries matched the meta reference. This earlier EP check used summaries, not full elementwise checks. |
| Qwen3.5-35B-A3B, 16 ranks, DP=8 / CP=2, EP disabled, FSDP shard size 16 | Meta, pre-fix rank0, fixed rank0 | Correct buffer instances improved from 16/48 to 48/48 across all ranks. First-step logits matched meta exactly after the fix, versus a maximum absolute difference of 8.49 before it. |
| Qwen3-0.6B, 4 ranks, DP=2 / CP=2, EP disabled, HSDP replicate=2 / shard=2 | Meta, pre-fix rank0, fixed rank0 | Covers FSDP subgroups that exclude global rank 0. Correct buffer instances improved from 4/8 to 8/8. Recorded logits matched meta exactly at both steps after the fix; sampled gradient differences were below 1e-6. |

## Longer-run validation

Both `init_on_meta` and fixed `init_on_rank0` completed **500 optimizer steps** . These runs used the native training entry point without diagnostic hooks or additional reference-buffer broadcasts.

**Configuration:** Qwen3.5-35B-A3B on 16 Ascend ranks, DP=8 / EP=4 / EFSDP=2 / CP=2, eager EP dispatcher, native FSDP, `offload_params=false`, `flash_attention_2`, BF16 compute, no activation checkpointing, sequence length 128, micro batch size 1, global batch size 8, constant learning rate 1e-4, and seed 42. Both runs used `PYTORCH_NPU_ALLOC_CONF=expandable_segments:True` and the same `v1_sft_demo` dataset.

### Results
Loss and gradient norm remained finite throughout both 500-step runs. Both recorded the same first-step loss: **1.5477**.The comparison below follows [TrainingLogParser's implementation], using native console logs with four-decimal loss precision:
- **A:** `init_on_meta`.
- **B:** fixed `init_on_rank0`
- **Comparison step = 1:** compare individual steps.
- **Comparison step = 50:** average each non-overlapping 50-step block before computing differences.
### Loss curves
<img width="2240" height="1920" alt="image" src="https://github.com/user-attachments/assets/f24bd75d-06ba-434c-9743-6fe354c666d2" />



