### PR TITLE
[KT] Support Kimi K2.5/2.6 LoRA fine-tuning

### DIFF
--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -125,7 +125,13 @@ def load_tokenizer(model_args: "ModelArguments") -> "TokenizerModule":
 def load_config(model_args: "ModelArguments") -> "PretrainedConfig":
     r"""Load model config."""
     init_kwargs = _get_init_kwargs(model_args)
-    return AutoConfig.from_pretrained(model_args.model_name_or_path, **init_kwargs)
+    config = AutoConfig.from_pretrained(model_args.model_name_or_path, **init_kwargs)
+    if model_args.use_kt:
+        from transformers.integrations.kt_artifacts import prepare_kt_pretrained_config
+
+        prepare_kt_pretrained_config(config)
+
+    return config
 
 
 def load_model(

--- a/src/llamafactory/model/model_utils/attention.py
+++ b/src/llamafactory/model/model_utils/attention.py
@@ -95,6 +95,10 @@ def configure_attn_implementation(config: "PretrainedConfig", model_args: "Model
 
     if getattr(config, "model_type", None) == "internlm2":  # special case for custom models
         setattr(config, "attn_implementation", requested_attn_implementation)
+    elif getattr(config, "model_type", None) == "kimi_k25":
+        setattr(config, "_attn_implementation", requested_attn_implementation)
+        setattr(config.vision_config, "_attn_implementation", requested_attn_implementation)
+        setattr(config.text_config, "_attn_implementation", requested_attn_implementation)
     elif getattr(config, "model_type", None) == "kimi_vl":
         setattr(config.vision_config, "_attn_implementation", requested_attn_implementation)
         setattr(config.text_config, "_attn_implementation", requested_attn_implementation)


### PR DESCRIPTION
# What does this PR do?

Enables Kimi K2.5 RAWINT4 LoRA fine-tuning through the existing KTransformers integration, with small fixes to model loading and attention configuration.

Only two files change (+11/-1). LLaMA-Factory's core training runtime is unchanged.

## Tests

- Passed Kimi K2.5 training smoke test, including gradient, adapter update and checkpoint checks.
- Checkpoint resume and fresh-process adapter reload also passed on the same LLaMA-Factory revision with the preceding KT revision.


